### PR TITLE
9828 Fix SP/GP Create UI - Step 1 - Business Type checkbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "3.5.18",
+  "version": "3.5.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "3.5.18",
+  "version": "3.5.19",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Registration/BusinessTypeConfirm.vue
+++ b/src/components/Registration/BusinessTypeConfirm.vue
@@ -122,10 +122,12 @@ export default class BusinessTypeConfirm extends Vue {
   font-weight: normal;
 }
 
+// Align the checkbox slot to the top left
 ::v-deep .v-input--checkbox .v-input__slot {
   align-items: flex-start;
 }
 
+// Align the checkbox icon with the left of the text (GP or SP)
 ::v-deep .v-input--checkbox .v-input__slot .v-input--selection-controls__input {
   margin-left: -3px;
 }

--- a/src/components/Registration/BusinessTypeConfirm.vue
+++ b/src/components/Registration/BusinessTypeConfirm.vue
@@ -1,6 +1,5 @@
 <template>
   <div id="business-type-confirm">
-    <div class="section-container">
       <v-row no-gutters>
         <v-col cols="12" sm="3" class="pr-4">
           <label class="d-block">Business Type</label>
@@ -30,7 +29,6 @@
           </div>
         </v-col>
       </v-row>
-    </div>
   </div>
 </template>
 

--- a/src/components/Registration/BusinessTypeConfirm.vue
+++ b/src/components/Registration/BusinessTypeConfirm.vue
@@ -1,32 +1,36 @@
 <template>
   <div id="business-type-confirm">
-    <v-row no-gutters>
-      <v-col cols="12" sm="3" class="pr-4">
-        <label class="d-block">Business Type</label>
-        <v-chip
-          v-if="hasBusinessTypeChecked"
-          id="checked-chip"
-          x-small label
-          color="primary"
-          text-color="white"
-        >
-          Checked
-        </v-chip>
-      </v-col>
-
-      <v-col cols="12" sm="9">
-        <p class="mb-0 checkbox-gp-text">{{ label }}</p>
-        <div id="business-check-div">
-          <v-checkbox
-            class="mt-0"
-            v-model="checked"
-            hide-details
-            :label="text"
+    <div class="section-container">
+      <v-row no-gutters>
+        <v-col cols="12" sm="3" class="pr-4">
+          <label class="d-block">Business Type</label>
+          <v-chip
+            v-if="hasBusinessTypeChecked"
+            id="checked-chip"
+            x-small label
+            color="primary"
+            text-color="white"
           >
-          </v-checkbox>
-        </div>
-      </v-col>
-    </v-row>
+            Checked
+          </v-chip>
+        </v-col>
+
+        <v-col cols="12" sm="9">
+          <p class="mb-0">{{ label }}</p>
+          <div id="business-checkbox-div">
+            <v-checkbox
+              hide-details
+              v-model="checked"
+              class="mt-0 pt-0"
+            >
+              <template slot="label">
+                <div class="certify-stmt" :class="{'error--text': showErrors}">{{ text }}</div>
+              </template>
+            </v-checkbox>
+          </div>
+        </v-col>
+      </v-row>
+    </div>
   </div>
 </template>
 
