### PR TITLE
10891 Implemented P&R for General Partnerships

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "3.5.12",
+  "version": "3.5.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "3.5.12",
+  "version": "3.5.13",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Registration/RegAddEditOrgPerson.vue
+++ b/src/components/Registration/RegAddEditOrgPerson.vue
@@ -89,6 +89,7 @@
             <article v-if="isOrg && isManualAdd">
               <label v-if="activeIndex === -1">Add Business or Corporation Unregistered in B.C.</label>
               <label v-else>Edit Business or Corporation Unregistered in B.C.</label>
+
               <!-- FUTURE -->
               <!-- <a class="lookup-toggle float-right">Business or Corporation Look Up</a> -->
 
@@ -100,7 +101,7 @@
 
               <HelpContactUs class="mt-6" />
 
-              <!-- Confirm checkbox -->
+              <!-- Confirm checkbox (org only) -->
               <v-checkbox
                 class="confirm-checkbox mt-8"
                 hide-details
@@ -117,7 +118,7 @@
                 </template>
               </v-checkbox>
 
-              <!-- Organization Name -->
+              <!-- Organization Name (org only) -->
               <v-text-field
                 filled
                 class="mt-8 mb-n6 org-name"
@@ -131,7 +132,7 @@
                 v-if="isProprietor"
                 filled
                 persistent-hint
-                class="item mt-8 mb-n2"
+                class="item business-number mt-8 mb-n2"
                 label="Business Number (Optional)"
                 hint="First 9 digits of the CRA Business Number"
                 v-model.trim="orgPerson.officer.businessNumber"
@@ -190,7 +191,7 @@
               <v-text-field
                 filled
                 persistent-hint
-                class="item mt-4 mb-n2"
+                class="item business-number mt-4 mb-n2"
                 label="Business Number (Optional)"
                 hint="First 9 digits of the CRA Business Number"
                 v-model.trim="orgPerson.officer.businessNumber"
@@ -206,7 +207,7 @@
               </p>
               <v-text-field
                 filled
-                class="item mt-4 mb-n6"
+                class="item email-address mt-4 mb-n6"
                 label="Email Address"
                 v-model.trim="orgPerson.officer.email"
                 :rules="enableRules ? Rules.EmailRules : []"

--- a/src/components/Registration/RegAddEditOrgPerson.vue
+++ b/src/components/Registration/RegAddEditOrgPerson.vue
@@ -87,15 +87,15 @@
 
             <!-- Add org manually -->
             <article v-if="isOrg && isManualAdd">
-              <label v-if="activeIndex === -1">Add Business or Corporation Manually</label>
-              <label v-else>Edit Business or Corporation Manually</label>
+              <label v-if="activeIndex === -1">Add Business or Corporation Unregistered in B.C.</label>
+              <label v-else>Edit Business or Corporation Unregistered in B.C.</label>
               <!-- FUTURE -->
               <!-- <a class="lookup-toggle float-right">Business or Corporation Look Up</a> -->
 
               <p class="mt-6 mb-0">
-                Use this manual entry form to add a company that is not legally required to register
-                in B.C. such as a bank or railway as a partner. All other types of businesses not
-                registered in B.C. cannot be a proprietor or partner.
+                Use this form to add a company that is not legally required to register in B.C. such as a
+                bank or railway as a partner. All other types of businesses not registered in B.C.
+                cannot be a proprietor or partner.
               </p>
 
               <HelpContactUs class="mt-6" />
@@ -107,8 +107,12 @@
                 v-model="orgPerson.confirmBusiness"
                 :rules="enableRules ? [(v) => !!v] : []"
               >
-                <template slot="label">
+                <template v-if="isProprietor" slot="label">
                   I confirm that the business proprietor being added is not legally required to
+                  register in B.C.
+                </template>
+                <template v-if="isPartner" slot="label">
+                  I confirm that the business partner being added is not legally required to
                   register in B.C.
                 </template>
               </v-checkbox>
@@ -122,8 +126,9 @@
                 :rules="enableRules ? OrgNameRules : []"
               />
 
-              <!-- Business Number -->
+              <!-- Business Number (org proprietors only) -->
               <v-text-field
+                v-if="isProprietor"
                 filled
                 persistent-hint
                 class="item mt-8 mb-n2"
@@ -157,6 +162,16 @@
                       v-model="selectedRoles"
                       :value="RoleTypes.PROPRIETOR"
                       :label="RoleTypes.PROPRIETOR"
+                      :disabled="true"
+                    />
+                  </v-col>
+
+                  <v-col cols="4" v-if="showPartnerRole" class="py-0">
+                    <v-checkbox
+                      class="mt-5"
+                      v-model="selectedRoles"
+                      :value="RoleTypes.PARTNER"
+                      :label="RoleTypes.PARTNER"
                       :disabled="true"
                     />
                   </v-col>
@@ -218,8 +233,8 @@
               />
             </article>
 
-            <!-- Delivery Address (for proprietors only) -->
-            <div v-if="isProprietor" class="mt-8">
+            <!-- Delivery Address (for proprietors and partners only) -->
+            <div v-if="isProprietor || isPartner" class="mt-8">
               <v-checkbox
                 class="inherit-checkbox"
                 hide-details

--- a/src/components/Registration/RegPeopleAndRoles.vue
+++ b/src/components/Registration/RegPeopleAndRoles.vue
@@ -21,21 +21,24 @@
           <li v-if="rule.id === RuleIds.NUM_COMPLETING_PARTY" :key="index">
             <v-icon v-if="validNumCompletingParty" color="green darken-2"
               class="cp-valid">mdi-check</v-icon>
