### PR TITLE
9014/11316 HTML tags show up in the warning popup window/Create UI - CP Dissolution - Update text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "3.5.21",
+  "version": "3.5.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "3.5.21",
+  "version": "3.5.22",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dissolution/CompleteAffidavit.vue
+++ b/src/components/Dissolution/CompleteAffidavit.vue
@@ -125,6 +125,11 @@
           </li>
           <li class="mt-1">
             <v-icon>mdi-circle-small</v-icon>
+            <span class="ml-2">Allow a minimum 1.5" margin at the top of the first page
+              (for BC Registries certified stamp)</span>
+          </li>
+          <li class="mt-1">
+            <v-icon>mdi-circle-small</v-icon>
             <span class="ml-2">Use a white background and a legible font with contrasting
               font colour</span>
           </li>

--- a/src/components/Dissolution/CompleteAffidavit.vue
+++ b/src/components/Dissolution/CompleteAffidavit.vue
@@ -120,8 +120,7 @@
         <ul class="mt-5">
           <li class="mt-1">
             <v-icon>mdi-circle-small</v-icon>
-            <span class="ml-2">Must be set to fit onto 8.5" x 11" letter-size paper
-            </span>
+            <span class="ml-2">Must be set to fit onto 8.5" x 11" letter-size paper</span>
           </li>
           <li class="mt-1">
             <v-icon>mdi-circle-small</v-icon>

--- a/src/components/Incorporation/UploadMemorandum.vue
+++ b/src/components/Incorporation/UploadMemorandum.vue
@@ -186,6 +186,11 @@
           </li>
           <li class="mt-1">
             <v-icon>mdi-circle-small</v-icon>
+            <span class="ml-2">Allow a minimum 1.5" margin at the top of the first page
+              (for BC Registries certified stamp)</span>
+          </li>
+          <li class="mt-1">
+            <v-icon>mdi-circle-small</v-icon>
             <span class="ml-2">Use a white background and a legible font with contrasting
               font colour</span>
           </li>

--- a/src/components/Incorporation/UploadRules.vue
+++ b/src/components/Incorporation/UploadRules.vue
@@ -146,6 +146,11 @@
           </li>
           <li class="mt-1">
             <v-icon>mdi-circle-small</v-icon>
+            <span class="ml-2">Allow a minimum 1.5" margin at the top of the first page
+              (for BC Registries certified stamp)</span>
+          </li>
+          <li class="mt-1">
+            <v-icon>mdi-circle-small</v-icon>
             <span class="ml-2">Use a white background and a legible font with contrasting
               font colour</span>
           </li>

--- a/src/dialogs/PaymentErrorDialog.vue
+++ b/src/dialogs/PaymentErrorDialog.vue
@@ -7,7 +7,7 @@
         <!-- display common message -->
         <div class="font-15" v-if="!isRoleStaff">
           <p>We are unable to process your payment at this time. This {{filingName}} has been saved
-            as a DRAFT and you can retry your payment from the Business Dashboard at a later time.</p>
+            as a DRAFT, you can retry your payment from your Business Registry dashboard at a later time.</p>
         </div>
 
         <!-- display generic message (no errors or warnings) -->

--- a/src/dialogs/PaymentErrorDialog.vue
+++ b/src/dialogs/PaymentErrorDialog.vue
@@ -28,11 +28,10 @@
         <!-- display errors -->
         <div class="font-15 mb-4" v-if="numErrors > 0">
           <p>We were unable to process your payment due to the following errors:</p>
-          <ul>
-            <li v-for="(error, index) in formatedError" :key="index">
-              <span v-html="error" id="formated-error-msg"></span>
-            </li>
-          </ul>
+          <div v-for="(error, index) in errors" :key="index" class="d-flex">
+            <span class="flex-shrink-0 bullet"><v-icon>mdi-circle-medium</v-icon></span>
+            <span class="flex-grow-1" v-html="error.message" />
+          </div>
         </div>
 
         <!-- display warnings-->
@@ -40,7 +39,7 @@
           <p>Please note the following warnings:</p>
           <ul>
             <li v-for="(warning, index) in warnings" :key="index">
-              {{warning.message}}
+              {{ warning.warning }}
             </li>
           </ul>
         </div>
