### PR TITLE
12529 Create UI: get account id from CURRENT_ACCOUNT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "4.0.16",
+  "version": "4.0.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "4.0.16",
+      "version": "4.0.17",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/bread-crumb": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "4.0.16",
+  "version": "4.0.17",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/resources/BreadCrumbResource.ts
+++ b/src/resources/BreadCrumbResource.ts
@@ -27,7 +27,7 @@ function getNumberedEntityName (): string {
 
 /** Returns URL param string with Account ID if present, else empty string. */
 function getParams (): string {
-  const accountId = sessionStorage.getItem('ACCOUNT_ID')
+  const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
   return accountId ? `?accountid=${accountId}` : ''
 }
 

--- a/src/services/business-lookup.services.ts
+++ b/src/services/business-lookup.services.ts
@@ -12,7 +12,7 @@ export default class BusinessLookupServices {
    */
   static async search (query: string): Promise<BusinessLookupResultIF[]> {
     const businessApiKey = sessionStorage.getItem('BUSINESS_API_KEY')
-    const accountId = sessionStorage.getItem('ACCOUNT_ID')
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id || null
     const legalType = 'BC' // Will be updating to a list once search api support it.
     let url = sessionStorage.getItem('REGISTRIES_SEARCH_API_URL')
     url = `${url}businesses/search/facets?num_of_rows=20&status=active&legalType=${legalType}`

--- a/src/utils/config-helper.ts
+++ b/src/utils/config-helper.ts
@@ -17,7 +17,7 @@ export async function fetchConfig (): Promise<any> {
   }
 
   // get and store account id, if present
-  const accountId = new URLSearchParams(windowLocationSearch).get('accountid')
+  const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
   if (accountId) {
     sessionStorage.setItem('ACCOUNT_ID', accountId)
     console.log('Set Account ID to: ' + accountId)

--- a/src/utils/config-helper.ts
+++ b/src/utils/config-helper.ts
@@ -15,13 +15,6 @@ export async function fetchConfig (): Promise<any> {
     return Promise.reject(new Error('Missing environment variables'))
   }
 
-  // get and store account id, if present
-  const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
-  if (accountId) {
-    sessionStorage.setItem('ACCOUNT_ID', accountId)
-    console.log('Set Account ID to: ' + accountId)
-  }
-
   // set Base URL for returning from redirects
   const baseUrl = `${origin}/${processEnvVueAppPath}/`
   sessionStorage.setItem('BASE_URL', baseUrl)

--- a/src/utils/config-helper.ts
+++ b/src/utils/config-helper.ts
@@ -10,7 +10,6 @@ export async function fetchConfig (): Promise<any> {
   const origin: string = window.location.origin
   const processEnvVueAppPath: string = process.env.VUE_APP_PATH
   const processEnvBaseUrl = process.env.BASE_URL
-  const windowLocationSearch = window.location.search // eg, ?accountid=2288
 
   if (!origin || !processEnvVueAppPath || !processEnvBaseUrl) {
     return Promise.reject(new Error('Missing environment variables'))

--- a/src/utils/navigate.ts
+++ b/src/utils/navigate.ts
@@ -5,7 +5,7 @@
 export function navigate (url: string): boolean {
   try {
     // get account id and set in params
-    const accountId = sessionStorage.getItem('ACCOUNT_ID')
+    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
     if (accountId) {
       if (url.includes('?')) {
         url += `&accountid=${accountId}`

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -628,7 +628,7 @@ describe('Incorporation - Define Company page for a BEN (named)', () => {
     expect(dialog.exists()).toBe(false)
 
     // verify redirection
-    const baseUrl = 'https://dashboard.url/T1234567'
+    const baseUrl = 'https://dashboard.url/T1234567?accountid=668'
     expect(window.location.assign).toHaveBeenCalledWith(baseUrl)
   })
 })


### PR DESCRIPTION
*Issue #:* [/bcgov/entity#12529](https://app.zenhub.com/workspaces/entities-team-space-6143567664fb320019b81f39/issues/bcgov/entity/12529)

*Description of changes:*
- get account id from CURRENT_ACCOUNT 
  - BreadCrumbResource.ts
  - business-lookup.services.ts
  - navigate.ts
- removed ACCOUNT_ID from config-helper.ts


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
