### PR TITLE
13372 Create UI: Review and Confirm step icon should not show error until there is error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "4.1.12",
+      "version": "4.1.13",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/bread-crumb": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/Actions.vue
+++ b/src/components/common/Actions.vue
@@ -117,6 +117,7 @@ export default class Actions extends Mixins(DateMixin, FilingTemplateMixin, Name
   @Getter isSaving!: boolean
   @Getter isSavingResuming!: boolean
   @Getter isFilingPaying!: boolean
+  @Getter isFinalRegistrationValid!: boolean
 
   @Action setIsSaving!: ActionBindingIF
   @Action setIsSavingResuming!: ActionBindingIF
@@ -124,6 +125,7 @@ export default class Actions extends Mixins(DateMixin, FilingTemplateMixin, Name
   @Action setHaveChanges!: ActionBindingIF
   @Action setEffectiveDateTimeValid!: ActionBindingIF
   @Action setValidateSteps!: ActionBindingIF
+  @Action setClickFileAndPay!: ActionBindingIF
 
   /** Is True if Jest is running the code. */
   get isJestRunning (): boolean {
@@ -206,6 +208,12 @@ export default class Actions extends Mixins(DateMixin, FilingTemplateMixin, Name
    * @returns a promise (ie, this is an async method)
    */
   private async onClickFilePay (): Promise<void> {
+    // Set the status of clickFileAndPay for registration
+    if (this.isTypeFirm) {
+      this.setClickFileAndPay(true)
+      if (!this.isFinalRegistrationValid) return
+    }
+
     // Prompt Step validations
     this.setValidateSteps(true)
 

--- a/src/components/common/Actions.vue
+++ b/src/components/common/Actions.vue
@@ -209,10 +209,7 @@ export default class Actions extends Mixins(DateMixin, FilingTemplateMixin, Name
    */
   private async onClickFilePay (): Promise<void> {
     // Set the status of clickFileAndPay for registration
-    if (this.isTypeFirm) {
-      this.setClickFileAndPay(true)
-      if (!this.isFinalRegistrationValid) return
-    }
+    if (this.isTypeFirm) this.setClickFileAndPay(true)
 
     // Prompt Step validations
     this.setValidateSteps(true)

--- a/src/components/common/Stepper.vue
+++ b/src/components/common/Stepper.vue
@@ -69,7 +69,10 @@ export default class Stepper extends Vue {
   @Getter isIncorporationAgreementValid!: boolean
   @Getter isIncorporationApplicationValid!: boolean
   @Getter isMemorandumValid!: boolean
-  @Getter isRegistrationValid!: boolean
+  @Getter isPartialRegistrationValid!: boolean
+  @Getter isFinalRegistrationValid!: boolean
+  @Getter getClickFileAndPay!: boolean
+  @Getter isTypeFirm!: boolean
   @Getter isResolutionValid!: boolean
   @Getter isRulesValid!: boolean
 
@@ -91,9 +94,18 @@ export default class Stepper extends Vue {
 
       case RouteNames.REGISTRATION_DEFINE_BUSINESS: return this.getRegistration.defineBusinessValid
       case RouteNames.REGISTRATION_PEOPLE_ROLES: return this.isAddPeopleAndRolesValid
-      case RouteNames.REGISTRATION_REVIEW_CONFIRM: return this.isRegistrationValid
+      case RouteNames.REGISTRATION_REVIEW_CONFIRM: return this.isRegistrationValid()
     }
     return false
+  }
+
+  private isRegistrationValid (): boolean {
+    if (this.isTypeFirm) {
+      if (!this.isPartialRegistrationValid) return false
+      if (!this.getClickFileAndPay) return this.isPartialRegistrationValid
+      return this.isFinalRegistrationValid
+    }
+    return this.isFinalRegistrationValid
   }
 
   /** show error styling for reveiw-confirm step after file and pay is selected */

--- a/src/components/common/Stepper.vue
+++ b/src/components/common/Stepper.vue
@@ -22,7 +22,8 @@
           >
             <v-icon class="step__icon" :class="{ 'selected-icon': isCurrentStep(step) }">{{ step.icon }}</v-icon>
           </v-btn>
-          <v-icon class="step__btn2" size="30" color="success darken-1" v-show="isValid(step.to)">
+          <v-icon class="step__btn2" size="30" color="success darken-1" v-show="isValid(step.to)
+            && isFirmReviewValid(step.to)">
             mdi-check-circle
           </v-icon>
           <v-icon class="step__btn2" size="30" color="error darken-1"
@@ -99,6 +100,8 @@ export default class Stepper extends Vue {
     return false
   }
 
+  /** Check for define and people components are valid first
+  * Check for review component when the FileAndPay button is clicked */
   private isRegistrationValid (): boolean {
     if (this.isTypeFirm) {
       if (!this.isPartialRegistrationValid) return false
@@ -106,6 +109,12 @@ export default class Stepper extends Vue {
       return this.isFinalRegistrationValid
     }
     return this.isFinalRegistrationValid
+  }
+
+  /** show error styling for registration review-confirm step after file and pay is selected */
+  private isFirmReviewValid (route: RouteNames): boolean {
+    const thisRoute = route === RouteNames.REGISTRATION_REVIEW_CONFIRM
+    return thisRoute ? this.getClickFileAndPay : !thisRoute
   }
 
   /** show error styling for reveiw-confirm step after file and pay is selected */

--- a/src/interfaces/resource-interfaces/resource-interface.ts
+++ b/src/interfaces/resource-interfaces/resource-interface.ts
@@ -51,7 +51,8 @@ export interface RegistrationResourceIF {
       certifyClause: string
       entityDisplay: string
     }
-  }
+  },
+  clickFileAndPay: boolean
 }
 
 // Interface to define the resource model

--- a/src/resources/Registrations/generalPartnership.ts
+++ b/src/resources/Registrations/generalPartnership.ts
@@ -39,5 +39,6 @@ export const GeneralPartnershipResource: RegistrationResourceIF = {
         'offence is subject to a maximum fine of $5,000.',
       entityDisplay: GetCorpFullDescription(CorpTypeCd.PARTNERSHIP)
     }
-  }
+  },
+  clickFileAndPay: false
 }

--- a/src/resources/Registrations/soleProprietorship.ts
+++ b/src/resources/Registrations/soleProprietorship.ts
@@ -52,5 +52,6 @@ export const SoleProprietorshipResource: RegistrationResourceIF = {
         'offence is subject to a maximum fine of $5,000.',
       entityDisplay: GetCorpFullDescription(CorpTypeCd.SOLE_PROP)
     }
-  }
+  },
+  clickFileAndPay: false
 }