@@ -46,6 +50,10 @@ export default class BusinessTypeConfirm extends Vue {
   /** Whether the business typ is SP or GP */
   @Prop({ default: false })
   readonly isTypePartnership!: boolean;
+
+  /** Show error to trigger error-text class */
+  @Prop({ required: true })
+  readonly showErrors!: boolean
 
   // Local variables
   protected checked = false
@@ -73,13 +81,13 @@ export default class BusinessTypeConfirm extends Vue {
   @Watch('checked')
   private onValueChanged (): void {
     // update business type + validate
-    this.emitBusinessType()
+    this.emitBusinessTypeConfirm()
     this.emitValid()
   }
 
   /** Emits updated business type event. */
   @Emit('update:businessTypeConfirm')
-  private emitBusinessType (): boolean {
+  private emitBusinessTypeConfirm (): boolean {
     return this.checked
   }
 
@@ -105,21 +113,26 @@ export default class BusinessTypeConfirm extends Vue {
   }
 }
 
-#business-check-div {
-  display: flex;
+#business-checkbox-div {
   margin-top: 20px;
 }
 
-#business-check-div .mt-0 {
-  margin-left: -3px;
-  padding-top: 1px;
+.certify-stmt {
+  display: inline;
+  font-size: 0.875rem;
+  color: $gray7;
+  font-weight: normal;
 }
 
 ::v-deep .v-input--checkbox .v-input__slot {
   align-items: flex-start;
 }
 
-.invalid-section ::v-deep .v-input--checkbox .v-input__slot .v-label {
+::v-deep .v-input--checkbox .v-input__slot .v-input--selection-controls__input {
+  margin-left: -3px;
+}
+
+.invalid-section .certify-stmt {
   color: $app-red !important;
 }
 

--- a/src/views/Registration/RegistrationDefineBusiness.vue
+++ b/src/views/Registration/RegistrationDefineBusiness.vue
@@ -16,7 +16,7 @@
         <BusinessTypeConfirm
           class="py-8 px-6"
           :class="{ 'invalid-section': getShowErrors && !businessTypeConfirmValid }"
-          :showErrors="getShowErrors"
+          :showErrors="getShowErrors && !businessTypeConfirmValid"
           :businessTypeConfirm="getRegistration.businessTypeConfirm"
           :isTypePartnership="isTypePartnership"
           @update:businessTypeConfirm="setRegistrationBusinessTypeConfirm($event)"

--- a/src/views/Registration/RegistrationDefineBusiness.vue
+++ b/src/views/Registration/RegistrationDefineBusiness.vue
@@ -14,8 +14,8 @@
         <!-- Business Type -->
         <header id="business-type-confirm-header" />
         <BusinessTypeConfirm
-          class="py-8 px-6"
           :class="{ 'invalid-section': getShowErrors && !businessTypeConfirmValid }"
+          :showErrors="getShowErrors"
           :businessTypeConfirm="getRegistration.businessTypeConfirm"
           :isTypePartnership="isTypePartnership"
           @update:businessTypeConfirm="setRegistrationBusinessTypeConfirm($event)"

--- a/src/views/Registration/RegistrationDefineBusiness.vue
+++ b/src/views/Registration/RegistrationDefineBusiness.vue
@@ -14,6 +14,7 @@
         <!-- Business Type -->
         <header id="business-type-confirm-header" />
         <BusinessTypeConfirm
+          class="py-8 px-6"
           :class="{ 'invalid-section': getShowErrors && !businessTypeConfirmValid }"
           :showErrors="getShowErrors"
           :businessTypeConfirm="getRegistration.businessTypeConfirm"

--- a/tests/unit/BusinessTypeConfirm.spec.ts
+++ b/tests/unit/BusinessTypeConfirm.spec.ts
@@ -6,9 +6,6 @@ import { wrapperFactory } from '../jest-wrapper-factory'
 import BusinessTypeConfirm from '@/components/Registration/BusinessTypeConfirm.vue'
 
 const validEvent = 'valid'
-/**
- * @param BusinessTypeConfirm the value to pass to the component for the checkbox. The default value is "undefined". *
- */
 
 describe('Business Type Confirm component', () => {
   let wrapper: any

--- a/tests/unit/BusinessTypeConfirm.spec.ts
+++ b/tests/unit/BusinessTypeConfirm.spec.ts
@@ -1,0 +1,88 @@
+import Vue from 'vue'
+import flushPromises from 'flush-promises'
+import { Wrapper } from '@vue/test-utils'
+import { getLastEvent } from '../get-last-event'
+import { wrapperFactory } from '../jest-wrapper-factory'
+import BusinessTypeConfirm from '@/components/Registration/BusinessTypeConfirm.vue'
+
+const validEvent = 'valid'
+/**
+ * @param BusinessTypeConfirm the value to pass to the component for the checkbox. The default value is "undefined". *
+ */
+
+describe('Business Type Confirm component', () => {
+  let wrapper: any
+
+  it('works as expected when there initial business type confirm is false', async () => {
+    wrapper = wrapperFactory(
+      BusinessTypeConfirm,
+      { 
+        businessTypeConfirm: false,
+        showErrors: false,
+      }
+    )
+
+    await Vue.nextTick()
+
+    // verify no error message
+    // verify events to be false 
+    expect(wrapper.find('.certify-stmt.error--text').exists()).toBe(false)
+    expect(getLastEvent(wrapper, validEvent)).toBe(false)
+
+    wrapper.destroy()
+  })
+
+  it('works as expected when the business type checkbox is checked', async () => {
+    wrapper = wrapperFactory(
+      BusinessTypeConfirm,
+      { 
+        businessTypeConfirm: true,
+        showErrors: false,
+      }
+    )
+    await Vue.nextTick()
+
+    // verify no error message
+    // verify events to be true 
+    expect(wrapper.find('.certify-stmt.error--text').exists()).toBe(false)
+    expect(getLastEvent(wrapper, validEvent)).toBe(true)
+
+    // check the business type checkbox
+    // verify no error message 
+    // verify events
+    const checkboxElement: Wrapper<Vue> = wrapper.find('input[type=checkbox]')
+    checkboxElement.setChecked()
+    expect(wrapper.find('.certify-stmt.error--text').exists()).toBe(false)
+    expect(getLastEvent(wrapper, 'update:businessTypeConfirm')).toBe(true)
+    expect(getLastEvent(wrapper, validEvent)).toBe(true)
+
+    wrapper.destroy()
+  })
+
+  it('works as expected when the business type checkbox is not checked', async () => {
+    wrapper = wrapperFactory(
+      BusinessTypeConfirm,
+      { 
+        businessTypeConfirm: false,
+        showErrors: true,
+      }
+    )
+    await Vue.nextTick()
+
+    // verify error message
+    // verify events to be false 
+    expect(wrapper.find('.certify-stmt.error--text').exists()).toBe(true)
+    expect(getLastEvent(wrapper, validEvent)).toBe(false)
+
+    // the business type checkbox is not checked
+    // verify no error message 
+    // verify events
+    const checkboxElement: Wrapper<Vue> = wrapper.find('input[type=checkbox]')
+    checkboxElement.setChecked(false)
+    expect(wrapper.find('.certify-stmt.error--text').exists()).toBe(true)
+    expect(getLastEvent(wrapper, 'update:businessTypeConfirm')).toBe(undefined)
+    expect(getLastEvent(wrapper, validEvent)).toBe(false)
+
+    wrapper.destroy()
+  })
+})


### PR DESCRIPTION
Issue #: [/bcgov/entity#9828](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/bcgov/entity/9828)

*Description of changes:*

1. UXA notes from Yui
- Checkbox text in Step 1 needs size and line spacing adjustments. The referred "Certify" component is in Step 3.
- Spacing between the baseline of the last line of text to the thin grey line below is off by a couple of pixels. Use the Name Request Applicant subsection
2. Added BusinessTypeConfirm.spec.ts file for unit test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
