### PR TITLE
14119 Revert first name and middle name max lengths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "4.3.4",
+      "version": "4.3.5",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -634,9 +634,6 @@ export default class App extends Mixins(
         console.log('Launch Darkly update error =', error) // eslint-disable-line no-console
       })
 
-      // set completing party before draft filing dissolution create
-      this.setCompletingParty(this.getCompletingParties())
-
       // fetch the draft filing and resources
       try {
         if (this.getBusinessId) {
@@ -669,6 +666,9 @@ export default class App extends Mixins(
         this.fetchErrorDialog = !this.isErrorDialog
         throw error // go to catch()
       }
+
+      // set completing party
+      this.setCompletingParty(this.getCompletingParties())
 
       // load parties only for SP/GP businesses
       if (this.isTypeFirm && this.getBusinessId) this.loadPartiesInformation()

--- a/src/components/Registration/RegPeopleAndRoles.vue
+++ b/src/components/Registration/RegPeopleAndRoles.vue
@@ -229,7 +229,7 @@ export default class RegPeopleAndRoles extends Mixins(PeopleRolesMixin) {
       this.isSbcStaff)) {
       this.currentOrgPerson.officer.firstName = this.getUserFirstName || ''
       this.currentOrgPerson.officer.lastName = this.getUserLastName || ''
-      this.currentOrgPerson.officer.email = this.getTombstone.userEmail
+      this.currentOrgPerson.officer.email = this.getUserEmail
       this.currentOrgPerson.mailingAddress = this.getUserAddress || { ...EmptyAddress }
     }
 

--- a/src/components/common/PeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles.vue
@@ -191,7 +191,7 @@ export default class PeopleAndRoles extends Mixins(PeopleRolesMixin) {
     if (roleType === RoleTypes.COMPLETING_PARTY && partyType === PartyTypes.PERSON) {
       this.currentOrgPerson.officer.firstName = this.getUserFirstName || ''
       this.currentOrgPerson.officer.lastName = this.getUserLastName || ''
-      this.currentOrgPerson.officer.email = this.getTombstone.userEmail
+      this.currentOrgPerson.officer.email = this.getUserEmail
       this.currentOrgPerson.mailingAddress = this.getUserAddress || { ...EmptyAddress }
     }
 

--- a/src/mixins/people-roles-mixin.ts
+++ b/src/mixins/people-roles-mixin.ts
@@ -20,7 +20,7 @@ export default class PeopleRolesMixin extends Vue {
   @Getter getShowErrors!: boolean
   @Getter getPeopleAndRolesResource!: PeopleAndRolesResourceIF
   @Getter getAddPeopleAndRoleStep!: PeopleAndRoleIF
-  @Getter getTombstone!: TombstoneIF
+  @Getter getUserEmail!: string
   @Getter getUserFirstName!: string
   @Getter getUserLastName!: string
   @Getter getUserAddress!: AddressIF

--- a/src/rules/first-name-rules.ts
+++ b/src/rules/first-name-rules.ts
@@ -2,5 +2,5 @@ import { VuetifyRuleFunction } from '@/types'
 
 export const FirstNameRules: Array<VuetifyRuleFunction> = [
   v => !!v?.trim() || 'First name is required',
-  v => (v?.length <= 20) || 'Cannot exceed 20 characters' // maximum character count
+  v => (v?.length <= 30) || 'Cannot exceed 30 characters' // maximum character count
 ]

--- a/src/rules/middle-name-rules.ts
+++ b/src/rules/middle-name-rules.ts
@@ -3,5 +3,5 @@ import { VuetifyRuleFunction } from '@/types'
 export const MiddleNameRules: Array<VuetifyRuleFunction> = [
   v => !/^\s/g.test(v) || 'Invalid spaces', // leading spaces
   v => !/\s$/g.test(v) || 'Invalid spaces', // trailing spaces
-  v => (!v || v.length <= 20) || 'Cannot exceed 20 characters' // maximum character count
+  v => (!v || v.length <= 30) || 'Cannot exceed 30 characters' // maximum character count
 ]

--- a/tests/unit/AddEditOrgPerson.spec.ts
+++ b/tests/unit/AddEditOrgPerson.spec.ts
@@ -319,8 +319,8 @@ describe('Add/Edit Org/Person component', () => {
 
     const messages = wrapper.findAll('.v-messages__message')
     expect(messages.length).toBe(3)
-    expect(messages.at(0).text()).toBe('Cannot exceed 20 characters')
-    expect(messages.at(1).text()).toBe('Cannot exceed 20 characters')
+    expect(messages.at(0).text()).toBe('Cannot exceed 30 characters')
+    expect(messages.at(1).text()).toBe('Cannot exceed 30 characters')
     expect(messages.at(2).text()).toBe('Cannot exceed 30 characters')
     expect(wrapper.vm.$data.addPersonOrgFormValid).toBe(false)
 


### PR DESCRIPTION
*Issue #:* bcgov/entity#14119

This PR reverts the following change: https://github.com/bcgov/business-create-ui/pull/429

*Description of changes:*

First commit:
- revert first name max length to 30
- revert middle name length to 30
- updated unit tests
- app version = 4.3.5

Second commit:
- bugfix: moved setCompletingParty after auth data is fetched (otherwise isRoleStaff is false)
- used direct getter for completing party's email

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).