### PR TITLE
Bug: 12384

### DIFF
--- a/src/mixins/date-mixin.ts
+++ b/src/mixins/date-mixin.ts
@@ -46,10 +46,12 @@ export default class DateMixin extends Mixins(CommonMixin) {
   createUtcDate (year: number, month: number, day: number, hours: number = 0, minutes: number = 0): Date {
     // use date from server to create a new date in Pacific timezone
     // (this sets the correct tz offset in the new date)
-    const date = new Date(this.getCurrentJsDate.toLocaleString('en-US', { timeZone: 'America/Vancouver' }))
 
-    // update all date and time fields
-    date.setFullYear(year, month, day)
+    let date = new Date(Date.UTC(year, month, day, hours, minutes))
+    let utcDate = new Date(date.toLocaleString('en-US', { timeZone: 'UTC' }))
+    let tzDate = new Date(date.toLocaleString('en-US', { timeZone: 'America/vancouver' }))
+    let offset = utcDate.getTime() - tzDate.getTime()
+    date.setTime(date.getTime() + offset)
 
     return date
   }

--- a/src/mixins/date-mixin.ts
+++ b/src/mixins/date-mixin.ts
@@ -50,7 +50,6 @@ export default class DateMixin extends Mixins(CommonMixin) {
 
     // update all date and time fields
     date.setFullYear(year, month, day)
-    date.setHours(hours, minutes, 0, 0) // zero out seconds and milliseconds
 
     return date
   }

--- a/src/mixins/date-mixin.ts
+++ b/src/mixins/date-mixin.ts
@@ -1,5 +1,4 @@
 import { Component, Mixins } from 'vue-property-decorator'
-import { Getter } from 'vuex-class'
 import { isDate } from 'lodash'
 import { CommonMixin } from '@/mixins'
 
@@ -12,7 +11,6 @@ import { CommonMixin } from '@/mixins'
  */
 @Component({})
 export default class DateMixin extends Mixins(CommonMixin) {
-  @Getter getCurrentJsDate!: Date
 
   /**
    * Fetches and returns the web server's current date (in UTC).
@@ -44,8 +42,10 @@ export default class DateMixin extends Mixins(CommonMixin) {
    * @example "2021, 6, 1, 0, 0" -> "2021-07-01T07:00:00.000Z"
    */
   createUtcDate (year: number, month: number, day: number, hours: number = 0, minutes: number = 0): Date {
-    // use date from server to create a new date in Pacific timezone
-    // (this sets the correct tz offset in the new date)
+    /* We essentially add the difference in offset of UTC and Vancouver timezone
+       to the UTC date created from parameters.
+       SO: https://stackoverflow.com/questions/15141762/
+    */
 
     let date = new Date(Date.UTC(year, month, day, hours, minutes))
     let utcDate = new Date(date.toLocaleString('en-US', { timeZone: 'UTC' }))
@@ -53,8 +53,6 @@ export default class DateMixin extends Mixins(CommonMixin) {
     let offset = utcDate.getTime() - tzDate.getTime()
     date.setTime(date.getTime() + offset)
 
-    console.log(date.toISOString());
-    console.log(new Date(2021, 0, 1));
     return date
   }
 

--- a/src/mixins/date-mixin.ts
+++ b/src/mixins/date-mixin.ts
@@ -1,4 +1,5 @@
 import { Component, Mixins } from 'vue-property-decorator'
+import { Getter } from 'vuex-class'
 import { isDate } from 'lodash'
 import { CommonMixin } from '@/mixins'
 
@@ -11,6 +12,7 @@ import { CommonMixin } from '@/mixins'
  */
 @Component({})
 export default class DateMixin extends Mixins(CommonMixin) {
+  @Getter getCurrentJsDate!: Date
 
   /**
    * Fetches and returns the web server's current date (in UTC).

--- a/src/mixins/date-mixin.ts
+++ b/src/mixins/date-mixin.ts
@@ -53,6 +53,8 @@ export default class DateMixin extends Mixins(CommonMixin) {
     let offset = utcDate.getTime() - tzDate.getTime()
     date.setTime(date.getTime() + offset)
 
+    console.log(date.toISOString());
+    console.log(new Date(2021, 0, 1));
     return date
   }
 

--- a/tests/unit/date-mixin.spec.ts
+++ b/tests/unit/date-mixin.spec.ts
@@ -46,7 +46,7 @@ describe('Date Mixin', () => {
 
     expect(vm.yyyyMmDdToDate(null)).toBeNull()
     expect(vm.yyyyMmDdToDate('12345678901')).toBeNull()
-    expect(vm.yyyyMmDdToDate('2021-01-01')).toEqual(new Date(2021, 0, 1)) // PST
-    expect(vm.yyyyMmDdToDate('2021-07-01')).toEqual(new Date(2021, 6, 1)) // PDT
+    expect(vm.yyyyMmDdToDate('2021-01-01').toISOString()).toEqual('2021-01-01T08:00:00.000Z') // PST
+    expect(vm.yyyyMmDdToDate('2021-07-01').toISOString()).toEqual('2021-07-01T07:00:00.000Z') // PDT
   })
 })


### PR DESCRIPTION
*Issue #:* https://github.com/bcgov/entity/issues/12384

*Description of changes:*

Fixed the Date Mixin method that returned an invalid value if the user is not in Pacific timezone.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
