### PR TITLE
13896 Pages should gray out after clicking Save and Resume Later and File Now, to avoid multiple clicks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "4.3.3",
+      "version": "4.3.4",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/Actions.vue
+++ b/src/components/common/Actions.vue
@@ -197,7 +197,6 @@ export default class Actions extends Mixins(DateMixin, FilingTemplateMixin, Name
       return
     }
 
-    this.setIsSavingResuming(false)
     this.emitGoToDashboard()
   }
 
@@ -219,7 +218,6 @@ export default class Actions extends Mixins(DateMixin, FilingTemplateMixin, Name
         !this.isValidDateTime(this.getEffectiveDateTime.effectiveDate)
       ) {
         this.setEffectiveDateTimeValid(false)
-        this.setIsFilingPaying(false)
 
         // don't call window.scrollTo during Jest tests because jsdom doesn't implement it
         if (!this.isJestRunning) window.scrollTo({ top: 1250, behavior: 'smooth' })

--- a/src/components/common/Actions.vue
+++ b/src/components/common/Actions.vue
@@ -181,6 +181,8 @@ export default class Actions extends Mixins(DateMixin, FilingTemplateMixin, Name
   protected async onClickSaveResume (): Promise<void> {
     // prevent double saving
     if (this.isBusySaving) return
+    // If Save and Resume is successful setIsFilingPaying should't be reset to false,
+    // this prevent buttons from being re-enabled if the page is slow to redirect.
     this.setIsSavingResuming(true)
 
     try {
@@ -211,6 +213,8 @@ export default class Actions extends Mixins(DateMixin, FilingTemplateMixin, Name
     if (this.isApplicationValid) {
       // prevent double saving
       if (this.isBusySaving) return
+      // If File and Pay is successful setIsFilingPaying should't be reset to false,
+      // this prevent buttons from being re-enabled if the page is slow to redirect.
       this.setIsFilingPaying(true)
 
       if (

--- a/tests/unit/Actions.spec.ts
+++ b/tests/unit/Actions.spec.ts
@@ -406,6 +406,7 @@ describe('Actions component - Filing Functionality', () => {
     store.state.stateModel.effectiveDateTime.isFutureEffective = filing.header.isFutureEffective
     store.state.stateModel.incorporationAgreementStep.agreementType =
       filing.incorporationApplication.incorporationAgreement.agreementType
+    store.state.stateModel.isSavingResuming = false
 
     const localVue = createLocalVue()
     localVue.use(VueRouter)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13896

*Description of changes:*

Note to consistently see this error you have to set throttling in dev tools

 - Upon clicking Save and Resume and File Now removed setSaving to false because if the page is slow to redirect then the buttons become reenabled.
 - App version = 3.8.13 -> 3.8.14
 - Related PR [Edit UI](https://github.com/bcgov/business-edit-ui/pull/408)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