--- a/src/store/actions/actions-model.ts
+++ b/src/store/actions/actions-model.ts
@@ -375,3 +375,7 @@ export const setLastDirectorChangeDate: ActionIF = ({ commit }, date: string): v
 export const setWarnings : ActionIF = ({ commit }, businessWarnings: Array<BusinessWarningIF>): void => {
   commit('mutateBusinessWarnings', businessWarnings)
 }
+
+export const setClickFileAndPay: ActionIF = ({ commit }, clickFileAndPay: boolean): void => {
+  commit('mutateClickFileAndPay', clickFileAndPay)
+}

--- a/src/store/getters/resource-getters.ts
+++ b/src/store/getters/resource-getters.ts
@@ -107,3 +107,8 @@ export const getCustodialRecordsResources = (state: StateIF): CustodianResourceI
 export const getAffidavitResources = (state: StateIF): AffidavitResourceIF => {
   return state.resourceModel.affidavit
 }
+
+/** The state of the File and Pay button is clicked */
+export const getClickFileAndPay = (state: StateIF): boolean => {
+  return state.resourceModel.clickFileAndPay
+}

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -458,7 +458,7 @@ export const isIncorporationAgreementValid = (state: StateIF): boolean => {
 export const isApplicationValid = (state: StateIF): boolean => {
   if (isIncorporationFiling(state)) return isIncorporationApplicationValid(state)
   if (isDissolutionFiling(state)) return isDissolutionValid(state)
-  if (isRegistrationFiling(state)) return isPartialRegistrationValid(state)
+  if (isRegistrationFiling(state)) return isFinalRegistrationValid(state)
   return false
 }
 

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -40,6 +40,7 @@ import {
   CompletingPartyIF,
   PartyIF
 } from '@/interfaces'
+import { stateModel } from '../state'
 import { getMaxStep } from './resource-getters'
 
 /** Whether the current filing is an Incorporation. */
@@ -457,7 +458,7 @@ export const isIncorporationAgreementValid = (state: StateIF): boolean => {
 export const isApplicationValid = (state: StateIF): boolean => {
   if (isIncorporationFiling(state)) return isIncorporationApplicationValid(state)
   if (isDissolutionFiling(state)) return isDissolutionValid(state)
-  if (isRegistrationFiling(state)) return isRegistrationValid(state)
+  if (isRegistrationFiling(state)) return isPartialRegistrationValid(state)
   return false
 }
 
@@ -533,8 +534,16 @@ export const isIncorporationApplicationValid = (state: StateIF): boolean => {
   )
 }
 
+/** Whether the partial registration steps are valid. */
+export const isPartialRegistrationValid = (state: StateIF): boolean => {
+  return (
+    getRegistration(state).defineBusinessValid &&
+    isAddPeopleAndRolesValid(state)
+  )
+}
+
 /** Whether all the registration steps are valid. */
-export const isRegistrationValid = (state: StateIF): boolean => {
+export const isFinalRegistrationValid = (state: StateIF): boolean => {
   const isCertifyValid = getCertifyState(state).valid && !!getCertifyState(state).certifiedBy
   // const isFeeAcknowledgementValid = getRegistration(state).feeAcknowledgement
   const isFeeAcknowledgementValid = true // FUTURE: use line above instead

--- a/src/store/mutations/mutations-model.ts
+++ b/src/store/mutations/mutations-model.ts
@@ -419,3 +419,7 @@ export const mutateBusinessWarnings = (state: StateIF, businessWarnings: Array<B
 export const mutateGoodStanding = (state: StateIF, goodStanding: boolean) => {
   state.stateModel.business.goodStanding = goodStanding
 }
+
+export const mutateClickFileAndPay = (state: StateIF, clickFileAndPay: boolean): void => {
+  state.resourceModel.clickFileAndPay = clickFileAndPay
+}

--- a/src/store/state/resource-model.ts
+++ b/src/store/state/resource-model.ts
@@ -45,7 +45,8 @@ const registrationResourceModel: any = {
       certifyClause: null,
       entityDisplay: null
     }
-  }
+  },
+  clickFileAndPay: false
 }
 
 const dissolutionResourceModel: DissolutionResourceIF = {

--- a/tests/unit/Stepper.spec.ts
+++ b/tests/unit/Stepper.spec.ts
@@ -26,4 +26,76 @@ describe('Stepper component', () => {
   it('renders the component properly', () => {
     expect(wrapper.find('#step-buttons-container').exists()).toBe(true)
   })
+
+  it('renders valid registration components', () => {
+    store.state.resourceModel.steps = [
+      {
+        id: 'step-1-btn',
+        step: 1,
+        icon: 'mdi-domain',
+        text: 'Define Your \nBusiness',
+        to: 'registration-define-business',
+        component: 'registration-define-business'
+      },
+      {
+        id: 'step-2-btn',
+        step: 2,
+        icon: 'mdi-account-multiple-plus',
+        text: 'Add People \nand Roles',
+        to: 'registration-people-roles',
+        component: 'registration-people-roles'
+      },
+      {
+        id: 'step-3-btn',
+        step: 3,
+        icon: 'mdi-text-box-check-outline',
+        text: 'Review\nand Confirm',
+        to: 'registration-review-confirm',
+        component: 'registration-review-confirm'
+      }
+    ]
+    wrapper = shallowMount(Stepper, { store, vuetify, router })
+    const indicators = wrapper.findAll('#step-buttons-container .step__indicator')
+    expect(indicators.length).toBe(3)
+
+    const icons = wrapper.findAll('#step-buttons-container .step__indicator .step__icon')
+    expect(icons.length).toBe(3)
+    expect(icons.at(0).text()).toBe('mdi-domain')
+    expect(icons.at(1).text()).toBe('mdi-account-multiple-plus')
+    expect(icons.at(2).text()).toBe('mdi-text-box-check-outline')
+
+    const labels = wrapper.findAll('#step-buttons-container .step__label')
+    expect(labels.length).toBe(3)
+    expect(labels.at(0).text()).toBe('Define Your \nBusiness')
+    expect(labels.at(1).text()).toBe('Add People \nand Roles')
+    expect(labels.at(2).text()).toBe('Review\nand Confirm')
+  })
+
+  it('check the status of the method isRegistrationValid', () => {
+    // check isRegistrationValid is false given two conditions
+    // set either defineBusinessValid or addPeopleAndRoleStep.valid to false
+    store.state.stateModel.registration.defineBusinessValid = true
+    store.state.stateModel.addPeopleAndRoleStep.valid = false
+    store.state.stateModel.entityType = 'SP'
+    store.state.stateModel.entityType = 'GP'
+    store.state.resourceModel.clickFileAndPay = false
+    expect(wrapper.vm.isRegistrationValid()).toBe(false)
+
+    // check isRegistrationValid is true if clickFileAndPay is false
+    store.state.stateModel.addPeopleAndRoleStep.valid = true
+    expect(wrapper.vm.isRegistrationValid()).toBe(true)
+
+    // check isRegistrationValid is false if isFinalRegistrationValid is false
+    store.state.resourceModel.clickFileAndPay = true
+    expect(wrapper.vm.isRegistrationValid()).toBe(false)
+
+    // check isRegistrationValid is true if isFinalRegistrationValid is true
+    store.state.stateModel.certifyState = {
+      valid: true,
+      certifiedBy: 'Aliprand Saar'
+    }
+    store.state.stateModel.tombstone.authRoles = ['staff']
+    store.state.stateModel.staffPaymentStep.valid = true
+    expect(wrapper.vm.isRegistrationValid()).toBe(true)
+  })
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13372
*Issue #:* /bcgov/entity#13371

*Description of changes:*
- [x] The extension field should keep its dotted line until the user enters a value in that field.
- [x] The Review and Confirm icon should show neutral icon until the user presses File and Pay without having satisfied all required fields on that step.
- [x] Test NR number: NR 1030445
- [x] unit tests added

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
