### PR TITLE
9735 SP/GP Create UI - Staff payment and update certify component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -202,7 +202,7 @@ import {
   getRegistryDashboardBreadcrumb,
   getSbcStaffDashboardBreadcrumb,
   getStaffDashboardBreadcrumb,
-  getStaffRegistryBreadcrumb,
+  getStaffMyRegistryBreadcrumb,
   IncorporationResources,
   RegistrationResources
 } from '@/resources'
@@ -321,7 +321,7 @@ export default class App extends Mixins(
       crumbs.unshift(getSbcStaffDashboardBreadcrumb())
     } else if (this.isRoleStaff) {
       // set StaffDashboard as Home crumb
-      crumbs.unshift(getStaffDashboardBreadcrumb(), getStaffRegistryBreadcrumb())
+      crumbs.unshift(getStaffDashboardBreadcrumb(), getStaffMyRegistryBreadcrumb())
     } else {
       // set Home and Dashboard crumbs
       crumbs.unshift(getRegistryDashboardBreadcrumb(), getMyBusinessRegistryBreadcrumb())

--- a/src/App.vue
+++ b/src/App.vue
@@ -202,7 +202,7 @@ import {
   getRegistryDashboardBreadcrumb,
   getSbcStaffDashboardBreadcrumb,
   getStaffDashboardBreadcrumb,
-  getStaffMyRegistryBreadcrumb,
+  getStaffMyBusinessRegistryBreadcrumb,
   IncorporationResources,
   RegistrationResources
 } from '@/resources'
@@ -321,7 +321,7 @@ export default class App extends Mixins(
       crumbs.unshift(getSbcStaffDashboardBreadcrumb())
     } else if (this.isRoleStaff) {
       // set StaffDashboard as Home crumb
-      crumbs.unshift(getStaffDashboardBreadcrumb(), getStaffMyRegistryBreadcrumb())
+      crumbs.unshift(getStaffDashboardBreadcrumb(), getStaffMyBusinessRegistryBreadcrumb())
     } else {
       // set Home and Dashboard crumbs
       crumbs.unshift(getRegistryDashboardBreadcrumb(), getMyBusinessRegistryBreadcrumb())

--- a/src/App.vue
+++ b/src/App.vue
@@ -202,6 +202,7 @@ import {
   getRegistryDashboardBreadcrumb,
   getSbcStaffDashboardBreadcrumb,
   getStaffDashboardBreadcrumb,
+  getStaffRegistryBreadcrumb,
   IncorporationResources,
   RegistrationResources
 } from '@/resources'
@@ -320,7 +321,7 @@ export default class App extends Mixins(
       crumbs.unshift(getSbcStaffDashboardBreadcrumb())
     } else if (this.isRoleStaff) {
       // set StaffDashboard as Home crumb
-      crumbs.unshift(getStaffDashboardBreadcrumb())
+      crumbs.unshift(getStaffDashboardBreadcrumb(), getStaffRegistryBreadcrumb())
     } else {
       // set Home and Dashboard crumbs
       crumbs.unshift(getRegistryDashboardBreadcrumb(), getMyBusinessRegistryBreadcrumb())

--- a/src/components/Registration/DefineRegistrationSummary.vue
+++ b/src/components/Registration/DefineRegistrationSummary.vue
@@ -85,7 +85,7 @@
       </template>
 
       <!-- Business Number -->
-      <template v-if="isTypePartnership">
+      <template>
         <v-divider class="mx-6" />
 
         <article class="section-container">
@@ -152,6 +152,7 @@ export default class DefineRegistrationSummary extends Mixins(DateMixin, EnumMix
 
   /** The business number. */
   get businessNumber (): string {
+    console.info('this.getRegistration: ', this.getRegistration)
     return this.getRegistration.businessNumber
   }
 

--- a/src/components/Registration/DefineRegistrationSummary.vue
+++ b/src/components/Registration/DefineRegistrationSummary.vue
@@ -85,20 +85,18 @@
       </template>
 
       <!-- Business Number -->
-      <template>
-        <v-divider class="mx-6" />
+      <v-divider class="mx-6" />
 
-        <article class="section-container">
-          <v-row no-gutters>
-            <v-col cols="12" sm="3" class="pr-4">
-              <label>Business Number</label>
-            </v-col>
-            <v-col cols="12" sm="9">
-              <span>{{ businessNumber || '(Not entered)' }}</span>
-            </v-col>
-          </v-row>
-        </article>
-      </template>
+      <article class="section-container">
+        <v-row no-gutters>
+          <v-col cols="12" sm="3" class="pr-4">
+            <label>Business Number</label>
+          </v-col>
+          <v-col cols="12" sm="9">
+            <span>{{ businessNumber || '(Not entered)' }}</span>
+          </v-col>
+        </v-row>
+      </article>
     </section>
   </div>
 </template>

--- a/src/components/Registration/DefineRegistrationSummary.vue
+++ b/src/components/Registration/DefineRegistrationSummary.vue
@@ -152,7 +152,6 @@ export default class DefineRegistrationSummary extends Mixins(DateMixin, EnumMix
 
   /** The business number. */
   get businessNumber (): string {
-    console.info('this.getRegistration: ', this.getRegistration)
     return this.getRegistration.businessNumber
   }
 

--- a/src/resources/BreadCrumbResource.ts
+++ b/src/resources/BreadCrumbResource.ts
@@ -66,3 +66,11 @@ export function getStaffDashboardBreadcrumb (): BreadcrumbIF {
     href: `${sessionStorage.getItem('BUSINESSES_URL')}staff/${getParams()}`
   }
 }
+
+export function getStaffRegistryBreadcrumb (): BreadcrumbIF {
+  const accountId = sessionStorage.getItem('ACCOUNT_ID')
+  return {
+    text: 'My Business Registry',
+    href: `${sessionStorage.getItem('BUSINESSES_URL')}account/${accountId}/business`
+  }
+}

--- a/src/resources/BreadCrumbResource.ts
+++ b/src/resources/BreadCrumbResource.ts
@@ -67,7 +67,7 @@ export function getStaffDashboardBreadcrumb (): BreadcrumbIF {
   }
 }
 
-export function getStaffMyRegistryBreadcrumb (): BreadcrumbIF {
+export function getStaffMyBusinessRegistryBreadcrumb (): BreadcrumbIF {
   const accountId = sessionStorage.getItem('ACCOUNT_ID')
   return {
     text: 'My Business Registry',

--- a/src/resources/BreadCrumbResource.ts
+++ b/src/resources/BreadCrumbResource.ts
@@ -67,7 +67,7 @@ export function getStaffDashboardBreadcrumb (): BreadcrumbIF {
   }
 }
 
-export function getStaffRegistryBreadcrumb (): BreadcrumbIF {
+export function getStaffMyRegistryBreadcrumb (): BreadcrumbIF {
   const accountId = sessionStorage.getItem('ACCOUNT_ID')
   return {
     text: 'My Business Registry',


### PR DESCRIPTION
Issue #: [/bcgov/entity#9735](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/bcgov/entity/9735)

*Description of changes:*
- ~insert staff payment component~ _already done_
- ~editable completing party in documents delivery~ _already done_
- ~update certify section to be third party, not the "I, ___ certify"~ _already done_
- [x] Added "My Business Registry" in the breadcrumb (with reference to [Invision](https://projects.invisionapp.com/share/3511UPXPMT2P#/screens/464799355))
- [x] Display Business Number for Sole Proprietors

Comment: Additional requirement to redirect "My Business Registry" to the list of businesses page with staff login.
Suggestion: new SBC AUTH ticket to work on the redirect url.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
