### PR TITLE
UX Fixes on dissolution dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "4.1.5",
+      "version": "4.1.6",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/bread-crumb": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dissolution/AssociationDetails.vue
+++ b/src/components/Dissolution/AssociationDetails.vue
@@ -38,7 +38,7 @@
           <label class="delivery-address-header">Delivery Address</label>
           <DeliveryAddress
             v-if="!isEmptyAddress(getBusiness.officeAddress.deliveryAddress) &&
-             !isSame(getBusiness.officeAddress.mailingAddress, getBusiness.officeAddress.deliveryAddress)"
+             !isSame(getBusiness.officeAddress.mailingAddress, getBusiness.officeAddress.deliveryAddress, ['id'])"
             :address="getBusiness.officeAddress.deliveryAddress"
             :editing="false"
           />

--- a/src/views/DissolutionFirm/DissolutionFirm.vue
+++ b/src/views/DissolutionFirm/DissolutionFirm.vue
@@ -50,7 +50,7 @@
        <!-- EDIT SECTION -->
         <v-row no-gutters class="pb-0">
           <v-col cols="12" sm="3" class="pr-4">
-            <label class="start-date-title font-weight-bold">Dissolution Date</label>
+            <label class="start-date-title font-weight-bold title-label">Dissolution Date</label>
           </v-col>
           <v-col cols="12" sm="9" class="pt-4 pt-sm-0" id="start-date-selector">
             <DatePickerShared
@@ -374,7 +374,9 @@ export default class DissolutionFirm extends Mixins(DateMixin, EnumMixin) {
 
   /** The minimum start date that can be entered (greater than registration date). */
   private get startDateMin (): Date {
-    return new Date(this.getBusinessFoundingDate)
+    const date = new Date(this.getBusinessFoundingDate)
+    date.setDate(date.getDate() + 1)
+    return date
   }
 
   /** Dissolution Error */
@@ -406,7 +408,7 @@ export default class DissolutionFirm extends Mixins(DateMixin, EnumMixin) {
       (v: string) => !!v || 'Dissolution date is required',
       (v: string) =>
         RuleHelpers.DateRuleHelpers
-          .isBetweenDates(this.startDateMin,
+          .isBetweenDates(new Date(this.getBusinessFoundingDate),
             this.startDateMax,
             v) ||
         `Dissolution Date must be after ${this.dateToPacificDate(this.startDateMin, true)} and up to

--- a/src/views/DissolutionFirm/DissolutionFirm.vue
+++ b/src/views/DissolutionFirm/DissolutionFirm.vue
@@ -374,7 +374,7 @@ export default class DissolutionFirm extends Mixins(DateMixin, EnumMixin) {
 
   /** The minimum start date that can be entered (greater than registration date). */
   private get startDateMin (): Date {
-    const date = new Date(this.getBusinessFoundingDate)
+    const date = this.apiToDate(this.getBusinessFoundingDate)
     date.setDate(date.getDate() + 1)
     return date
   }
@@ -408,7 +408,7 @@ export default class DissolutionFirm extends Mixins(DateMixin, EnumMixin) {
       (v: string) => !!v || 'Dissolution date is required',
       (v: string) =>
         RuleHelpers.DateRuleHelpers
-          .isBetweenDates(new Date(this.getBusinessFoundingDate),
+          .isBetweenDates(this.apiToDate(this.getBusinessFoundingDate),
             this.startDateMax,
             v) ||
         `Dissolution Date must be after ${this.dateToPacificDate(this.startDateMin, true)} and up to

--- a/tests/unit/DissolutionFirm.spec.ts
+++ b/tests/unit/DissolutionFirm.spec.ts
@@ -5,6 +5,7 @@ import DissolutionFirm from '@/views/DissolutionFirm/DissolutionFirm.vue'
 import { DissolutionResources } from '@/resources/'
 
 const store = getVuexStore()
+store.state.stateModel.business.foundingDate = '2022-06-07T00:00:00.000+00:00'
 
 // Test Case Data
 // GP will come soon
@@ -35,7 +36,6 @@ for (const test of dissolutionFirmTestCases) {
         { entityType: test.entityType },
         null,
         DissolutionResources
-
       )
 
       // verify page content


### PR DESCRIPTION
*Issue #:* /bcgov/entity#12629

*Description of changes:*
* fix date picker - first date available to pick is one day after the business founding date
* display text "Same as Mailing address" if Mailing address and Delivery address match in "Business Addresses" section
* fix dissolution date header - make the label turn red upon error validation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
