### PR TITLE
Feature 13412 - Allow Changing Completing Party in Registrations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "dependencies": {
         "@babel/compat-data": "^7.11.0",
         "@bcrs-shared-components/bread-crumb": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Registration/RegAddEditOrgPerson.vue
+++ b/src/components/Registration/RegAddEditOrgPerson.vue
@@ -64,7 +64,7 @@
                   label="First Name"
                   v-model.trim="orgPerson.officer.firstName"
                   :rules="enableRules ? Rules.FirstNameRules : []"
-                  :readonly="isCompletingParty && (!isRoleStaff || !isSbcStaff)"
+                  :readonly="isCompletingParty && !(isRoleStaff || isSbcStaff)"
                 />
                 <v-text-field
                   filled
@@ -72,7 +72,7 @@
                   label="Middle Name (Optional)"
                   v-model.trim="orgPerson.officer.middleName"
                   :rules="enableRules ? Rules.MiddleNameRules : []"
-                  :readonly="isCompletingParty && (!isRoleStaff || !isSbcStaff)"
+                  :readonly="isCompletingParty && !(isRoleStaff || isSbcStaff)"
                 />
                 <v-text-field
                   filled
@@ -80,7 +80,7 @@
                   label="Last Name"
                   v-model.trim="orgPerson.officer.lastName"
                   :rules="enableRules ? Rules.LastNameRules : []"
-                  :readonly="isCompletingParty && (!isRoleStaff || !isSbcStaff)"
+                  :readonly="isCompletingParty && !(isRoleStaff || isSbcStaff)"
                 />
               </div>
             </article>
@@ -228,7 +228,7 @@
                 label="Email Address"
                 v-model.trim="orgPerson.officer.email"
                 :rules="enableRules ? Rules.EmailRules : []"
-                :readonly="isCompletingParty && (!isRoleStaff || !isSbcStaff)"
+                :readonly="isCompletingParty && !(isRoleStaff || isSbcStaff)"
               />
             </article>
 

--- a/src/components/Registration/RegAddEditOrgPerson.vue
+++ b/src/components/Registration/RegAddEditOrgPerson.vue
@@ -64,7 +64,7 @@
                   label="First Name"
                   v-model.trim="orgPerson.officer.firstName"
                   :rules="enableRules ? Rules.FirstNameRules : []"
-                  :readonly="isCompletingParty && !isRoleStaff"
+                  :readonly="isCompletingParty && (!isRoleStaff || !isSbcStaff)"
                 />
                 <v-text-field
                   filled
@@ -72,7 +72,7 @@
                   label="Middle Name (Optional)"
                   v-model.trim="orgPerson.officer.middleName"
                   :rules="enableRules ? Rules.MiddleNameRules : []"
-                  :readonly="isCompletingParty && !isRoleStaff"
+                  :readonly="isCompletingParty && (!isRoleStaff || !isSbcStaff)"
                 />
                 <v-text-field
                   filled
@@ -80,7 +80,7 @@
                   label="Last Name"
                   v-model.trim="orgPerson.officer.lastName"
                   :rules="enableRules ? Rules.LastNameRules : []"
-                  :readonly="isCompletingParty && !isRoleStaff"
+                  :readonly="isCompletingParty && (!isRoleStaff || !isSbcStaff)"
                 />
               </div>
             </article>
@@ -228,7 +228,7 @@
                 label="Email Address"
                 v-model.trim="orgPerson.officer.email"
                 :rules="enableRules ? Rules.EmailRules : []"
-                :readonly="isCompletingParty && !isRoleStaff"
+                :readonly="isCompletingParty && (!isRoleStaff || !isSbcStaff)"
               />
             </article>
 
@@ -313,6 +313,7 @@ import HelpContactUs from '@/components/Registration/HelpContactUs.vue'
 import { AddEditOrgPersonMixin } from '@/mixins'
 import { Rules } from '@/rules'
 import { BusinessLookupServices } from '@/services/'
+import { isSbcStaff } from '@/store/getters'
 
 /** This is a sub-component of PeopleAndRoles. */
 @Component({

--- a/src/components/Registration/RegAddEditOrgPerson.vue
+++ b/src/components/Registration/RegAddEditOrgPerson.vue
@@ -313,7 +313,6 @@ import HelpContactUs from '@/components/Registration/HelpContactUs.vue'
 import { AddEditOrgPersonMixin } from '@/mixins'
 import { Rules } from '@/rules'
 import { BusinessLookupServices } from '@/services/'
-import { isSbcStaff } from '@/store/getters'
 
 /** This is a sub-component of PeopleAndRoles. */
 @Component({

--- a/src/components/Registration/RegPeopleAndRoles.vue
+++ b/src/components/Registration/RegPeopleAndRoles.vue
@@ -224,7 +224,7 @@ export default class RegPeopleAndRoles extends Mixins(PeopleRolesMixin) {
     this.currentOrgPerson.officer.partyType = partyType
 
     // pre-populate Completing Party's name, email address and mailing address only if the logged in user is not staff (registries or sbc)
-    if (roleType === RoleTypes.COMPLETING_PARTY && partyType === PartyTypes.PERSON && (!this.isRoleStaff || !this.isSbcStaff)) {
+    if (roleType === RoleTypes.COMPLETING_PARTY && partyType === PartyTypes.PERSON && !(this.isRoleStaff || this.isSbcStaff)) {
       this.currentOrgPerson.officer.firstName = this.getUserFirstName || ''
       this.currentOrgPerson.officer.lastName = this.getUserLastName || ''
       this.currentOrgPerson.officer.email = this.getTombstone.userEmail

--- a/src/components/Registration/RegPeopleAndRoles.vue
+++ b/src/components/Registration/RegPeopleAndRoles.vue
@@ -223,8 +223,8 @@ export default class RegPeopleAndRoles extends Mixins(PeopleRolesMixin) {
     // assign party type (org or person)
     this.currentOrgPerson.officer.partyType = partyType
 
-    // pre-populate Completing Party's name, email address and mailing address
-    if (roleType === RoleTypes.COMPLETING_PARTY && partyType === PartyTypes.PERSON) {
+    // pre-populate Completing Party's name, email address and mailing address only is the logged in user is not staff
+    if (roleType === RoleTypes.COMPLETING_PARTY && partyType === PartyTypes.PERSON && !this.isRoleStaff) {
       this.currentOrgPerson.officer.firstName = this.getUserFirstName || ''
       this.currentOrgPerson.officer.lastName = this.getUserLastName || ''
       this.currentOrgPerson.officer.email = this.getTombstone.userEmail

--- a/src/components/Registration/RegPeopleAndRoles.vue
+++ b/src/components/Registration/RegPeopleAndRoles.vue
@@ -223,7 +223,7 @@ export default class RegPeopleAndRoles extends Mixins(PeopleRolesMixin) {
     // assign party type (org or person)
     this.currentOrgPerson.officer.partyType = partyType
 
-    // pre-populate Completing Party's name, email address and mailing address only if the logged in user is not staff (registries or sbc)
+    // pre-populate Completing Party's name, email address and mailing address only if logged in user is not staff (registries or sbc)
     if (roleType === RoleTypes.COMPLETING_PARTY && partyType === PartyTypes.PERSON && !(this.isRoleStaff || this.isSbcStaff)) {
       this.currentOrgPerson.officer.firstName = this.getUserFirstName || ''
       this.currentOrgPerson.officer.lastName = this.getUserLastName || ''

--- a/src/components/Registration/RegPeopleAndRoles.vue
+++ b/src/components/Registration/RegPeopleAndRoles.vue
@@ -224,7 +224,7 @@ export default class RegPeopleAndRoles extends Mixins(PeopleRolesMixin) {
     this.currentOrgPerson.officer.partyType = partyType
 
     // pre-populate Completing Party's name, email address and mailing address only if the logged in user is not staff (registries or sbc)
-    if (roleType === RoleTypes.COMPLETING_PARTY && partyType === PartyTypes.PERSON && !this.isRoleStaff && !this.isSbcStaff) {
+    if (roleType === RoleTypes.COMPLETING_PARTY && partyType === PartyTypes.PERSON && (!this.isRoleStaff || !this.isSbcStaff)) {
       this.currentOrgPerson.officer.firstName = this.getUserFirstName || ''
       this.currentOrgPerson.officer.lastName = this.getUserLastName || ''
       this.currentOrgPerson.officer.email = this.getTombstone.userEmail

--- a/src/components/Registration/RegPeopleAndRoles.vue
+++ b/src/components/Registration/RegPeopleAndRoles.vue
@@ -223,8 +223,8 @@ export default class RegPeopleAndRoles extends Mixins(PeopleRolesMixin) {
     // assign party type (org or person)
     this.currentOrgPerson.officer.partyType = partyType
 
-    // pre-populate Completing Party's name, email address and mailing address only if the logged in user is not staff
-    if (roleType === RoleTypes.COMPLETING_PARTY && partyType === PartyTypes.PERSON && !this.isRoleStaff) {
+    // pre-populate Completing Party's name, email address and mailing address only if the logged in user is not staff (registries or sbc)
+    if (roleType === RoleTypes.COMPLETING_PARTY && partyType === PartyTypes.PERSON && !this.isRoleStaff && !this.isSbcStaff) {
       this.currentOrgPerson.officer.firstName = this.getUserFirstName || ''
       this.currentOrgPerson.officer.lastName = this.getUserLastName || ''
       this.currentOrgPerson.officer.email = this.getTombstone.userEmail

--- a/src/components/Registration/RegPeopleAndRoles.vue
+++ b/src/components/Registration/RegPeopleAndRoles.vue
@@ -223,7 +223,7 @@ export default class RegPeopleAndRoles extends Mixins(PeopleRolesMixin) {
     // assign party type (org or person)
     this.currentOrgPerson.officer.partyType = partyType
 
-    // pre-populate Completing Party's name, email address and mailing address only is the logged in user is not staff
+    // pre-populate Completing Party's name, email address and mailing address only if the logged in user is not staff
     if (roleType === RoleTypes.COMPLETING_PARTY && partyType === PartyTypes.PERSON && !this.isRoleStaff) {
       this.currentOrgPerson.officer.firstName = this.getUserFirstName || ''
       this.currentOrgPerson.officer.lastName = this.getUserLastName || ''

--- a/src/mixins/add-edit-org-person-mixin.ts
+++ b/src/mixins/add-edit-org-person-mixin.ts
@@ -39,6 +39,7 @@ export default class AddEditOrgPersonMixin extends Vue {
 
   @Getter getCurrentDate!: string
   @Getter isRoleStaff!: boolean
+  @Getter isSbcStaff!: boolean
   @Getter isTypeBcomp!: boolean
   @Getter isTypeCoop!: boolean
   @Getter isTypeSoleProp!: boolean

--- a/src/mixins/people-roles-mixin.ts
+++ b/src/mixins/people-roles-mixin.ts
@@ -25,6 +25,7 @@ export default class PeopleRolesMixin extends Vue {
   @Getter isTypeSoleProp!: boolean
   @Getter isTypePartnership!: boolean
   @Getter isRoleStaff!: boolean
+  @Getter isSbcStaff!: boolean
 
   @Action setOrgPersonList!: ActionBindingIF
   @Action setAddPeopleAndRoleStepValidity!: ActionBindingIF

--- a/src/mixins/people-roles-mixin.ts
+++ b/src/mixins/people-roles-mixin.ts
@@ -24,6 +24,7 @@ export default class PeopleRolesMixin extends Vue {
   @Getter getRegistration!: RegistrationStateIF
   @Getter isTypeSoleProp!: boolean
   @Getter isTypePartnership!: boolean
+  @Getter isRoleStaff!: boolean
 
   @Action setOrgPersonList!: ActionBindingIF
   @Action setAddPeopleAndRoleStepValidity!: ActionBindingIF


### PR DESCRIPTION
*Issue #:* /bcgov/entity/issues/13412

*Description of changes:*
We want to keep the orgperson detail emplty in case of registration by a staff. So that staff will manually have to fill the information on behalf of the customer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
