### PR TITLE
Added whitespace styling in parent of DocumentDelivery component -- same for IA as for Dissolution.

### DIFF
--- a/src/views/Incorporations/ReviewConfirm.vue
+++ b/src/views/Incorporations/ReviewConfirm.vue
@@ -180,7 +180,7 @@ export default class ReviewConfirm extends Mixins() {
     padding: 0.75rem 0;
 
     .col-3 {
-      font-size: 1rem;
+      font-size: 0.875rem;
       color: $gray9;
       padding: 0 0 0 0.75rem !important;
     }

--- a/src/views/Incorporations/ReviewConfirm.vue
+++ b/src/views/Incorporations/ReviewConfirm.vue
@@ -36,7 +36,7 @@
     </section>
 
     <!-- Document Delivery -->
-    <section class="mt-10">
+    <section id="document-delivery-section" class="mt-10">
       <header>
         <h2>Document Delivery</h2>
         <p class="mt-1">Copies of the incorporation documents will be sent to the following email addresses listed
@@ -164,8 +164,30 @@ export default class ReviewConfirm extends Mixins() {
 </script>
 
 <style lang="scss" scoped>
+@import '@/assets/styles/theme.scss';
+
 .company-statement-label {
   letter-spacing: -0.04rem;
   font-weight: 700;
+}
+
+::v-deep #document-delivery-section {
+  .v-card {
+    padding: 1.5rem 1.25rem !important;
+  }
+
+  .row {
+    padding: 0.75rem 0;
+
+    .col-3 {
+      font-size: 1rem;
+      color: $gray9;
+      padding: 0 0 0 0.75rem !important;
+    }
+
+    .col-9 {
+      padding: 0 0.5rem 0 0 !important;
+    }
+  }
 }
 </style>


### PR DESCRIPTION
*Issue #:* None

*Description of changes:*
- Added whitespace styling in parent of DocumentDelivery component -- same for IA as for Dissolution.
- Updated font size to match other components on this page.
- No app version change this time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).