### PR TITLE
Fixed CertifiedBy assignment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -600,12 +600,6 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
     this.setCourtOrderFileNumber(draftFiling.dissolution.courtOrder?.fileNumber)
     this.setHasPlanOfArrangement(draftFiling.dissolution.courtOrder?.hasPlanOfArrangement)
 
-    // restore Certify state
-    this.setCertifyState({
-      valid: false,
-      certifiedBy: draftFiling.header.certifiedBy
-    })
-
     // NB: do not restore/overwrite Folio Number - just use the FN from auth info (see App.vue)
 
     // NB: Staff role is mutually exclusive with premium account.

--- a/src/views/Dissolution/DissolutionReviewConfirm.vue
+++ b/src/views/Dissolution/DissolutionReviewConfirm.vue
@@ -375,16 +375,6 @@ export default class DissolutionReviewConfirm extends Mixins(DateMixin) {
     })
   }
 
-  /** Called when component is mounted. */
-  mounted (): void {
-    this.setCertifyState(
-      {
-        valid: this.getCertifyState.valid,
-        certifiedBy: this.getCertifyState.certifiedBy
-      }
-    )
-  }
-
   /** Is true when the Dissolution Date and Time section is invalid. */
   get isDissolutionDateTimeInvalid (): boolean {
     return (this.getValidateSteps && !this.getEffectiveDateTime.valid)

--- a/src/views/Dissolution/DissolutionReviewConfirm.vue
+++ b/src/views/Dissolution/DissolutionReviewConfirm.vue
@@ -375,6 +375,16 @@ export default class DissolutionReviewConfirm extends Mixins(DateMixin) {
     })
   }
 
+  /** Called when component is mounted. */
+  mounted (): void {
+    this.setCertifyState(
+      {
+        valid: this.getCertifyState.valid,
+        certifiedBy: this.getCertifyState.certifiedBy
+      }
+    )
+  }
+
   /** Is true when the Dissolution Date and Time section is invalid. */
   get isDissolutionDateTimeInvalid (): boolean {
     return (this.getValidateSteps && !this.getEffectiveDateTime.valid)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#11237

*Description of changes:*
* Remove redundant assignment of certify state when parsing DRAFT dissolution.

*Notes:* 
- This parsing of the draft filing always happens in the case of Incorporations and Dissolutions. 
- In this parsing, the certify state would be assigned but it was redundant as we assign the certifiedBy state from the Account ALWAYS. 
- Previously iteration must have worked as the draft was MOST LIKELY* assigned prior to our assignment in our `App.vue` but after a rework, the timing might have swapped. Subsequently overriding the properties from the account by the properties in an empty draft filing. 

- Another solution would be to assign the `certifiedBy` into the draft value from Filings UI where the Dissolution is created. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
