### PR TITLE
8433 COOP IA upload memorandum - move scrollToComponent to page level, UI text updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "2.0.23",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "2.0.23",
+  "version": "2.1.0",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/CreateMemorandum/UploadMemorandum.vue
+++ b/src/components/CreateMemorandum/UploadMemorandum.vue
@@ -2,7 +2,7 @@
   <div id="upload-memorandum">
     <section class="mt-10">
       <header>
-        <h2>1. Memorandum of the Association</h2>
+        <h2>1. Memorandum of Association</h2>
         <p>Before submitting your incorporation application you must <b>complete, sign, and date</b> the
           <v-tooltip top max-width="20rem" content-class="top-tooltip">
             <template v-slot:activator="{ on }">
@@ -102,7 +102,7 @@
               id="chk-confirm-memorandum"
               v-model="memorandumConfirmed"
               :rules="confirmCompletionMemorandum"
-              label="I confirm the following items are included as required in the Memorandum of the Association:"
+              label="I confirm the following items are included as required in the Memorandum of Association:"
               @change="onMemorandumConfirmedChange($event)"
             />
             <ul>
@@ -122,8 +122,9 @@
                       <span v-on="on" class="tool-tip dotted-underline">Dissolution Provision</span>
                     </template>
                     <span>
-                      Dissolution Provision – all cooperative associations should have provisions for the distribution
-                      of their property after they have been dissolved or wound up.</span>
+                      Dissolution Provision – all Cooperative Associations should have provisions for the distribution
+                      of their property after they have been dissolved or wound up.  See example memorandum for
+                      information relevant to your Cooperative Association type.</span>
                   </v-tooltip>
                    in the Memorandum of Association.
                 </span>
@@ -139,8 +140,8 @@
                           <span v-on="on" class="tool-tip dotted-underline">correct type of shares</span>
                         </template>
                         <span>
-                          Correct type of shares – housing cooperative associations and community service cooperatives
-                          must not issue investment shares.
+                          Housing Cooperative Associations and Community Service Cooperative Associations
+                          MUST NOT issue investment shares.
                         </span>
                       </v-tooltip>
                       are used in the Memorandum of Association based on the type of
@@ -153,7 +154,7 @@
                 <v-row>
                   <v-col cols="1"><v-icon>mdi-circle-small</v-icon></v-col>
                   <v-col cols="11" class="ml-n11">
-                    <span>Each Subscriber and Witness has signed and dated the Memorandum of the
+                    <span>Each Subscriber and Witness has signed and dated the Memorandum of
                       Association and their name is printed under their signature.
                     </span>
                   </v-col>

--- a/src/components/CreateMemorandum/UploadMemorandumSummary.vue
+++ b/src/components/CreateMemorandum/UploadMemorandumSummary.vue
@@ -5,7 +5,7 @@
       <label class="upload-memorandum-title pl-2"><strong>Memorandum</strong></label>
     </div>
 
-    <div v-if="!getCreateMemorandumStep.valid" class="invalid-section pl-5">
+    <div v-if="!getCreateMemorandumStep.validationDetail.valid" class="invalid-section pl-5">
       <div class="upload-memorandum-error-message">
         <span>
           <v-icon color="error">mdi-information-outline</v-icon>
@@ -17,7 +17,7 @@
       </div>
     </div>
 
-    <div v-if="getCreateMemorandumStep.valid" class="upload-memorandum-success-message pl-5">
+    <div v-if="getCreateMemorandumStep.validationDetail.valid" class="upload-memorandum-success-message pl-5">
       <v-row no-gutters>
         <v-col md="1">
           <v-icon class="upload-success-chk">mdi-check</v-icon>

--- a/src/components/CreateRules/UploadRulesSummary.vue
+++ b/src/components/CreateRules/UploadRulesSummary.vue
@@ -5,7 +5,7 @@
       <label class="upload-rules-title pl-2"><strong>Rules</strong></label>
     </div>
 
