### PR TITLE
9518 cleanup and attempt to fix timing issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -142,7 +142,7 @@
 
 <script lang="ts">
 // Libraries
-import { Component, Mixins, Vue, Watch } from 'vue-property-decorator'
+import { Component, Mixins, Watch } from 'vue-property-decorator'
 import { Action, Getter } from 'vuex-class'
 import { PAYMENT_REQUIRED } from 'http-status-codes'
 import { cloneDeep } from 'lodash'
@@ -373,7 +373,7 @@ export default class App extends Mixins(
   private get saveErrorDialogName (): string {
     switch (this.getFilingType) {
       case FilingTypes.INCORPORATION_APPLICATION: return 'Application'
-      case FilingTypes.REGISTRATION: return 'Application'
+      case FilingTypes.REGISTRATION: return 'Registration'
       case FilingTypes.VOLUNTARY_DISSOLUTION: return 'Filing'
     }
   }
@@ -614,14 +614,16 @@ export default class App extends Mixins(
           }
         )
       }
+
+      console.log('*** got data')
+      this.haveData = true
     } catch (error) {
       // errors should be handled above
       console.error('Unhandled error in fetchData() =', error) // eslint-disable-line no-console
       // just fall through to finally()
     } finally {
-      this.haveData = true
       // wait for things to stabilize, then reset flag
-      Vue.nextTick(() => this.setHaveChanges(false))
+      this.$nextTick(() => this.setHaveChanges(false))
     }
   }
 

--- a/src/components/Dissolution/CompleteAffidavit.vue
+++ b/src/components/Dissolution/CompleteAffidavit.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="dissolution-affidavit">
+  <div id="complete-affidavit">
     <section class="mt-10">
       <header>
         <h2>1. Affidavit</h2>
@@ -190,7 +190,7 @@ import FileUploadPreview from '@/components/common/FileUploadPreview.vue'
     FileUploadPreview
   }
 })