-            <v-icon v-else-if="getShowErrors" color="error" class="cp-invalid">mdi-close</v-icon>
+            <v-icon v-else-if="getShowErrors" color="error"
+              class="cp-invalid">mdi-close</v-icon>
             <v-icon v-else>mdi-circle-small</v-icon>
             <span class="rule-item-txt">{{rule.text}}</span>
           </li>
           <li v-if="rule.id === RuleIds.NUM_PROPRIETORS" :key="index">
             <v-icon v-if="validNumProprietors" color="green darken-2"
-              class="prop-valid">mdi-check</v-icon>
-            <v-icon v-else-if="getShowErrors" color="error" class="prop-invalid">mdi-close</v-icon>
+              class="proprietor-valid">mdi-check</v-icon>
+            <v-icon v-else-if="getShowErrors" color="error"
+              class="proprietor-invalid">mdi-close</v-icon>
             <v-icon v-else>mdi-circle-small</v-icon>
             <span class="rule-item-txt">{{rule.text}}</span>
           </li>
           <li v-if="rule.id === RuleIds.NUM_PARTNERS" :key="index">
             <v-icon v-if="validNumPartners" color="green darken-2"
-              class="prop-valid">mdi-check</v-icon>
-            <v-icon v-else-if="getShowErrors" color="error" class="prop-invalid">mdi-close</v-icon>
+              class="partner-valid">mdi-check</v-icon>
+            <v-icon v-else-if="getShowErrors" color="error"
+              class="partner-invalid">mdi-close</v-icon>
             <v-icon v-else>mdi-circle-small</v-icon>
             <span class="rule-item-txt">{{rule.text}}</span>
           </li>

--- a/src/components/Registration/RegPeopleAndRoles.vue
+++ b/src/components/Registration/RegPeopleAndRoles.vue
@@ -32,6 +32,13 @@
             <v-icon v-else>mdi-circle-small</v-icon>
             <span class="rule-item-txt">{{rule.text}}</span>
           </li>
+          <li v-if="rule.id === RuleIds.NUM_PARTNERS" :key="index">
+            <v-icon v-if="validNumPartners" color="green darken-2"
+              class="prop-valid">mdi-check</v-icon>
+            <v-icon v-else-if="getShowErrors" color="error" class="prop-invalid">mdi-close</v-icon>
+            <v-icon v-else>mdi-circle-small</v-icon>
+            <span class="rule-item-txt">{{rule.text}}</span>
+          </li>
         </template>
       </ul>
     </section>
@@ -73,37 +80,62 @@
         <span>Add the Completing Party</span>
       </v-btn>
 
-      <!-- *** FUTURE: fix v-if to work for multiple proprietors for GPs -->
-      <v-btn
-        v-if="!validNumProprietors"
-        outlined
-        color="primary"
-        class="btn-outlined-primary mt-6 btn-add-person"
-        :disabled="showOrgPersonForm"
-        @click="addOrgPerson(RoleTypes.PROPRIETOR, PartyTypes.PERSON)"
-      >
-        <v-icon>mdi-account-plus</v-icon>
-        <span>Add a Person</span>
-      </v-btn>
+      <template v-if="isTypeSoleProp">
+        <v-btn
+          v-if="!validNumProprietors"
+          outlined
+          color="primary"
+          class="btn-outlined-primary mt-6 btn-add-person"
+          :disabled="showOrgPersonForm"
+          @click="addOrgPerson(RoleTypes.PROPRIETOR, PartyTypes.PERSON)"
+        >
+          <v-icon>mdi-account-plus</v-icon>
+          <span>Add a Person</span>
+        </v-btn>
 
-      <!-- *** FUTURE: fix v-if to work for multiple proprietors for GPs -->
-      <v-btn
-        v-if="!validNumProprietors"
-        outlined
-        color="primary"
-        class="btn-outlined-primary mt-6 btn-add-organization"
-        :disabled="showOrgPersonForm"
-        @click="addOrgPerson(RoleTypes.PROPRIETOR, PartyTypes.ORGANIZATION)"
-      >
-        <v-icon>mdi-domain-plus</v-icon>
-        <span>Add a Business or a Corporation</span>
-      </v-btn>
+        <v-btn
+          v-if="!validNumProprietors"
+          outlined
+          color="primary"
+          class="btn-outlined-primary mt-6 btn-add-organization"
+          :disabled="showOrgPersonForm"
+          @click="addOrgPerson(RoleTypes.PROPRIETOR, PartyTypes.ORGANIZATION)"
+        >
+          <v-icon>mdi-domain-plus</v-icon>
+          <span>Add a Business or a Corporation</span>
+        </v-btn>
+      </template>
+
+      <template v-if="isTypePartnership">
+        <v-btn
+          v-if="!validNumPartners"
+          outlined
+          color="primary"
+          class="btn-outlined-primary mt-6 btn-add-person"
+          :disabled="showOrgPersonForm"
+          @click="addOrgPerson(RoleTypes.PARTNER, PartyTypes.PERSON)"
+        >
+          <v-icon>mdi-account-plus</v-icon>
+          <span>Add a Person</span>
+        </v-btn>
+
+        <v-btn
+          v-if="!validNumPartners"
+          outlined
+          color="primary"
+          class="btn-outlined-primary mt-6 btn-add-organization"
+          :disabled="showOrgPersonForm"
+          @click="addOrgPerson(RoleTypes.PARTNER, PartyTypes.ORGANIZATION)"
+        >
+          <v-icon>mdi-domain-plus</v-icon>
+          <span>Add a Business or a Corporation</span>
+        </v-btn>
+      </template>
     </div>
 
     <!-- Add/Edit Bus/Corp -->
     <v-expand-transition>
       <v-card flat v-if="showOrgPersonForm" class="mt-8">