-    <div v-if="!getCreateRulesStep.valid" class="invalid-section">
+    <div v-if="!getCreateRulesStep.validationDetail.valid" class="invalid-section">
       <div class="upload-rules-error-message">
         <span>
           <v-icon color="error">mdi-information-outline</v-icon>
@@ -17,7 +17,7 @@
       </div>
     </div>
 
-    <div v-if="getCreateRulesStep.valid" class="upload-rules-success-message">
+    <div v-if="getCreateRulesStep.validationDetail.valid" class="upload-rules-success-message">
       <v-row no-gutters>
         <v-col md="1">
           <v-icon class="upload-success-chk">mdi-check</v-icon>

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -3,6 +3,8 @@ export * from './utils-interfaces/form-type'
 export * from './utils-interfaces/confirm-dialog-type'
 export * from './utils-interfaces/document-upload-interface'
 export * from './utils-interfaces/doc-interface'
+export * from './utils-interfaces/validation-detail-interface'
+export * from './utils-interfaces/validation-item-detail-interface'
 
 // Store Interfaces
 export * from './store-interfaces/state-interface'

--- a/src/interfaces/stepper-interfaces/CreateMemorandum/create-memorandum-interface.ts
+++ b/src/interfaces/stepper-interfaces/CreateMemorandum/create-memorandum-interface.ts
@@ -1,7 +1,7 @@
-import { DocIF } from '@/interfaces'
+import { DocIF, ValidationDetailIF } from '@/interfaces'
 
 export interface CreateMemorandumIF {
-  valid: boolean
+  validationDetail: ValidationDetailIF
   memorandumConfirmed: boolean
   memorandumDoc: DocIF
   docKey: string

--- a/src/interfaces/stepper-interfaces/CreateRules/create-rules-interface.ts
+++ b/src/interfaces/stepper-interfaces/CreateRules/create-rules-interface.ts
@@ -1,7 +1,7 @@
-import { DocIF } from '@/interfaces'
+import { DocIF, ValidationDetailIF } from '@/interfaces'
 
 export interface CreateRulesIF {
-  valid: boolean
+  validationDetail: ValidationDetailIF
   rulesConfirmed: boolean
   rulesDoc: DocIF
   docKey: string

--- a/src/interfaces/utils-interfaces/validation-detail-interface.ts
+++ b/src/interfaces/utils-interfaces/validation-detail-interface.ts
@@ -1,0 +1,6 @@
+import { ValidationItemDetailIF } from '@/interfaces'
+
+export interface ValidationDetailIF {
+  valid: boolean
+  validationItemDetails: ValidationItemDetailIF[]
+}

--- a/src/interfaces/utils-interfaces/validation-item-detail-interface.ts
+++ b/src/interfaces/utils-interfaces/validation-item-detail-interface.ts
@@ -1,0 +1,5 @@
+export interface ValidationItemDetailIF {
+  name: string
+  valid: boolean
+  elementId: string
+}

--- a/src/mixins/common-mixin.ts
+++ b/src/mixins/common-mixin.ts
@@ -1,5 +1,6 @@
 import { Component, Vue } from 'vue-property-decorator'
 import { omit, isEqual } from 'lodash'
+import { ValidationItemDetailIF } from '@/interfaces'
 
 /**
  * Mixin that provides some useful common utilities.
@@ -50,5 +51,15 @@ export default class CommonMixin extends Vue {
       return false
     }
     return true
+  }
+
+  buildValidFlags (validationItems: ValidationItemDetailIF[]): object {
+    let result = {}
+    for (const vi of validationItems) { result[vi.name] = vi.valid }
+    return result
+  }
+
+  buildElementIds (validationItems: ValidationItemDetailIF[]): object {
+    return validationItems.map(vi => vi.elementId)
   }
 }

--- a/src/mixins/common-mixin.ts
+++ b/src/mixins/common-mixin.ts
@@ -53,12 +53,22 @@ export default class CommonMixin extends Vue {
     return true
   }
 
+  /**
+   * Extracts validation flags from validation item detail object
+   * @param validation items details object
+   * @return array of validation flags for all validation items
+   */
   buildValidFlags (validationItems: ValidationItemDetailIF[]): object {
     let result = {}
     for (const vi of validationItems) { result[vi.name] = vi.valid }
     return result
   }
 
+  /**
+   * Extracts element ids from validation item detail object
+   * @param validation items details object
+   * @return array of element ids for all validation items
+   */
   buildElementIds (validationItems: ValidationItemDetailIF[]): object {
     return validationItems.map(vi => vi.elementId)
   }

--- a/src/mixins/common-mixin.ts
+++ b/src/mixins/common-mixin.ts
@@ -69,7 +69,7 @@ export default class CommonMixin extends Vue {
    * @param validation items details object
    * @return array of element ids for all validation items
    */
-  buildElementIds (validationItems: ValidationItemDetailIF[]): object {
+  buildElementIds (validationItems: ValidationItemDetailIF[]): string[] {
     return validationItems.map(vi => vi.elementId)
   }
 }

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -182,7 +182,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
           }
         }
         const createRules:CreateRulesIF = {
-          valid: false,
+          validationDetail: null,
           rulesConfirmed: draftFiling.incorporationApplication.cooperative?.rulesConfirmed,
           rulesDoc: rulesDoc,
           docKey: draftFiling.incorporationApplication.cooperative?.rulesFileKey
@@ -198,7 +198,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
           }
         }
         const createMemorandum:CreateMemorandumIF = {
-          valid: false,
+          validationDetail: null,
           memorandumConfirmed: draftFiling.incorporationApplication.cooperative?.memorandumConfirmed,
           memorandumDoc: memorandumDoc,
           docKey: draftFiling.incorporationApplication.cooperative?.memorandumFileKey

--- a/src/store/actions/actions-model.ts
+++ b/src/store/actions/actions-model.ts
@@ -2,7 +2,7 @@ import { ActionIF } from '@/interfaces/store-interfaces/action-interface'
 import {
   AccountInformationIF, AddressIF, BusinessContactIF, CertifyIF, IncorporationAddressIF,
   IncorporationAgreementIF, NameRequestIF, NameTranslationIF, OrgPersonIF, ResourceIF,
-  ShareClassIF, CreateRulesIF, CreateMemorandumIF
+  ShareClassIF, CreateRulesIF, CreateMemorandumIF, ValidationDetailIF
 } from '@/interfaces'
 import { CoopType, CorpTypeCd } from '@/enums'
 
@@ -130,16 +130,16 @@ export const setRules = ({ commit }, rules: CreateRulesIF) => {
   commit('mutateRules', rules)
 }
 
-export const setRulesStepValidity: ActionIF = ({ commit }, valid: boolean): void => {
-  commit('mutateRulesStepValidity', valid)
+export const setRulesStepValidity: ActionIF = ({ commit }, validationDetail: ValidationDetailIF): void => {
+  commit('mutateRulesStepValidity', validationDetail)
 }
 
 export const setMemorandum = ({ commit }, memorandum: CreateMemorandumIF) => {
   commit('mutateMemorandum', memorandum)
 }
 
-export const setMemorandumStepValidity: ActionIF = ({ commit }, valid: boolean): void => {
-  commit('mutateMemorandumStepValidity', valid)
+export const setMemorandumStepValidity: ActionIF = ({ commit }, validationDetail: ValidationDetailIF): void => {
+  commit('mutateMemorandumStepValidity', validationDetail)
 }
 
 export const setShareClasses = ({ commit }, shareClasses: ShareClassIF[]) => {

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -158,7 +158,7 @@ export const getCreateRulesStep = (state: StateIF): CreateRulesIF => {
 
 /** Is true when the step is valid. */
 export const isRulesValid = (state: StateIF): boolean => {
-  return getCreateRulesStep(state).valid
+  return getCreateRulesStep(state).validationDetail.valid
 }
 
 /** The Incorporation Agreement object. */
@@ -168,7 +168,7 @@ export const getIncorporationAgreementStep = (state: StateIF): IncorporationAgre
 
 /** Is true when the step is valid. */
 export const isMemorandumValid = (state: StateIF): boolean => {
-  return getCreateMemorandumStep(state).valid
+  return getCreateMemorandumStep(state).validationDetail.valid
 }
 
 /** The Create Memorandum object. */
@@ -291,8 +291,8 @@ export const isApplicationValid = (state: StateIF): boolean => {
   // Coop steps
   const isCoopStepsValid = (
     getCooperativeType(state) &&
-    getCreateRulesStep(state).valid &&
-    getCreateMemorandumStep(state).valid
+    getCreateRulesStep(state).validationDetail.valid &&
+    getCreateMemorandumStep(state).validationDetail.valid
   )
 
   return (

--- a/src/store/mutations/mutations-model.ts
+++ b/src/store/mutations/mutations-model.ts
@@ -13,7 +13,8 @@ import {
   ShareClassIF,
   StateIF,
   CreateRulesIF,
-  CreateMemorandumIF
+  CreateMemorandumIF,
+  ValidationDetailIF
 } from '@/interfaces'
 
 export const mutateTempId = (state: StateIF, tempId: string) => {
@@ -145,8 +146,8 @@ export const mutateRules = (state: StateIF, rules: CreateRulesIF) => {
   if (!state.stateModel.ignoreChanges) mutateHaveChanges(state, true)
 }
 
-export const mutateRulesStepValidity = (state: StateIF, valid: boolean) => {
-  state.stateModel.createRulesStep.valid = valid
+export const mutateRulesStepValidity = (state: StateIF, validationDetail: ValidationDetailIF) => {
+  state.stateModel.createRulesStep.validationDetail = validationDetail
 }
 
 export const mutateMemorandum = (state: StateIF, memorandum: CreateMemorandumIF) => {
@@ -154,8 +155,8 @@ export const mutateMemorandum = (state: StateIF, memorandum: CreateMemorandumIF)
   if (!state.stateModel.ignoreChanges) mutateHaveChanges(state, true)
 }
 
-export const mutateMemorandumStepValidity = (state: StateIF, valid: boolean) => {
-  state.stateModel.createMemorandumStep.valid = valid
+export const mutateMemorandumStepValidity = (state: StateIF, validationDetail: ValidationDetailIF) => {
+  state.stateModel.createMemorandumStep.validationDetail = validationDetail
 }
 
 export const mutateShareClasses = (state: StateIF, shareClasses: ShareClassIF[]) => {

--- a/src/store/state/state-model.ts
+++ b/src/store/state/state-model.ts
@@ -63,7 +63,10 @@ export const stateModel: StateModelIF = {
     shareClasses: []
   },
   createRulesStep: {
-    valid: false,
+    validationDetail: {
+      valid: false,
+      validationItemDetails: []
+    },
     rulesConfirmed: false,
     rulesDoc: null,
     docKey: null
@@ -73,7 +76,10 @@ export const stateModel: StateModelIF = {
     agreementType: null
   },
   createMemorandumStep: {
-    valid: false,
+    validationDetail: {
+      valid: false,
+      validationItemDetails: []
+    },
     memorandumConfirmed: false,
     memorandumDoc: null,
     docKey: null

--- a/src/views/CreateMemorandum.vue
+++ b/src/views/CreateMemorandum.vue
@@ -6,17 +6,55 @@
 
 <script lang="ts">
 // Libraries
-import { Component, Vue } from 'vue-property-decorator'
+import { Component, Mixins, Vue, Watch } from 'vue-property-decorator'
+import { Action, Getter } from 'vuex-class'
+
+// Interfaces
+import { ActionBindingIF, CreateMemorandumIF } from '@/interfaces'
+
+// Mixins
+import { CommonMixin } from '@/mixins'
 
 // Components
 import { UploadMemorandum } from '@/components/CreateMemorandum'
+
+import { RouteNames } from '@/enums'
 
 @Component({
   components: {
     UploadMemorandum
   }
 })
-export default class CreateMemorandum extends Vue {}
+export default class CreateMemorandum extends Mixins(CommonMixin) {
+  @Getter getShowErrors!: boolean
+  @Getter getCreateMemorandumStep!: CreateMemorandumIF
+
+  @Action setIgnoreChanges!: ActionBindingIF
+
+  /** Called when component is created. */
+  private created (): void {
+    // ignore data changes until page has loaded
+    this.setIgnoreChanges(true)
+    Vue.nextTick(() => {
+      this.setIgnoreChanges(false)
+    })
+  }
+
+  @Watch('$route')
+  private async scrollToInvalidComponent (): Promise<void> {
+    if (this.getShowErrors && this.$route.name === RouteNames.CREATE_MEMORANDUM) {
+      // Scroll to invalid components.
+      await Vue.nextTick()
+      const vid = this.getCreateMemorandumStep.validationDetail.validationItemDetails
+      const validFlags = this.buildValidFlags(vid)
+      const componentIds = this.buildElementIds(vid)
+      await this.validateAndScroll(
+        validFlags,
+        componentIds
+      )
+    }
+  }
+}
 </script>
 
 <style lang="scss" scoped>

--- a/src/views/CreateRules.vue
+++ b/src/views/CreateRules.vue
@@ -6,17 +6,55 @@
 
 <script lang="ts">
 // Libraries
-import { Component, Vue } from 'vue-property-decorator'
+import { Component, Mixins, Vue, Watch } from 'vue-property-decorator'
+import { Action, Getter } from 'vuex-class'
+
+// Interfaces
+import { ActionBindingIF, CreateRulesIF } from '@/interfaces'
+
+// Mixins
+import { CommonMixin } from '@/mixins'
 
 // Components
 import { UploadRules } from '@/components/CreateRules'
+
+import { RouteNames } from '@/enums'
 
 @Component({
   components: {
     UploadRules
   }
 })
-export default class CreateRules extends Vue {}
+export default class CreateRules extends Mixins(CommonMixin) {
+  @Getter getShowErrors!: boolean
+  @Getter getCreateRulesStep!: CreateRulesIF
+
+  @Action setIgnoreChanges!: ActionBindingIF
+
+  /** Called when component is created. */
+  private created (): void {
+    // ignore data changes until page has loaded
+    this.setIgnoreChanges(true)
+    Vue.nextTick(() => {
+      this.setIgnoreChanges(false)
+    })
+  }
+
+  @Watch('$route')
+  private async scrollToInvalidComponent (): Promise<void> {
+    if (this.getShowErrors && this.$route.name === RouteNames.CREATE_RULES) {
+      // Scroll to invalid components.
+      await Vue.nextTick()
+      const vid = this.getCreateRulesStep.validationDetail.validationItemDetails
+      const validFlags = this.buildValidFlags(vid)
+      const componentIds = this.buildElementIds(vid)
+      await this.validateAndScroll(
+        validFlags,
+        componentIds
+      )
+    }
+  }
+}
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#8433

*Description of changes:*

* moved `scrollToComponent` from component to page level for upload rules and upload memorandum components.  Note `scrollToComponent` can be probably moved to the root component(`App`) but have held off on doing this as I think it would make sense that if we decide to do this we would want to move all the other `scrollToComponent` calls to the `App` level.  
* update tooltip text and other component text based off of UXA feedback

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