-export default class Affidavit extends Mixins(CommonMixin, DocumentMixin, EnumMixin) {
+export default class CompleteAffidavit extends Mixins(CommonMixin, DocumentMixin, EnumMixin) {
   // Refs
   $refs!: {
     confirmAffidavitChk: FormIF
@@ -301,7 +301,8 @@ export default class Affidavit extends Mixins(CommonMixin, DocumentMixin, EnumMi
   }
 
   private updateAffidavitStepValidity () {
-    const validationDetail:ValidationDetailIF =
+    console.log('*** setting affidavit step validity')
+    const validationDetail: ValidationDetailIF =
       {
         valid: this.hasAffidavitConfirmed && this.hasValidUploadFile,
         validationItemDetails: [
@@ -336,6 +337,11 @@ export default class Affidavit extends Mixins(CommonMixin, DocumentMixin, EnumMi
     this.affidavitConfirmed = this.getAffidavitStep.affidavitConfirmed
     this.hasValidUploadFile = !!this.uploadAffidavitDocKey
     this.hasAffidavitConfirmed = this.affidavitConfirmed
+  }
+
+  async mounted (): Promise<void> {
+    // wait for components to load/stabilize then update validation state in store
+    await this.$nextTick()
     this.updateAffidavitStepValidity()
   }
 

--- a/src/components/Dissolution/CompleteResolution.vue
+++ b/src/components/Dissolution/CompleteResolution.vue
@@ -290,7 +290,7 @@
 
 <script lang="ts">
 // Libraries
-import { Component, Mixins, Watch, Vue } from 'vue-property-decorator'
+import { Component, Mixins, Watch } from 'vue-property-decorator'
 import { Action, Getter } from 'vuex-class'
 
 // Shared Components
@@ -530,6 +530,7 @@ export default class CompleteResolution extends Mixins(CommonMixin, DateMixin) {
   }
 
   private updateResolutionStepValidationDetail () {
+    console.log('*** setting resolution step validity')
     let validationDetail: ValidationDetailIF = null
     const resolutionIsValid = this.isResolutionValid()
     if (this.isTypeCoop) {
@@ -585,8 +586,8 @@ export default class CompleteResolution extends Mixins(CommonMixin, DateMixin) {
   private async onResolutionConfirmedChange (resolutionConfirmed: boolean): Promise<void> {
     // This is required as there are timing issues between this component and the CompleteResolutionSummary
     // component.  The CompleteResolutionSummary isn't always able to detect that the confirm checkbox
-    // value has changed without using Vue.nextTick()
-    await Vue.nextTick()
+    // value has changed without using nextTick()
+    await this.$nextTick()
     this.setResolution({
       ...this.getCreateResolutionStep,
       resolutionConfirmed: resolutionConfirmed
@@ -599,16 +600,16 @@ export default class CompleteResolution extends Mixins(CommonMixin, DateMixin) {
     const foundingDate = new Date(this.getBusinessFoundingDate)
     foundingDate.setHours(0, 0, 0, 0)
     this.foundingDate = foundingDate
-    this.resolutionConfirmed = !!this.getCreateResolutionStep.resolutionConfirmed
+    this.resolutionConfirmed = this.getCreateResolutionStep.resolutionConfirmed
     this.resolutionDateText = this.getCreateResolutionStep.resolutionDate
     this.resolutionText = this.getCreateResolutionStep.resolutionText
-    this.signingPerson = this.getCreateResolutionStep.signingPerson || EmptyPerson
+    this.signingPerson = this.getCreateResolutionStep.signingPerson || { ...EmptyPerson }
     this.signatureDateText = this.getCreateResolutionStep.signingDate
   }
 
   async mounted (): Promise<void> {
     // wait for components to load/stabilize then update validation state in store
-    await Vue.nextTick()
+    await this.$nextTick()
     this.updateResolutionStepValidationDetail()
   }
 
@@ -637,7 +638,7 @@ export default class CompleteResolution extends Mixins(CommonMixin, DateMixin) {
   }
 
   async onResolutionDateSync (val: string): Promise<void> {
-    await Vue.nextTick()
+    await this.$nextTick()
     this.resolutionDateText = val
     this.setResolution({
       ...this.getCreateResolutionStep,
@@ -646,7 +647,7 @@ export default class CompleteResolution extends Mixins(CommonMixin, DateMixin) {
     if (this.$refs.signatureDatePickerRef && this.signatureDateText) {
       // Need this await as the updated resolutionDateText value is not updated in time when
       // signatureDateMinDate is evaluated
-      await Vue.nextTick()
+      await this.$nextTick()
       // triggering signature date validation as signature date is dependent on resolution date
       this.$refs.signatureDatePickerRef.validateForm()
     }
@@ -675,7 +676,7 @@ export default class CompleteResolution extends Mixins(CommonMixin, DateMixin) {
   @Watch('signingPerson', { deep: true })
   private async onSigningPersonChanged (): Promise<void> {
     if (this.isTypeCoop) {
-      await Vue.nextTick()
+      await this.$nextTick()
       this.setResolution({
         ...this.getCreateResolutionStep,
         signingPerson: this.signingPerson
@@ -685,7 +686,7 @@ export default class CompleteResolution extends Mixins(CommonMixin, DateMixin) {
   }
 
   async onSigningDateSync (val: string): Promise<void> {
-    await Vue.nextTick()
+    await this.$nextTick()
     this.signatureDateText = val
     this.setResolution({
       ...this.getCreateResolutionStep,

--- a/src/components/Dissolution/DissolutionStatement.vue
+++ b/src/components/Dissolution/DissolutionStatement.vue
@@ -53,7 +53,7 @@ export default class DissolutionStatement extends Vue {
 
   private dissolutionStatementType: DissolutionStatementTypes = null
 
-  // Lifecycle methods
+  /** Called when component is created. */
   created (): void {
     if (this.getDissolutionStatementStep) {
       this.dissolutionStatementType = this.getDissolutionStatementStep.dissolutionStatementType

--- a/src/components/Incorporation/UploadMemorandum.vue
+++ b/src/components/Incorporation/UploadMemorandum.vue
@@ -376,6 +376,11 @@ export default class UploadMemorandum extends Mixins(CommonMixin, DocumentMixin)
     this.memorandumConfirmed = this.getCreateMemorandumStep.memorandumConfirmed
     this.hasValidUploadFile = !!this.uploadMemorandumDocKey
     this.hasMemorandumConfirmed = this.memorandumConfirmed
+  }
+
+  async mounted (): Promise<void> {
+    // wait for components to load/stabilize then update validation state in store
+    await this.$nextTick()
     this.updateMemorandumStepValidity()
   }
 

--- a/src/components/Incorporation/UploadRules.vue
+++ b/src/components/Incorporation/UploadRules.vue
@@ -306,6 +306,11 @@ export default class UploadRules extends Mixins(CommonMixin, DocumentMixin) {
     this.rulesConfirmed = this.getCreateRulesStep.rulesConfirmed
     this.hasValidUploadFile = !!this.uploadRulesDocKey
     this.hasRulesConfirmed = this.rulesConfirmed
+  }
+
+  async mounted (): Promise<void> {
+    // wait for components to load/stabilize then update validation state in store
+    await this.$nextTick()
     this.updateRulesStepValidity()
   }
 

--- a/src/components/common/AgreementType.vue
+++ b/src/components/common/AgreementType.vue
@@ -84,7 +84,6 @@ export default class AgreementType extends Mixins(EnumMixin) {
   @Getter getIncorporationAgreementStep!: IncorporationAgreementIF
 
   @Action setIncorporationAgreementStepData!: ActionBindingIF
-  @Action setIgnoreChanges!: ActionBindingIF
 
   private agreementType: string = null
 
@@ -102,15 +101,9 @@ export default class AgreementType extends Mixins(EnumMixin) {
       .find(x => x.code === this.getIncorporationAgreementStep.agreementType)?.description
   }
 
-  // Lifecycle methods
+  /** Called when component is created. */
   created (): void {
-    // temporarily ignore data changes
-    this.setIgnoreChanges(true)
     this.agreementType = this.getIncorporationAgreementStep.agreementType
-    // watch data changes once page has loaded (in next tick)
-    Vue.nextTick(() => {
-      this.setIgnoreChanges(false)
-    })
   }
 
   mounted (): void {

--- a/src/components/common/Stepper.vue
+++ b/src/components/common/Stepper.vue
@@ -22,7 +22,7 @@
           >
             <v-icon class="step__icon" :class="{ 'selected-icon': isCurrentStep(step) }">{{ step.icon }}</v-icon>
           </v-btn>
-          <v-icon class="step__btn2" size="30" color="success darken-1" v-show=isValid(step.to)>
+          <v-icon class="step__btn2" size="30" color="success darken-1" v-show="isValid(step.to)">
             mdi-check-circle
           </v-icon>
           <v-icon class="step__btn2" size="30" color="error darken-1" v-show="!isValid(step.to) && getValidateSteps">

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -340,6 +340,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
           legalType: this.getEntityType
         },
         businessAddress: this.getRegistration.businessAddress,
+        // *** FUTURE: save businessType here
         contactPoint: {
           email: this.getBusinessContact.email,
           phone: this.getBusinessContact.phone,
@@ -391,6 +392,8 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
 
     // restore Business Address
     this.setRegistrationBusinessAddress(draftFiling.registration.businessAddress)
+
+    // *** FUTURE: restore businessType here
 
     // restore Contact Info
     const draftContact = {

--- a/src/views/Dissolution/DissolutionAffidavit.vue
+++ b/src/views/Dissolution/DissolutionAffidavit.vue
@@ -5,8 +5,8 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Vue, Watch } from 'vue-property-decorator'
-import Affidavit from '@/components/Dissolution/Affidavit.vue'
+import { Component, Mixins, Watch } from 'vue-property-decorator'
+import Affidavit from '@/components/Dissolution/CompleteAffidavit.vue'
 import { RouteNames } from '@/enums'
 import { CommonMixin } from '@/mixins'
 import { Getter } from 'vuex-class'
@@ -26,7 +26,7 @@ export default class DissolutionAffidavit extends Mixins(CommonMixin) {
   private async scrollToInvalidComponent (): Promise<void> {
     if (this.getShowErrors && this.$route.name === RouteNames.DISSOLUTION_AFFIDAVIT) {
       // Scroll to invalid components.
-      await Vue.nextTick()
+      await this.$nextTick()
       const vid = this.getAffidavitStep.validationDetail.validationItemDetails
       const validFlags = this.buildValidFlags(vid)
       const componentIds = this.buildElementIds(vid)
@@ -38,7 +38,3 @@ export default class DissolutionAffidavit extends Mixins(CommonMixin) {
   }
 }
 </script>
-
-<style lang="scss" scoped>
-@import '@/assets/styles/theme.scss';
-</style>

--- a/src/views/Dissolution/DissolutionDefineDissolution.vue
+++ b/src/views/Dissolution/DissolutionDefineDissolution.vue
@@ -68,7 +68,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Vue, Watch } from 'vue-property-decorator'
+import { Component, Mixins, Watch } from 'vue-property-decorator'
 import { Action, Getter } from 'vuex-class'
 import AssociationDetails from '@/components/Dissolution/AssociationDetails.vue'
 import CareAndCustodySelect from '@/components/Dissolution/CareAndCustodySelect.vue'
@@ -133,7 +133,7 @@ export default class DissolutionDefineDissolution extends Mixins(CommonMixin, En
   private async scrollToInvalidComponent (): Promise<void> {
     if (this.getShowErrors && this.$route.name === RouteNames.DISSOLUTION_DEFINE_DISSOLUTION) {
       // scroll to invalid components
-      await Vue.nextTick()
+      await this.$nextTick()
       await this.validateAndScroll(
         {
           isStatementValid: this.isTypeCoop ? this.getDissolutionStatementStep.valid : true,

--- a/src/views/Dissolution/DissolutionResolution.vue
+++ b/src/views/Dissolution/DissolutionResolution.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Vue, Watch } from 'vue-property-decorator'
+import { Component, Mixins, Watch } from 'vue-property-decorator'
 import { Getter } from 'vuex-class'
 import { CreateResolutionIF } from '@/interfaces'
 import { CommonMixin } from '@/mixins'
@@ -25,7 +25,7 @@ export default class DissolutionResolution extends Mixins(CommonMixin) {
   private async scrollToInvalidComponent (): Promise<void> {
     if (this.getShowErrors && this.$route.name === RouteNames.DISSOLUTION_RESOLUTION) {
       // scroll to invalid components
-      await Vue.nextTick()
+      await this.$nextTick()
       const vid = this.getCreateResolutionStep.validationDetail.validationItemDetails
       const validFlags = this.buildValidFlags(vid)
       const componentIds = this.buildElementIds(vid)
@@ -37,7 +37,3 @@ export default class DissolutionResolution extends Mixins(CommonMixin) {
   }
 }
 </script>
-
-<style lang="scss" scoped>
-@import '@/assets/styles/theme.scss';
-</style>

--- a/src/views/Incorporation/IncorporationAgreement.vue
+++ b/src/views/Incorporation/IncorporationAgreement.vue
@@ -207,7 +207,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Watch, Vue } from 'vue-property-decorator'
+import { Component, Mixins, Watch } from 'vue-property-decorator'
 import { Getter } from 'vuex-class'
 import AgreementType from '@/components/common/AgreementType.vue'
 import { IncorporationAgreementIF } from '@/interfaces'
@@ -247,7 +247,7 @@ export default class IncorporationAgreement extends Mixins(CommonMixin, EnumMixi
   private async scrollToInvalidComponent (): Promise<void> {
     if (this.getShowErrors && this.$route.name === RouteNames.INCORPORATION_AGREEMENT) {
       // scroll to invalid components
-      await Vue.nextTick()
+      await this.$nextTick()
       await this.validateAndScroll(
         {
           isAgreementValid: this.getIncorporationAgreementStep.valid

--- a/src/views/Incorporation/IncorporationDefineCompany.vue
+++ b/src/views/Incorporation/IncorporationDefineCompany.vue
@@ -122,7 +122,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Vue, Watch } from 'vue-property-decorator'
+import { Component, Mixins, Watch } from 'vue-property-decorator'
 import { Getter, Action } from 'vuex-class'
 import {
   ActionBindingIF,
@@ -192,7 +192,7 @@ export default class IncorporationDefineCompany extends Mixins(CommonMixin) {
     }
 
     // watch data changes once page has loaded (in next tick)
-    Vue.nextTick(() => {
+    this.$nextTick(() => {
       this.setIgnoreChanges(false)
     })
   }
@@ -266,7 +266,7 @@ export default class IncorporationDefineCompany extends Mixins(CommonMixin) {
   private async scrollToInvalidComponent (): Promise<void> {
     if (this.getShowErrors && this.$route.name === RouteNames.INCORPORATION_DEFINE_COMPANY) {
       // scroll to invalid components
-      await Vue.nextTick()
+      await this.$nextTick()
       await this.validateAndScroll(
         {
           hasValidNameTranslation: this.hasValidNameTranslation,

--- a/src/views/Incorporation/IncorporationMemorandum.vue
+++ b/src/views/Incorporation/IncorporationMemorandum.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Vue, Watch } from 'vue-property-decorator'
+import { Component, Mixins, Watch } from 'vue-property-decorator'
 import { Getter } from 'vuex-class'
 import { CreateMemorandumIF } from '@/interfaces'
 import { CommonMixin } from '@/mixins'
@@ -25,7 +25,7 @@ export default class IncorporationMemorandum extends Mixins(CommonMixin) {
   private async scrollToInvalidComponent (): Promise<void> {
     if (this.getShowErrors && this.$route.name === RouteNames.INCORPORATION_MEMORANDUM) {
       // scroll to invalid components
-      await Vue.nextTick()
+      await this.$nextTick()
       const vid = this.getCreateMemorandumStep.validationDetail.validationItemDetails
       const validFlags = this.buildValidFlags(vid)
       const componentIds = this.buildElementIds(vid)
@@ -37,7 +37,3 @@ export default class IncorporationMemorandum extends Mixins(CommonMixin) {
   }
 }
 </script>
-
-<style lang="scss" scoped>
-@import '@/assets/styles/theme.scss';
-</style>

--- a/src/views/Incorporation/IncorporationPeopleRoles.vue
+++ b/src/views/Incorporation/IncorporationPeopleRoles.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Vue, Watch } from 'vue-property-decorator'
+import { Component, Mixins, Watch } from 'vue-property-decorator'
 import { Getter } from 'vuex-class'
 import { PeopleAndRoleIF, PeopleAndRolesResourceIF } from '@/interfaces'
 import { CommonMixin } from '@/mixins'
@@ -31,7 +31,7 @@ export default class IncorporationPeopleRoles extends Mixins(CommonMixin) {
   private async scrollToInvalidComponent (): Promise<void> {
     if (this.getShowErrors && this.$route.name === RouteNames.INCORPORATION_PEOPLE_ROLES) {
       // scroll to invalid components
-      await Vue.nextTick()
+      await this.$nextTick()
       await this.validateAndScroll(
         {
           peopleAndRoles: this.getAddPeopleAndRoleStep.valid

--- a/src/views/Incorporation/IncorporationRules.vue
+++ b/src/views/Incorporation/IncorporationRules.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Vue, Watch } from 'vue-property-decorator'
+import { Component, Mixins, Watch } from 'vue-property-decorator'
 import { Getter } from 'vuex-class'
 import { CreateRulesIF } from '@/interfaces'
 import { CommonMixin } from '@/mixins'
@@ -26,7 +26,7 @@ export default class IncorporationRules extends Mixins(CommonMixin) {
   private async scrollToInvalidComponent (): Promise<void> {
     if (this.getShowErrors && this.$route.name === RouteNames.INCORPORATION_RULES) {
       // scroll to invalid components
-      await Vue.nextTick()
+      await this.$nextTick()
       const vid = this.getCreateRulesStep.validationDetail.validationItemDetails
       const validFlags = this.buildValidFlags(vid)
       const componentIds = this.buildElementIds(vid)
@@ -38,7 +38,3 @@ export default class IncorporationRules extends Mixins(CommonMixin) {
   }
 }
 </script>
-
-<style lang="scss" scoped>
-@import '@/assets/styles/theme.scss';
-</style>

--- a/src/views/Incorporation/IncorporationShareStructure.vue
+++ b/src/views/Incorporation/IncorporationShareStructure.vue
@@ -92,7 +92,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Vue, Watch } from 'vue-property-decorator'
+import { Component, Mixins, Watch } from 'vue-property-decorator'
 import { Action, Getter } from 'vuex-class'
 import { v4 as uuidv4 } from 'uuid'
 import {
@@ -256,7 +256,7 @@ export default class IncorporationShareStructure extends Mixins(CommonMixin) {
   private async scrollToInvalidComponent (): Promise<void> {
     if (this.getShowErrors && this.$route.name === RouteNames.INCORPORATION_SHARE_STRUCTURE) {
       // scroll to invalid components
-      await Vue.nextTick()
+      await this.$nextTick()
       await this.validateAndScroll(
         {
           shareStructure: this.getCreateShareStructureStep.valid

--- a/src/views/Registration/RegistrationDefineBusiness.vue
+++ b/src/views/Registration/RegistrationDefineBusiness.vue
@@ -94,7 +94,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Vue, Watch } from 'vue-property-decorator'
+import { Component, Mixins, Watch } from 'vue-property-decorator'
 import { Action, Getter } from 'vuex-class'
 import BusinessAddresses from '@/components/Registration/BusinessAddresses.vue'
 import BusinessContactInfo from '@/components/common/BusinessContactInfo.vue'
@@ -179,7 +179,7 @@ export default class RegistrationDefineBusiness extends Mixins(CommonMixin) {
   async scrollToInvalidComponent (): Promise<void> {
     if (this.getShowErrors && this.$route.name === RouteNames.REGISTRATION_DEFINE_BUSINESS) {
       // scroll to invalid components
-      await Vue.nextTick()
+      await this.$nextTick()
       await this.validateAndScroll(this.validFlags, this.validComponents)
     }
   }

--- a/src/views/Registration/RegistrationPeopleRoles.vue
+++ b/src/views/Registration/RegistrationPeopleRoles.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Vue, Watch } from 'vue-property-decorator'
+import { Component, Mixins, Watch } from 'vue-property-decorator'
 import { Getter } from 'vuex-class'
 import { PeopleAndRoleIF, PeopleAndRolesResourceIF } from '@/interfaces'
 import { CommonMixin } from '@/mixins'
@@ -31,7 +31,7 @@ export default class RegistrationPeopleRoles extends Mixins(CommonMixin) {
   private async scrollToInvalidComponent (): Promise<void> {
     if (this.getShowErrors && this.$route.name === RouteNames.REGISTRATION_PEOPLE_ROLES) {
       // scroll to invalid components
-      await Vue.nextTick()
+      await this.$nextTick()
       await this.validateAndScroll(
         {
           peopleAndRoles: this.getAddPeopleAndRoleStep.valid

--- a/tests/unit/UploadAffidavit.spec.ts
+++ b/tests/unit/UploadAffidavit.spec.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import { shallowWrapperFactory, wrapperFactory } from '../jest-wrapper-factory'
-import Affidavit from '@/components/Dissolution/Affidavit.vue'
+import Affidavit from '@/components/Dissolution/CompleteAffidavit.vue'
 import { DissolutionResources } from '@/resources'
 import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module'
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#9518

*Description of changes:*
- now set haveData in try{} instead of finally{}
- added some logging (temporary)
- replaced Vue.nextTick() with this.$nextTick()
- removed some unneeded "ignore changes"
- moved some "step validation" from created() to mounted()
- app version = 3.4.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).