@@ -103,21 +102,16 @@ export default class PaymentErrorDialog extends Vue {
   get numWarnings (): number {
     return this.warnings?.length || 0
   }
-
-  /** The formated error message */
-  protected formatedError = []
-  protected mounted (): void {
-    this.formatedError = this.errors.map((item:any) => (
-      item.message.split('<br/>').map((item2:string, index2:number) => {
-        return index2 === 0 ? item2 + '<br/>' : '<span>' + item2 + '</span><br/>'
-      }).join('')
-    ))
-  }
 }
 </script>
 
 <style scoped>
-  #formated-error-msg >>> span {
-    margin-left: 22px
+  .flex-shrink-0.bullet {
+    padding-left: 1.4px;
+    padding-right: 5px;
+  }
+
+  ::v-deep .v-icon {
+    font-size: 18px;
   }
 </style>

--- a/src/dialogs/PaymentErrorDialog.vue
+++ b/src/dialogs/PaymentErrorDialog.vue
@@ -62,7 +62,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue, Prop, Emit, Watch } from 'vue-property-decorator'
+import { Component, Vue, Prop, Emit } from 'vue-property-decorator'
 import { Getter } from 'vuex-class'
 import RegistriesContactInfo from '@/components/common/RegistriesContactInfo.vue'
 

--- a/src/dialogs/PaymentErrorDialog.vue
+++ b/src/dialogs/PaymentErrorDialog.vue
@@ -29,8 +29,8 @@
         <div class="font-15 mb-4" v-if="numErrors > 0">
           <p>We were unable to process your payment due to the following errors:</p>
           <div v-for="(error, index) in errors" :key="index" class="d-flex">
-            <span id="error-bullet" class="flex-shrink-0">
-              <v-icon id="error-circle">mdi-circle-medium</v-icon>
+            <span class="flex-shrink-0 error-bullet">
+              <v-icon class="error-circle">mdi-circle-medium</v-icon>
             </span>
             <span class="flex-grow-1" v-html="error.message" />
           </div>
@@ -108,12 +108,12 @@ export default class PaymentErrorDialog extends Vue {
 </script>
 
 <style scoped>
-  #error-bullet {
+  .error-bullet {
     padding-left: 1.4px;
     padding-right: 5px;
   }
 
-  #error-circle {
+  .error-circle {
     font-size: 18px;
   }
 </style>

--- a/src/dialogs/PaymentErrorDialog.vue
+++ b/src/dialogs/PaymentErrorDialog.vue
@@ -29,9 +29,7 @@
         <div class="font-15 mb-4" v-if="numErrors > 0">
           <p>We were unable to process your payment due to the following errors:</p>
           <div v-for="(error, index) in errors" :key="index" class="d-flex">
-            <span class="flex-shrink-0 error-bullet">
-              <v-icon class="error-circle">mdi-circle-medium</v-icon>
-            </span>
+            <span class="flex-shrink-0"><v-icon>mdi-circle-medium</v-icon></span>
             <span class="flex-grow-1" v-html="error.message" />
           </div>
         </div>
@@ -40,9 +38,7 @@
         <div class="font-15 mb-4" v-if="numWarnings > 0">
           <p>Please note the following warnings:</p>
           <div v-for="(warning, index) in warnings" :key="index" class="d-flex">
-            <span class="flex-shrink-0 error-bullet">
-              <v-icon class="error-circle">mdi-circle-medium</v-icon>
-            </span>
+            <span class="flex-shrink-0"><v-icon>mdi-circle-medium</v-icon></span>
             <span class="flex-grow-1" v-html="warning.message" />
           </div>
         </div>
@@ -107,14 +103,3 @@ export default class PaymentErrorDialog extends Vue {
   }
 }
 </script>
-
-<style scoped>
-  .error-bullet {
-    padding-left: 1.4px;
-    padding-right: 5px;
-  }
-
-  .error-circle {
-    font-size: 18px;
-  }
-</style>

--- a/src/dialogs/PaymentErrorDialog.vue
+++ b/src/dialogs/PaymentErrorDialog.vue
@@ -29,7 +29,9 @@
         <div class="font-15 mb-4" v-if="numErrors > 0">
           <p>We were unable to process your payment due to the following errors:</p>
           <div v-for="(error, index) in errors" :key="index" class="d-flex">
-            <span class="flex-shrink-0 bullet"><v-icon>mdi-circle-medium</v-icon></span>
+            <span id="error-bullet" class="flex-shrink-0">
+              <v-icon id="error-circle">mdi-circle-medium</v-icon>
+            </span>
             <span class="flex-grow-1" v-html="error.message" />
           </div>
         </div>
