### PR TITLE
Added flag to display filings filed by Registry Staff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/interfaces/filing-interfaces/filing-interface.ts
+++ b/src/interfaces/filing-interfaces/filing-interface.ts
@@ -12,6 +12,7 @@ export interface IncorporationFilingIF {
       filingId?: number // Optional as this is not required when building a filing - causes an error for new filings
       folioNumber?: string // Optional to the user and only displayed for certain account types
       isFutureEffective: boolean
+      isStaff: boolean
     },
     business: {
       legalType: string,

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -17,11 +17,12 @@ export default class FilingTemplateMixin extends Vue {
   @State stateModel!: StateModelIF
 
   // Global getters
-  @Getter isTypeBcomp!: GetterIF
+  @Getter isTypeBcomp!: boolean
   @Getter isNamedBusiness!: boolean
   @Getter getNameRequestNumber!: string
   @Getter getApprovedName!: string
   @Getter getTempId!: string
+  @Getter isRoleStaff!: boolean
 
   // Global actions
   @Action setEntityType!: ActionBindingIF
@@ -53,7 +54,8 @@ export default class FilingTemplateMixin extends Vue {
           certifiedBy: this.stateModel.certifyState.certifiedBy,
           date: this.stateModel.currentDate,
           folioNumber: this.stateModel.defineCompanyStep.folioNumber,
-          isFutureEffective: this.stateModel.incorporationDateTime.isFutureEffective
+          isFutureEffective: this.stateModel.incorporationDateTime.isFutureEffective,
+          isStaff: this.isRoleStaff
         },
         business: {
           legalType: this.stateModel.entityType,

--- a/tests/unit/Actions.spec.ts
+++ b/tests/unit/Actions.spec.ts
@@ -197,7 +197,8 @@ describe('Actions component - Filing Functionality', () => {
         date: '2020/01/29',
         effectiveDate: formattedEffectiveDate,
         folioNumber: null,
-        isFutureEffective: false
+        isFutureEffective: false,
+        isStaff: false
       },
       business: {
         identifier: 'T1234567',


### PR DESCRIPTION
*Issue #:* /bcgov/entity#6814

*Description of changes:*
- added isStaff flag to IA filing
- updated interface accordingly
- updated unit test
- updated app patch release

_Yes, I know IAs are not filed by staff, but this is both future-proofing this app and also sets the flag correctly for this filing type  (ie, False) even though it's optional in the Filings History List._

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).