### PR TITLE
13372 Create UI: Review and Confirm step icon should not show error until there is error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "4.1.12",
+      "version": "4.1.13",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/bread-crumb": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/Stepper.vue
+++ b/src/components/common/Stepper.vue
@@ -26,7 +26,7 @@
             mdi-check-circle
           </v-icon>
           <v-icon class="step__btn2" size="30" color="error darken-1"
-            v-show="!isValid(step.to) && getShowErrors && isReviewStepValid(step.to)">
+            v-show="!isValid(step.to) && getShowErrors && isReviewStepValid(step.to) && getValidateSteps">
             mdi-close-circle
           </v-icon>
         </div>

--- a/src/components/common/Stepper.vue
+++ b/src/components/common/Stepper.vue
@@ -26,7 +26,7 @@
             mdi-check-circle
           </v-icon>
           <v-icon class="step__btn2" size="30" color="error darken-1"
-            v-show="!isValid(step.to) && getShowErrors && isReviewStepValid(step.to) && getValidateSteps">
+            v-show="!isValid(step.to) && getShowErrors && getValidateSteps">
             mdi-close-circle
           </v-icon>
         </div>
@@ -94,14 +94,6 @@ export default class Stepper extends Vue {
       case RouteNames.REGISTRATION_REVIEW_CONFIRM: return this.isRegistrationValid
     }
     return false
-  }
-
-  /** show error styling for reveiw-confirm step after file and pay is selected */
-  protected isReviewStepValid (route: RouteNames): boolean {
-    return (
-      route !== RouteNames.DISSOLUTION_REVIEW_CONFIRM ||
-      this.getValidateSteps
-    )
   }
 
   private goTo (step) {

--- a/tests/unit/Stepper.spec.ts
+++ b/tests/unit/Stepper.spec.ts
@@ -16,6 +16,33 @@ describe('Stepper component', () => {
   let wrapper: any
 
   beforeEach(() => {
+    store.state.resourceModel.steps = [
+      {
+        id: 'step-1-btn',
+        step: 1,
+        icon: 'mdi-domain',
+        text: 'Define Your \nBusiness',
+        to: 'registration-define-business',
+        component: 'registration-define-business'
+      },
+      {
+        id: 'step-2-btn',
+        step: 2,
+        icon: 'mdi-account-multiple-plus',
+        text: 'Add People \nand Roles',
+        to: 'registration-people-roles',
+        component: 'registration-people-roles'
+      },
+      {
+        id: 'step-3-btn',
+        step: 3,
+        icon: 'mdi-text-box-check-outline',
+        text: 'Review\nand Confirm',
+        to: 'registration-review-confirm',
+        component: 'registration-review-confirm'
+      }
+    ]
+    store.state.stateModel.validateSteps = false
     wrapper = shallowMount(Stepper, { store, vuetify, router })
   })
 
@@ -25,5 +52,23 @@ describe('Stepper component', () => {
 
   it('renders the component properly', () => {
     expect(wrapper.find('#step-buttons-container').exists()).toBe(true)
+  })
+
+  it('renders the icons properly', () => {
+    wrapper = shallowMount(Stepper, { store, vuetify, router })
+    const indicators = wrapper.findAll('#step-buttons-container .step__indicator')
+    expect(indicators.length).toBe(3)
+
+    const icons = wrapper.findAll('#step-buttons-container .step__indicator .step__icon')
+    expect(icons.length).toBe(3)
+    expect(icons.at(0).text()).toBe('mdi-domain')
+    expect(icons.at(1).text()).toBe('mdi-account-multiple-plus')
+    expect(icons.at(2).text()).toBe('mdi-text-box-check-outline')
+
+    const labels = wrapper.findAll('#step-buttons-container .step__label')
+    expect(labels.length).toBe(3)
+    expect(labels.at(0).text()).toBe('Define Your \nBusiness')
+    expect(labels.at(1).text()).toBe('Add People \nand Roles')
+    expect(labels.at(2).text()).toBe('Review\nand Confirm')
   })
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13372

*Description of changes:*
- added "getValidateSteps" to the red cross icon validator.
- added unit test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
