### PR TITLE
12759 Fix incorrect error for review and confirm step of dissolution filing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "4.0.22",
+  "version": "4.0.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "4.0.22",
+      "version": "4.0.23",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/bread-crumb": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "4.0.22",
+  "version": "4.0.23",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/Stepper.vue
+++ b/src/components/common/Stepper.vue
@@ -25,7 +25,8 @@
           <v-icon class="step__btn2" size="30" color="success darken-1" v-show="isValid(step.to)">
             mdi-check-circle
           </v-icon>
-          <v-icon class="step__btn2" size="30" color="error darken-1" v-show="!isValid(step.to) && getShowErrors">
+          <v-icon class="step__btn2" size="30" color="error darken-1"
+            v-show="!isValid(step.to) && getShowErrors && isReviewStepValid(step.to)">
             mdi-close-circle
           </v-icon>
         </div>
@@ -57,6 +58,7 @@ export default class Stepper extends Vue {
   @Getter getRegistration!: RegistrationStateIF
   @Getter getShowErrors!: boolean
   @Getter getSteps!: Array<any>
+  @Getter getValidateSteps!: boolean
   @Getter isAddPeopleAndRolesValid!: boolean
   @Getter isAffidavitValid!: boolean
   @Getter isBusySaving!: boolean
@@ -92,6 +94,14 @@ export default class Stepper extends Vue {
       case RouteNames.REGISTRATION_REVIEW_CONFIRM: return this.isRegistrationValid
     }
     return false
+  }
+
+  /** show error styling for reveiw-confirm step after file and pay is selected */
+  protected isReviewStepValid (route: RouteNames): boolean {
+    return (
+      route !== RouteNames.DISSOLUTION_REVIEW_CONFIRM ||
+      this.getValidateSteps
+    )
   }
 
   private goTo (step) {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#12759

*Description of changes:*
- Validation for error styling now excludes review and confirm step until after file and pay is clicked
- App version = 4.0.23


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