-        <!-- FUTURE: move this component into a slot in ListPeopleAndRoles ??? -->
         <RegAddEditOrgPerson
           :initialValue="currentOrgPerson"
           :activeIndex="activeIndex"
@@ -164,11 +196,13 @@ export default class RegPeopleAndRoles extends Mixins(PeopleRolesMixin) {
     const isPerson = (partyType === PartyTypes.PERSON)
     const isOrganization = (partyType === PartyTypes.ORGANIZATION)
 
+    // if the proprietor is a person then this is a SP
     if (isProprietor && isPerson) {
       if (!await this.confirmAddProprietorPerson()) return
       this.setRegistrationBusinessType(BusinessTypes.SP)
     }
 
+    // if the proprietor is an org then this is a DBA
     if (isProprietor && isOrganization) {
       if (!await this.confirmAddProprietorOrganization()) return
       this.setRegistrationBusinessType(BusinessTypes.DBA)
@@ -180,9 +214,12 @@ export default class RegPeopleAndRoles extends Mixins(PeopleRolesMixin) {
     if (roleType) {
       // a role was provided - pre-select it
       this.currentOrgPerson.roles = [{ roleType }]
-    } else if (this.validNumCompletingParty) {
+    } else if (this.validNumCompletingParty && this.isTypeSoleProp) {
       // only Proprietor role is possible - pre-select it
       this.currentOrgPerson.roles = [{ roleType: RoleTypes.PROPRIETOR }]
+    } else if (this.validNumCompletingParty && this.isTypePartnership) {
+      // only Partner role is possible - pre-select it
+      this.currentOrgPerson.roles = [{ roleType: RoleTypes.PARTNER }]
     } else {
       // no roles pre-selected
       this.currentOrgPerson.roles = []

--- a/src/components/common/ListPeopleAndRoles.vue
+++ b/src/components/common/ListPeopleAndRoles.vue
@@ -66,7 +66,7 @@
           </v-col>
 
           <v-col class="delivery-address-column">
-            <template v-if="isDirector(orgPerson) || isProprietor(orgPerson)">
+            <template v-if="isDirector(orgPerson) || isProprietor(orgPerson) || isPartner(orgPerson)">
               <p v-if="isSame(orgPerson.mailingAddress, orgPerson.deliveryAddress)">
                 Same as Mailing Address
               </p>
@@ -191,6 +191,11 @@ export default class ListPeopleAndRoles extends Mixins(CommonMixin) {
   /** Returns true if specified org/person is a proprietor. */
   public isProprietor (orgPerson: OrgPersonIF): boolean {
     return orgPerson?.roles.some(role => role.roleType === RoleTypes.PROPRIETOR)
+  }
+
+  /** Returns true if specified org/person is a partner. */
+  public isPartner (orgPerson: OrgPersonIF): boolean {
+    return orgPerson?.roles.some(role => role.roleType === RoleTypes.PARTNER)
   }
 
   /** Formats the org-person's name. */

--- a/src/enums/roleTypes.ts
+++ b/src/enums/roleTypes.ts
@@ -4,6 +4,7 @@ export enum RoleTypes {
   CUSTODIAN = 'Custodian',
   INCORPORATOR = 'Incorporator',
   LIQUIDATOR = 'Liquidator',
+  PARTNER = 'Partner',
   PROPRIETOR = 'Proprietor',
   SUBSCRIBER = 'Subscriber',
 }

--- a/src/enums/ruleIds.ts
+++ b/src/enums/ruleIds.ts
@@ -6,4 +6,5 @@ export enum RuleIds {
   DIRECTOR_COUNTRY = 3,
   DIRECTOR_PROVINCE = 4,
   NUM_PROPRIETORS = 5,
+  NUM_PARTNERS = 6,
 }

--- a/src/mixins/add-edit-org-person-mixin.ts
+++ b/src/mixins/add-edit-org-person-mixin.ts
@@ -87,6 +87,11 @@ export default class AddEditOrgPersonMixin extends Vue {
     return this.selectedRoles.includes(RoleTypes.PROPRIETOR)
   }
 
+  /** Whether Partner is checked. */
+  protected get isPartner (): boolean {
+    return this.selectedRoles.includes(RoleTypes.PARTNER)
+  }
+
   /** Whether current data object is a person. */
   protected get isPerson (): boolean {
     return (this.orgPerson.officer?.partyType === PartyTypes.PERSON)
@@ -119,8 +124,12 @@ export default class AddEditOrgPersonMixin extends Vue {
 
   /** Whether the Proprietor role should be shown. */
   protected get showProprietorRole (): boolean {
-    const isRoleProprietor = this.orgPerson.roles.some(role => role.roleType === RoleTypes.PROPRIETOR)
-    return isRoleProprietor
+    return this.orgPerson.roles.some(role => role.roleType === RoleTypes.PROPRIETOR)
+  }
+
+  /** Whether the Partner role should be shown. */
+  protected get showPartnerRole (): boolean {
+    return this.orgPerson.roles.some(role => role.roleType === RoleTypes.PARTNER)
   }
 
   /** Whether the Completing Party role should be disabled. */
@@ -171,7 +180,7 @@ export default class AddEditOrgPersonMixin extends Vue {
 
       // set address properties
       this.inProgressMailingAddress = { ...this.orgPerson.mailingAddress }
-      if (this.isDirector || this.isProprietor) {
+      if (this.isDirector || this.isProprietor || this.isPartner) {
         this.inProgressDeliveryAddress = { ...this.orgPerson.deliveryAddress }
         // initialize inheritMailingAddress checkbox conditionally
         this.updateSameAsMailingChkBox()
@@ -182,7 +191,7 @@ export default class AddEditOrgPersonMixin extends Vue {
   /** decide if the "Delivery Address same as Mailing Address" check box should be checked */
   protected updateSameAsMailingChkBox (): void {
     // safety check
-    if (!this.isDirector && !this.isProprietor) return
+    if (!this.isDirector && !this.isProprietor && !this.isPartner) return
 
     // if not already assigned, initialize delivery address to prevent template errors
     if (!this.inProgressDeliveryAddress) this.inProgressDeliveryAddress = cloneDeep(EmptyAddress)
@@ -308,7 +317,7 @@ export default class AddEditOrgPersonMixin extends Vue {
       person.officer.id = uuidv4()
     }
     person.mailingAddress = { ...this.inProgressMailingAddress }
-    if (this.isDirector || this.isProprietor) {
+    if (this.isDirector || this.isProprietor || this.isPartner) {
       person.deliveryAddress = this.setPersonDeliveryAddress()
     }
     person.roles = this.setPersonRoles()
@@ -336,6 +345,9 @@ export default class AddEditOrgPersonMixin extends Vue {
     }
     if (this.isProprietor) {
       roles.push({ roleType: RoleTypes.PROPRIETOR, appointmentDate: this.getCurrentDate })
+    }
+    if (this.isPartner) {
+      roles.push({ roleType: RoleTypes.PARTNER, appointmentDate: this.getCurrentDate })
     }
 
     return roles

--- a/src/mixins/add-edit-org-person-mixin.ts
+++ b/src/mixins/add-edit-org-person-mixin.ts
@@ -168,7 +168,7 @@ export default class AddEditOrgPersonMixin extends Vue {
 
   /** Called when component is created. */
   created (): void {
-    // mark this step as invalid when adding or editing
+    // mark this step as invalid while adding or editing
     this.setAddPeopleAndRoleStepValidity(false)
 
     if (this.initialValue) {
@@ -182,7 +182,7 @@ export default class AddEditOrgPersonMixin extends Vue {
       this.inProgressMailingAddress = { ...this.orgPerson.mailingAddress }
       if (this.isDirector || this.isProprietor || this.isPartner) {
         this.inProgressDeliveryAddress = { ...this.orgPerson.deliveryAddress }
-        // initialize inheritMailingAddress checkbox conditionally
+        // initialize inheritMailingAddress checkbox
         this.updateSameAsMailingChkBox()
       }
     }
@@ -313,7 +313,7 @@ export default class AddEditOrgPersonMixin extends Vue {
     let person: OrgPersonIF = { ...this.orgPerson }
     person.officer = { ...this.orgPerson.officer }
     if (this.activeIndex === -1) {
-      // assign a new (random) ID
+      // assign a new (random but unique) ID
       person.officer.id = uuidv4()
     }
     person.mailingAddress = { ...this.inProgressMailingAddress }
@@ -328,6 +328,7 @@ export default class AddEditOrgPersonMixin extends Vue {
     if (this.inheritMailingAddress) {
       this.inProgressDeliveryAddress = this.inProgressMailingAddress
     }
+    // return a new object (not a copy)
     return { ...this.inProgressDeliveryAddress }
   }
 

--- a/src/resources/Registrations/generalPartnership.ts
+++ b/src/resources/Registrations/generalPartnership.ts
@@ -24,7 +24,7 @@ export const GeneralPartnershipResource: RegistrationResourceIF = {
         test: (num) => { return (num === 1) }
       },
       {
-        id: RuleIds.NUM_PROPRIETORS,
+        id: RuleIds.NUM_PARTNERS,
         text: 'At least two Partners',
         test: (num) => { return (num >= 2) }
       }

--- a/src/views/Registration/RegistrationReviewConfirm.vue
+++ b/src/views/Registration/RegistrationReviewConfirm.vue
@@ -149,11 +149,21 @@ export default class RegistrationReviewConfirm extends Vue {
   get documentDeliveryAdditionalValue (): string {
     const orgPersonList = this.getAddPeopleAndRoleStep.orgPeople
 
-    const emails = orgPersonList
-      .filter(op => op.roles.some(role => role.roleType === RoleTypes.PROPRIETOR))
-      .map(op => op.officer?.email)
-      .filter(e => !!e)
-    return emails.join(',')
+    if (this.isTypeSoleProp) {
+      const emails = orgPersonList
+        .filter(op => op.roles.some(role => role.roleType === RoleTypes.PROPRIETOR))
+        .map(op => op.officer?.email)
+        .filter(e => !!e)
+      return emails.join(', ')
+    }
+    if (this.isTypePartnership) {
+      const emails = orgPersonList
+        .filter(op => op.roles.some(role => role.roleType === RoleTypes.PARTNER))
+        .map(op => op.officer?.email)
+        .filter(e => !!e)
+      return emails.join(', ')
+    }
+    return null
   }
 
   /** Is true when the Document Delivery conditions are not met. */

--- a/tests/unit/RegAddEditOrgPerson.spec.ts
+++ b/tests/unit/RegAddEditOrgPerson.spec.ts
@@ -27,7 +27,10 @@ const resetEvent = 'resetEvent'
 const firstNameSelector = '.first-name'
 const middleNameSelector = '.middle-name'
 const lastNameSelector = '.last-name'
+const confirmCheckboxSelector = '.confirm-checkbox'
 const orgNameSelector = '.org-name'
+const businessNumberSelector = '.business-number'
+const emailAddressSelector = '.email-address'
 const buttonRemoveSelector = '.btn-remove'
 const buttonDoneSelector = '.btn-done'
 const buttonCancelSelector = '.btn-cancel'
@@ -38,9 +41,10 @@ const validCompletingParty = {
     firstName: 'Adam',
     lastName: 'Smith',
     middleName: 'D',
-    organizationName: '',
+    // no org name
     partyType: 'person',
     email: 'completing-party@example.com'
+    // no business number
   },
   roles: [
     { roleType: 'Completing Party', appointmentDate: '2020-03-30' }
@@ -52,15 +56,8 @@ const validCompletingParty = {
     addressRegion: 'BC',
     postalCode: 'V8Z 5C6',
     addressCountry: 'CA'
-  },
-  deliveryAddress: {
-    streetAddress: '123 Fake Street',
-    streetAddressAdditional: '',
-    addressCity: 'Victoria',
-    addressRegion: 'BC',
-    postalCode: 'V8Z 5C6',
-    addressCountry: 'CA'
   }
+  // no delivery address
 }
 
 const validProprietorPerson = {
@@ -69,9 +66,10 @@ const validProprietorPerson = {
     firstName: 'Bill',
     lastName: 'Jones',
     middleName: 'M',
-    organizationName: '',
+    // no org name
     partyType: 'person',
-    email: 'proprietor-person@example.com'
+    email: 'proprietor-person@example.com',
+    businessNumber: '123456789'
   },
   roles: [
     { roleType: 'Proprietor', appointmentDate: '2020-03-30' }
@@ -97,12 +95,13 @@ const validProprietorPerson = {
 const validProprietorOrg = {
   officer: {
     id: '0',
-    firstName: '',
-    lastName: '',
-    middleName: '',
-    organizationName: 'Test Org',
+    // no first name
+    // no last name
+    // no middle name
+    organizationName: 'Proprietor Org Inc',
     partyType: 'organization',
-    email: 'proprietor-org@example.com'
+    email: 'proprietor-org@example.com',
+    businessNumber: '123456789'
   },
   roles: [
     { roleType: 'Proprietor', appointmentDate: '2020-03-30' }
@@ -114,7 +113,81 @@ const validProprietorOrg = {
     addressRegion: 'BC',
     postalCode: 'V8Z 5C6',
     addressCountry: 'CA'
+  },
+  deliveryAddress: {
+    streetAddress: '3942 Fake Street',
+    streetAddressAdditional: '',
+    addressCity: 'Victoria',
+    addressRegion: 'BC',
+    postalCode: 'V8Z 5C6',
+    addressCountry: 'CA'
+  },
+  confirmBusiness: true
+}
+
+const validPartnerPerson = {
+  officer: {
+    id: '1',
+    firstName: 'Bill',
+    lastName: 'Jones',
+    middleName: 'M',
+    // no org name
+    partyType: 'person',
+    email: 'partner-person@example.com'
+    // no business number
+  },
+  roles: [
+    { roleType: 'Partner', appointmentDate: '2020-03-30' }
+  ],
+  mailingAddress: {
+    streetAddress: '123 Fake Street',
+    streetAddressAdditional: '',
+    addressCity: 'Victoria',
+    addressRegion: 'BC',
+    postalCode: 'V8Z 5C6',
+    addressCountry: 'CA'
+  },
+  deliveryAddress: {
+    streetAddress: '123 Fake Street',
+    streetAddressAdditional: '',
+    addressCity: 'Victoria',
+    addressRegion: 'BC',
+    postalCode: 'V8Z 5C6',
+    addressCountry: 'CA'
   }
+}
+
+const validPartnerOrg = {
+  officer: {
+    id: '0',
+    // no first name
+    // no last name
+    // no middle name
+    organizationName: 'Partner Org Inc',
+    partyType: 'organization',
+    email: 'partner-org@example.com'
+    // no business number
+  },
+  roles: [
+    { roleType: 'Partner', appointmentDate: '2020-03-30' }
+  ],
+  mailingAddress: {
+    streetAddress: '3942 Fake Street',
+    streetAddressAdditional: '',
+    addressCity: 'Victoria',
+    addressRegion: 'BC',
+    postalCode: 'V8Z 5C6',
+    addressCountry: 'CA'
+  },
+  deliveryAddress: {
+    streetAddress: '3942 Fake Street',
+    streetAddressAdditional: '',
+    addressCity: 'Victoria',
+    addressRegion: 'BC',
+    postalCode: 'V8Z 5C6',
+    addressCountry: 'CA'
+  },
+  confirmBusiness: true
 }
 
 /**
@@ -153,11 +226,12 @@ describe('Registration Add/Edit Org/Person component', () => {
     expect(vm.isIncorporator).toBe(false)
     expect(vm.isDirector).toBe(false)
     expect(vm.isProprietor).toBe(false)
+    expect(vm.isPartner).toBe(false)
 
     wrapper.destroy()
   })
 
-  it('loads the component and sets the data for proprietor-person', () => {
+  it('loads the component and sets the data for proprietor-person (SP)', () => {
     const wrapper = createComponent(validProprietorPerson, -1, null)
     const vm = wrapper.vm as any
 
@@ -166,11 +240,26 @@ describe('Registration Add/Edit Org/Person component', () => {
     expect(vm.isIncorporator).toBe(false)
     expect(vm.isDirector).toBe(false)
     expect(vm.isProprietor).toBe(true)
+    expect(vm.isPartner).toBe(false)
 
     wrapper.destroy()
   })
 
-  it('loads the component and sets the data for proprietor-org', () => {
+  it('loads the component and sets the data for partner-person (GP)', () => {
+    const wrapper = createComponent(validPartnerPerson, -1, null)
+    const vm = wrapper.vm as any
+
+    expect(vm.$data.orgPerson).toStrictEqual(validPartnerPerson)
+    expect(vm.isCompletingParty).toBe(false)
+    expect(vm.isIncorporator).toBe(false)
+    expect(vm.isDirector).toBe(false)
+    expect(vm.isProprietor).toBe(false)
+    expect(vm.isPartner).toBe(true)
+
+    wrapper.destroy()
+  })
+
+  it('loads the component and sets the data for proprietor-org (SP)', () => {
     const wrapper = createComponent(validProprietorOrg, -1, null)
     const vm = wrapper.vm as any
 
@@ -179,6 +268,21 @@ describe('Registration Add/Edit Org/Person component', () => {
     expect(vm.isIncorporator).toBe(false)
     expect(vm.isDirector).toBe(false)
     expect(vm.isProprietor).toBe(true)
+    expect(vm.isPartner).toBe(false)
+
+    wrapper.destroy()
+  })
+
+  it('loads the component and sets the data for partner-org (GP)', () => {
+    const wrapper = createComponent(validPartnerOrg, -1, null)
+    const vm = wrapper.vm as any
+
+    expect(vm.$data.orgPerson).toStrictEqual(validPartnerOrg)
+    expect(vm.isCompletingParty).toBe(false)
+    expect(vm.isIncorporator).toBe(false)
+    expect(vm.isDirector).toBe(false)
+    expect(vm.isProprietor).toBe(false)
+    expect(vm.isPartner).toBe(true)
 
     wrapper.destroy()
   })
@@ -190,12 +294,16 @@ describe('Registration Add/Edit Org/Person component', () => {
     const firstNameInput = wrapper.find(`${firstNameSelector} input`)
     const middleNameInput = wrapper.find(`${middleNameSelector} input`)
     const lastNameInput = wrapper.find(`${lastNameSelector} input`)
+    const emailInput = wrapper.find(`${emailAddressSelector} input`)
+    // FUTURE: verify mailing address
     expect((firstNameInput.element as HTMLInputElement).value)
       .toEqual(validCompletingParty['officer']['firstName'])
     expect((middleNameInput.element as HTMLInputElement).value)
       .toEqual(validCompletingParty['officer']['middleName'])
     expect((lastNameInput.element as HTMLInputElement).value)
       .toEqual(validCompletingParty['officer']['lastName'])
+    expect((emailInput.element as HTMLInputElement).value)
+      .toEqual(validCompletingParty['officer']['email'])
 
     // verify buttons
     expect(wrapper.find(buttonDoneSelector).attributes('disabled')).toBeUndefined()
@@ -205,19 +313,26 @@ describe('Registration Add/Edit Org/Person component', () => {
     wrapper.destroy()
   })
 
-  it('displays form data for proprietor-person', () => {
+  it('displays form data for proprietor-person (SP)', () => {
     const wrapper = createComponent(validProprietorPerson, 0, null)
 
     // verify input values
     const firstNameInput = wrapper.find(`${firstNameSelector} input`)
     const middleNameInput = wrapper.find(`${middleNameSelector} input`)
     const lastNameInput = wrapper.find(`${lastNameSelector} input`)
+    const businessNumberInput = wrapper.find(`${businessNumberSelector} input`)
+    const emailInput = wrapper.find(`${emailAddressSelector} input`)
+    // FUTURE: verify mailing address and delivery address
     expect((firstNameInput.element as HTMLInputElement).value)
       .toEqual(validProprietorPerson['officer']['firstName'])
     expect((middleNameInput.element as HTMLInputElement).value)
       .toEqual(validProprietorPerson['officer']['middleName'])
     expect((lastNameInput.element as HTMLInputElement).value)
       .toEqual(validProprietorPerson['officer']['lastName'])
+    expect((businessNumberInput.element as HTMLInputElement).value)
+      .toEqual(validProprietorPerson['officer']['businessNumber'])
+    expect((emailInput.element as HTMLInputElement).value)
+      .toEqual(validProprietorPerson['officer']['email'])
 
     // verify buttons
     expect(wrapper.find(buttonDoneSelector).attributes('disabled')).toBeUndefined()
@@ -227,13 +342,72 @@ describe('Registration Add/Edit Org/Person component', () => {
     wrapper.destroy()
   })
 
-  it('displays form data for proprietor-org', () => {
+  it('displays form data for partner-person (GP)', () => {
+    const wrapper = createComponent(validPartnerPerson, 0, null)
+
+    // verify input values
+    const firstNameInput = wrapper.find(`${firstNameSelector} input`)
+    const middleNameInput = wrapper.find(`${middleNameSelector} input`)
+    const lastNameInput = wrapper.find(`${lastNameSelector} input`)
+    const emailInput = wrapper.find(`${emailAddressSelector} input`)
+    // FUTURE: verify mailing address and delivery address
+    expect((firstNameInput.element as HTMLInputElement).value)
+      .toEqual(validPartnerPerson['officer']['firstName'])
+    expect((middleNameInput.element as HTMLInputElement).value)
+      .toEqual(validPartnerPerson['officer']['middleName'])
+    expect((lastNameInput.element as HTMLInputElement).value)
+      .toEqual(validPartnerPerson['officer']['lastName'])
+    expect((emailInput.element as HTMLInputElement).value)
+      .toEqual(validPartnerPerson['officer']['email'])
+
+    // verify buttons
+    expect(wrapper.find(buttonDoneSelector).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(buttonRemoveSelector).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(buttonCancelSelector).attributes('disabled')).toBeUndefined()
+
+    wrapper.destroy()
+  })
+
+  it('displays form data for proprietor-org (SP)', () => {
     const wrapper = createComponent(validProprietorOrg, 0, null)
 
     // verify input values
+    const confirmCheckboxInput = wrapper.find(`${confirmCheckboxSelector} input`)
     const orgNameInput = wrapper.find(`${orgNameSelector} input`)
+    const businessNumberInput = wrapper.find(`${businessNumberSelector} input`)
+    const emailInput = wrapper.find(`${emailAddressSelector} input`)
+    // FUTURE: verify mailing address and delivery address
+    expect((confirmCheckboxInput.element as HTMLInputElement).checked)
+      .toEqual(validProprietorOrg['confirmBusiness'])
     expect((orgNameInput.element as HTMLInputElement).value)
       .toEqual(validProprietorOrg['officer']['organizationName'])
+    expect((businessNumberInput.element as HTMLInputElement).value)
+      .toEqual(validProprietorOrg['officer']['businessNumber'])
+    expect((emailInput.element as HTMLInputElement).value)
+      .toEqual(validProprietorOrg['officer']['email'])
+
+    // verify buttons
+    expect(wrapper.find(buttonDoneSelector).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(buttonRemoveSelector).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(buttonCancelSelector).attributes('disabled')).toBeUndefined()
+
+    wrapper.destroy()
+  })
+
+  it('displays form data for partner-org (GP)', () => {
+    const wrapper = createComponent(validPartnerOrg, 0, null)
+
+    // verify input values
+    const confirmCheckboxInput = wrapper.find(`${confirmCheckboxSelector} input`)
+    const orgNameInput = wrapper.find(`${orgNameSelector} input`)
+    const emailInput = wrapper.find(`${emailAddressSelector} input`)
+    // FUTURE: verify mailing address and delivery address
+    expect((confirmCheckboxInput.element as HTMLInputElement).checked)
+      .toEqual(validPartnerOrg['confirmBusiness'])
+    expect((orgNameInput.element as HTMLInputElement).value)
+      .toEqual(validPartnerOrg['officer']['organizationName'])
+    expect((emailInput.element as HTMLInputElement).value)
+      .toEqual(validPartnerOrg['officer']['email'])
 
     // verify buttons
     expect(wrapper.find(buttonDoneSelector).attributes('disabled')).toBeUndefined()

--- a/tests/unit/RegPeopleAndRoles.spec.ts
+++ b/tests/unit/RegPeopleAndRoles.spec.ts
@@ -6,6 +6,7 @@ import { getVuexStore } from '@/store'
 import { mount } from '@vue/test-utils'
 import RegPeopleAndRoles from '@/components/Registration/RegPeopleAndRoles.vue'
 import { SoleProprietorshipResource } from '@/resources/Registrations/soleProprietorship'
+import { GeneralPartnershipResource } from '@/resources/Registrations/generalPartnership'
 import RegAddEditOrgPerson from '@/components/Registration/RegAddEditOrgPerson.vue'
 import ListPeopleAndRoles from '@/components/common/ListPeopleAndRoles.vue'
 
@@ -20,11 +21,12 @@ const store = getVuexStore()
 
 // selectors to test changes to the DOM elements
 const btnStartAddCompletingParty = '.btn-start-add-cp'
-const btnAddPerson = '.btn-add-person'
 const btnAddCompletingParty = '.btn-add-cp'
+const btnAddPerson = '.btn-add-person'
 const btnAddOrganization = '.btn-add-organization'
 const checkCompletingParty = '.cp-valid'
-const checkProprietor = '.prop-valid'
+const checkProprietor = '.proprietor-valid'
+const checkPartner = '.partner-valid'
 
 function getPersonList (roles = null): any {
   const completingPartyRole = {
@@ -163,6 +165,147 @@ describe('Registration People And Roles component - SP', () => {
     const wrapper = wrapperFactory()
     expect(wrapper.find(checkCompletingParty).exists()).toBeTruthy()
     expect(wrapper.find(checkProprietor).exists()).toBeTruthy()
+    wrapper.destroy()
+  })
+
+  it('it does not show people list component when people list is empty', () => {
+    store.state.stateModel.addPeopleAndRoleStep.orgPeople = []
+    const wrapper = wrapperFactory()
+    expect(wrapper.find(ListPeopleAndRoles).exists()).toBeFalsy()
+    wrapper.destroy()
+  })
+
+  it('shows the people list component when people list is not empty', () => {
+    store.state.stateModel.addPeopleAndRoleStep.orgPeople = getPersonList()
+    const wrapper = wrapperFactory()
+    expect(wrapper.find(ListPeopleAndRoles).exists()).toBeTruthy()
+    wrapper.destroy()
+  })
+
+  it('destroys the people list component when the last org-person is removed', async () => {
+    store.state.stateModel.addPeopleAndRoleStep.orgPeople = getPersonList()
+    const wrapper = wrapperFactory()
+
+    // verify before click
+    expect(wrapper.find(ListPeopleAndRoles).exists()).toBe(true)
+
+    // call the On Remove Person event handler
+    wrapper.vm.onRemovePerson(0)
+
+    // wait for dialog to display
+    await Vue.nextTick()
+
+    // click the Remove button
+    await wrapper.vm.$el.querySelector('.dialog-yes-btn').click()
+
+    // wait for everything to update
+    await flushPromises()
+
+    // verify after click
+    expect(wrapper.find(ListPeopleAndRoles).exists()).toBe(false)
+
+    wrapper.destroy()
+  })
+})
+
+describe('Registration People And Roles component - GP', () => {
+  let wrapperFactory: any
+
+  beforeEach(() => {
+    store.state.stateModel.entityType = 'GP'
+    store.state.resourceModel = GeneralPartnershipResource
+    wrapperFactory = () => mount(RegPeopleAndRoles, {
+      store,
+      vuetify,
+      stubs: {
+        RegAddEditOrgPerson: true,
+        ListPeopleAndRoles: true
+      }
+    })
+  })
+
+  it('shows Start Add Completing Party button when people list is empty', () => {
+    store.state.stateModel.addPeopleAndRoleStep.orgPeople = []
+    const wrapper = wrapperFactory()
+    expect(wrapper.find(btnStartAddCompletingParty).exists()).toBeTruthy()
+    expect(wrapper.find(btnStartAddCompletingParty).text()).toContain('Start by Adding the Completing Party')
+    // also verify list people component
+    expect(wrapper.find(ListPeopleAndRoles).exists()).toBeFalsy()
+    wrapper.destroy()
+  })
+
+  it('does not show the other buttons when people list is empty', () => {
+    store.state.stateModel.addPeopleAndRoleStep.orgPeople = []
+    const wrapper = wrapperFactory()
+    expect(wrapper.find(btnAddPerson).exists()).toBeFalsy()
+    expect(wrapper.find(btnAddCompletingParty).exists()).toBeFalsy()
+    expect(wrapper.find(btnAddOrganization).exists()).toBeFalsy()
+    wrapper.destroy()
+  })
+
+  it('does not show Start Add Completing Party button when people list is not empty', () => {
+    store.state.stateModel.addPeopleAndRoleStep.orgPeople = getPersonList()
+    const wrapper = wrapperFactory()
+    expect(wrapper.find(btnStartAddCompletingParty).exists()).toBeFalsy()
+    // also verify list people component
+    expect(wrapper.find(ListPeopleAndRoles).exists()).toBeTruthy()
+    wrapper.destroy()
+  })
+
+  it('shows Add Person and Add Organization buttons when people list is not empty', async () => {
+    store.state.stateModel.addPeopleAndRoleStep.orgPeople = getPersonList()
+    const wrapper = wrapperFactory()
+    expect(wrapper.find(btnAddPerson).exists()).toBeTruthy()
+    expect(wrapper.find(btnAddOrganization).exists()).toBeTruthy()
+    wrapper.destroy()
+  })
+
+  it('shows Add Completing Party button when people list is not empty and has no completing party', () => {
+    store.state.stateModel.addPeopleAndRoleStep.orgPeople = getPersonList([
+      { roleType: 'Partner', appointmentDate: '2020-03-30' }
+    ])
+    const wrapper = wrapperFactory()
+    expect(wrapper.find(btnAddCompletingParty).exists()).toBeTruthy()
+    wrapper.destroy()
+  })
+
+  it('does not show Add Completing Party Button when people list is not empty and has completing party', () => {
+    store.state.stateModel.addPeopleAndRoleStep.orgPeople = getPersonList()
+    const wrapper = wrapperFactory()
+    expect(wrapper.find(btnAddCompletingParty).exists()).toBeFalsy()
+    wrapper.destroy()
+  })
+
+  it('renders the add-edit component when add button is clicked', async () => {
+    store.state.stateModel.addPeopleAndRoleStep.orgPeople = getPersonList()
+    const wrapper = wrapperFactory()
+
+    // verify before click
+    expect(wrapper.find(RegAddEditOrgPerson).exists()).toBe(false)
+
+    // click the Add Person button
+    await wrapper.vm.$el.querySelector(btnAddPerson).click()
+
+    // NB: no dialog atm
+
+    // wait for everything to update
+    await flushPromises()
+
+    // verify after click
+    expect(wrapper.find(RegAddEditOrgPerson).exists()).toBe(true)
+
+    wrapper.destroy()
+  })
+
+  it('shows check mark next to roles added', () => {
+    store.state.stateModel.addPeopleAndRoleStep.orgPeople = [
+      { roles: [{ roleType: 'Completing Party' }] },
+      { roles: [{ roleType: 'Partner' }] },
+      { roles: [{ roleType: 'Partner' }] }
+    ]
+    const wrapper = wrapperFactory()
+    expect(wrapper.find(checkCompletingParty).exists()).toBeTruthy()
+    expect(wrapper.find(checkPartner).exists()).toBeTruthy()
     wrapper.destroy()
   })
 

--- a/tests/unit/RegPeopleAndRoles.spec.ts
+++ b/tests/unit/RegPeopleAndRoles.spec.ts
@@ -65,10 +65,11 @@ function getPersonList (roles = null): any {
   ]
 }
 
-describe('Registration People And Roles component', () => {
+describe('Registration People And Roles component - SP', () => {
   let wrapperFactory: any
 
   beforeEach(() => {
+    store.state.stateModel.entityType = 'SP'
     store.state.resourceModel = SoleProprietorshipResource
     wrapperFactory = () => mount(RegPeopleAndRoles, {
       store,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#10891

~This is ready to go except for some UI confirmations (or changes) from Yui.~ No changed needed atm.

*Description of changes:*
- display delivery address for partners in list
- updated org label, blurb and confirm text
- business number is only for proprietor
- added roles checkbox for partner
- prompt delivery address also for partners
- added rule for num partners
- added buttons for adding partners
- added role type and rule for partner
- updated misc logic, getters, etc
- added some classnames for testing
- updated unit tests
- app version = 3.5.13

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).