### PR TITLE
13371 Create UI: Phone extension visual should remain "optional" until value entered

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "4.1.13",
+  "version": "4.1.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "4.1.13",
+      "version": "4.1.14",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/bread-crumb": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "4.1.13",
+  "version": "4.1.14",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/BusinessContactInfo.vue
+++ b/src/components/common/BusinessContactInfo.vue
@@ -53,15 +53,13 @@
               id="txt-phone"
             />
           </v-col>
-          <v-col cols="6" sm="4" class="pl-2 pt-4 pt-sm-0 phone-ext"
-            :class="{'phone-ext-filled': contact.extension}">
+          <v-col cols="6" sm="4" class="pl-2 pt-4 pt-sm-0">
             <v-text-field
               filled
               label="Extension (Optional)"
               persistent-hint
               v-mask="'#####'"
               v-model="contact.extension"
-              :disabled="!contact.phone"
               id="txt-phone-extension"
             />
           </v-col>
@@ -187,19 +185,5 @@ export default class BusinessContactInfo extends Mixins(CommonMixin) {
 ::v-deep .v-label {
   font-weight: normal;
   color: $gray7;
-}
-
-// display the dotted line until extension is entered
-::v-deep .phone-ext .v-text-field > .v-input__control > .v-input__slot::before {
-  border-image: repeating-linear-gradient(
-    to right,
-    rgba(0, 0, 0, 0.38) 0px,
-    rgba(0, 0, 0, 0.38) 2px,
-    transparent 2px,
-    transparent 4px
-  ) 1 repeat;
-}
-::v-deep .phone-ext.phone-ext-filled .v-text-field > .v-input__control > .v-input__slot::before {
-  border-image: none;
 }
 </style>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13371

*Description of changes:*
- removed disabled for extension (updated requirement)
- reverted the code to before


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