@@ -39,7 +41,7 @@
           <p>Please note the following warnings:</p>
           <ul>
             <li v-for="(warning, index) in warnings" :key="index">
-              {{ warning.warning }}
+              {{ warning.message }}
             </li>
           </ul>
         </div>
@@ -106,12 +108,12 @@ export default class PaymentErrorDialog extends Vue {
 </script>
 
 <style scoped>
-  .flex-shrink-0.bullet {
+  #error-bullet {
     padding-left: 1.4px;
     padding-right: 5px;
   }
 
-  ::v-deep .v-icon {
+  #error-circle {
     font-size: 18px;
   }
 </style>

--- a/src/dialogs/PaymentErrorDialog.vue
+++ b/src/dialogs/PaymentErrorDialog.vue
@@ -29,8 +29,8 @@
         <div class="font-15 mb-4" v-if="numErrors > 0">
           <p>We were unable to process your payment due to the following errors:</p>
           <ul>
-            <li v-for="(error, index) in errors[0].message.split('<br/>')" :key="index">
-              {{ error }}
+            <li v-for="(error, index) in formatedError" :key="index">
+              <span v-html="error" id="formated-error-msg"></span>
             </li>
           </ul>
         </div>
@@ -63,7 +63,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue, Prop, Emit } from 'vue-property-decorator'
+import { Component, Vue, Prop, Emit, Watch } from 'vue-property-decorator'
 import { Getter } from 'vuex-class'
 import RegistriesContactInfo from '@/components/common/RegistriesContactInfo.vue'
 
@@ -103,5 +103,21 @@ export default class PaymentErrorDialog extends Vue {
   get numWarnings (): number {
     return this.warnings?.length || 0
   }
+
+  /** The formated error message */
+  protected formatedError = []
+  protected mounted (): void {
+    this.formatedError = this.errors.map((item:any) => (
+      item.message.split('<br/>').map((item2:string, index2:number) => {
+        return index2 === 0 ? item2 + '<br/>' : '<span>' + item2 + '</span><br/>'
+      }).join('')
+    ))
+  }
 }
 </script>
+
+<style scoped>
+  #formated-error-msg >>> span {
+    margin-left: 22px
+  }
+</style>

--- a/src/dialogs/PaymentErrorDialog.vue
+++ b/src/dialogs/PaymentErrorDialog.vue
@@ -29,8 +29,8 @@
         <div class="font-15 mb-4" v-if="numErrors > 0">
           <p>We were unable to process your payment due to the following errors:</p>
           <ul>
-            <li v-for="(error, index) in errors" :key="index">
-              {{error.message}}
+            <li v-for="(error, index) in errors[0].message.split('<br/>')" :key="index">
+              {{ error }}
             </li>
           </ul>
         </div>

--- a/src/dialogs/PaymentErrorDialog.vue
+++ b/src/dialogs/PaymentErrorDialog.vue
@@ -39,11 +39,12 @@
         <!-- display warnings-->
         <div class="font-15 mb-4" v-if="numWarnings > 0">
           <p>Please note the following warnings:</p>
-          <ul>
-            <li v-for="(warning, index) in warnings" :key="index">
-              {{ warning.message }}
-            </li>
-          </ul>
+          <div v-for="(warning, index) in warnings" :key="index" class="d-flex">
+            <span class="flex-shrink-0 error-bullet">
+              <v-icon class="error-circle">mdi-circle-medium</v-icon>
+            </span>
+            <span class="flex-grow-1" v-html="warning.message" />
+          </div>
         </div>
 
         <template v-if="!isRoleStaff">

--- a/tests/unit/PaymentErrorDialog.spec.ts
+++ b/tests/unit/PaymentErrorDialog.spec.ts
@@ -107,6 +107,38 @@ describe('Payment Error Dialog', () => {
     )
     expect(wrapper.findAll('p').at(2).text()).toContain('If this error persists')
     expect(wrapper.findAll('li').length).toBe(0)
+    expect(wrapper.findAll('span').length).toBe(2)
+    expect(wrapper.findAll('span').at(1).text()).toContain('Your account is in the 3 day PAD confirmation period.')
+
+    expect(wrapper.find(RegistriesContactInfo).exists()).toBe(true)
+    expect(wrapper.find('#dialog-exit-button').exists()).toBe(true)
+
+    wrapper.destroy()
+  })
+
+  it('renders PAD warning messages correctly when they are present', () => {
+    store.state.stateModel.tombstone.authRoles = ['edit', 'view']
+    const wrapper = shallowMount(PaymentErrorDialog,
+      {
+        vuetify,
+        store,
+        propsData: { dialog: true, warnings: [
+          { warning: 'Test Warning 1' },
+          { warning: 'Test Warning 2' }
+        ]}
+      })
+
+    expect(wrapper.attributes('contentclass')).toBe('payment-error-dialog')
+    expect(wrapper.isVisible()).toBe(true)
+    expect(wrapper.find('#dialog-title').text()).toBe('Unable to Process Payment')
+    expect(wrapper.findAll('p').length).toBe(3)
+    expect(wrapper.findAll('p').at(0).text()).toContain('We are unable to process your payment')
+    expect(wrapper.findAll('p').at(1).text()).toContain('Please note the following warnings')
+    expect(wrapper.findAll('li').length).toBe(2)
+    expect(wrapper.findAll('li').at(0).text()).toBe('Test Warning 1')
+    expect(wrapper.findAll('li').at(1).text()).toBe('Test Warning 2')
+    expect(wrapper.find('#dialog-exit-button').exists()).toBe(true)
+    expect(wrapper.find('#dialog-okay-button').exists()).toBe(false)
 
     expect(wrapper.find(RegistriesContactInfo).exists()).toBe(true)
     expect(wrapper.find('#dialog-exit-button').exists()).toBe(true)

--- a/tests/unit/PaymentErrorDialog.spec.ts
+++ b/tests/unit/PaymentErrorDialog.spec.ts
@@ -123,8 +123,8 @@ describe('Payment Error Dialog', () => {
         vuetify,
         store,
         propsData: { dialog: true, warnings: [
-          { warning: 'Test Warning 1' },
-          { warning: 'Test Warning 2' }
+          { message: 'Test Warning 1' },
+          { message: 'Test Warning 2' }
         ]}
       })
 

--- a/tests/unit/PaymentErrorDialog.spec.ts
+++ b/tests/unit/PaymentErrorDialog.spec.ts
@@ -134,9 +134,12 @@ describe('Payment Error Dialog', () => {
     expect(wrapper.findAll('p').length).toBe(3)
     expect(wrapper.findAll('p').at(0).text()).toContain('We are unable to process your payment')
     expect(wrapper.findAll('p').at(1).text()).toContain('Please note the following warnings')
-    expect(wrapper.findAll('li').length).toBe(2)
-    expect(wrapper.findAll('li').at(0).text()).toBe('Test Warning 1')
-    expect(wrapper.findAll('li').at(1).text()).toBe('Test Warning 2')
+    
+    expect(wrapper.findAll('li').length).toBe(0)
+    expect(wrapper.findAll('span').length).toBe(4)
+    expect(wrapper.findAll('span').at(1).text()).toContain('Test Warning 1')
+    expect(wrapper.findAll('span').at(3).text()).toContain('Test Warning 2')
+
     expect(wrapper.find('#dialog-exit-button').exists()).toBe(true)
     expect(wrapper.find('#dialog-okay-button').exists()).toBe(false)
 

--- a/tests/unit/PaymentErrorDialog.spec.ts
+++ b/tests/unit/PaymentErrorDialog.spec.ts
@@ -106,8 +106,7 @@ describe('Payment Error Dialog', () => {
       'We were unable to process your payment due to the following errors:'
     )
     expect(wrapper.findAll('p').at(2).text()).toContain('If this error persists')
-    expect(wrapper.findAll('li').length).toBe(1)
-    expect(wrapper.findAll('li').at(0).text()).toContain(padError[0].message)
+    expect(wrapper.findAll('li').length).toBe(0)
 
     expect(wrapper.find(RegistriesContactInfo).exists()).toBe(true)
     expect(wrapper.find('#dialog-exit-button').exists()).toBe(true)


### PR DESCRIPTION
Issue #: [/bcgov/entity#9014](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/bcgov/entity/9014)

Description of changes:
When a payment error occurred, a popup window for "Unable to process payment" show up.
tags are included in the text in the popup window, and they need to be removed.
- [x] Create UI 


Issue #: [/bcgov/entity#11316](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/bcgov/entity/11316)

Description of changes:
Update help text for uploading mineo docs to advise people to leave a 1-inch margin at the top of their documents.
- [x] Voluntary dissolution, affidavit
- [x] Co-op incorp, memorandum
- [x] Co-op incorp, rules

Business Type Confirm is now saved to a draft filing in the client side
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).


