### PR TITLE
13345 Fix name translation length + UI fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "4.3.10",
+  "version": "4.3.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "4.3.10",
+      "version": "4.3.11",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "4.3.10",
+  "version": "4.3.11",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Incorporation/ShareStructure.vue
+++ b/src/components/Incorporation/ShareStructure.vue
@@ -144,7 +144,7 @@
                   <v-btn large color="primary" class="form-primary-btn"
                     @click="validateForm()" :disabled="!formValid" id="btn-done">Done</v-btn>
 
-                  <v-btn large class="form-cancel-btn" @click="resetFormAndData(true)" id="btn-cancel">Cancel</v-btn>
+                  <v-btn large @click="resetFormAndData(true)" id="btn-cancel">Cancel</v-btn>
                 </div>
               </v-form>
             </div>

--- a/src/components/common/AddNameTranslation.vue
+++ b/src/components/common/AddNameTranslation.vue
@@ -1,40 +1,38 @@
 <template>
-  <div id="name-translation">
+  <div id="add-name-translation">
     <!-- Name Translation form -->
-    <v-form v-model="nameTranslationForm" class="name-translation-form">
-      <v-row>
-        <v-col class="pb-0">
-          <v-text-field
-            filled
-            persistent-hint
-            id="name-translation-input"
-            label="Enter Name Translation"
-            v-model="nameTranslation"
-            :rules="nameTranslationRules"
-          />
-        </v-col>
-      </v-row>
-      <v-row>
-        <v-col class="form__btns pt-0">
-          <v-btn large color="error" id="btn-remove"
-            :disabled="!editNameTranslation"
-            @click="removeTranslation()"
-          >
-            Remove
-          </v-btn>
-          <v-btn large color="primary" id="btn-done" class="form-primary-btn"
-            :disabled="!nameTranslationForm"
-            @click="addTranslation()"
-          >
-            Done
-          </v-btn>
-          <v-btn large id="btn-cancel" class="form-cancel-btn"
-            @click="cancelTranslation()"
-          >
-            Cancel
-          </v-btn>
-        </v-col>
-      </v-row>
+    <v-form v-model="nameTranslationForm">
+      <v-text-field
+        filled
+        persistent-hint
+        id="name-translation-input"
+        label="Enter Name Translation"
+        v-model="nameTranslation"
+        :rules="nameTranslationRules"
+      />
+
+      <div class="form__btns">
+        <v-btn large color="error" id="btn-remove"
+          :disabled="!editNameTranslation"
+          @click="removeTranslation()"
+        >
+          Remove
+        </v-btn>
+
+        <v-btn large color="primary" id="btn-done"
+          class="form-primary-btn"
+          :disabled="!nameTranslationForm"
+          @click="addTranslation()"
+        >
+          Done
+        </v-btn>
+
+        <v-btn large id="btn-cancel"
+          @click="cancelTranslation()"
+        >
+          Cancel
+        </v-btn>
+      </div>
     </v-form>
   </div>
 </template>
@@ -57,7 +55,7 @@ export default class AddNameTranslation extends Vue {
   readonly nameTranslationRules: Array<VuetifyRuleFunction> = [
     v => !!v || 'A name translation is required', // is not empty
     v => /^[A-Za-zÀ-ÿ_@./#’&+-]+(?: [A-Za-zÀ-ÿ_@./#’&+-]+)*$/.test(v) || 'Invalid character', // English, French and single spaces
-    v => (!v || v.length <= 150) || 'Cannot exceed 150 characters' // maximum character count
+    v => (!v || v.length <= 50) || 'Cannot exceed 50 characters' // maximum character count
   ]
 
   /** Called when component is mounted. */

--- a/src/components/common/ListNameTranslations.vue
+++ b/src/components/common/ListNameTranslations.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card flat id="name-translations-list">
+  <v-card flat id="list-name-translations">
     <!-- List Headers -->
     <v-row class="name-translation-title list-item__subtitle" no-gutters>
       <v-col>
@@ -19,7 +19,7 @@
       </v-col>
 
       <!-- Actions Column -->
-      <v-col>
+      <v-col class="col-auto">
         <div class="actions mt-n1 float-right">
           <span class="edit-action">
             <v-btn
@@ -27,7 +27,7 @@
               text
               color="primary"
               :disabled="isAddingNameTranslation"
-              @click="emitNameEdit(index)"
+              @click="editTranslation(index)"
             >
                 <v-icon small>mdi-pencil</v-icon>
                 <span>Edit</span>
@@ -49,7 +49,7 @@
                 </v-btn>
               </template>
               <v-list class="more-actions-list">
-                <v-list-item @click="emitRemoveName(index)">
+                <v-list-item @click="removeTranslation(index)">
                   <v-list-item-title>
                     <v-icon small color="primary">mdi-delete</v-icon>
                     <span class="ml-2">Remove</span>
@@ -81,17 +81,17 @@ export default class ListNameTranslations extends Vue {
    * Emit an index and event to the parent to handle editing.
    * @param index The active index which is subject to change.
    */
-  @Emit('editNameTranslation')
+  @Emit('editTranslation')
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  private emitNameEdit (index: number): void {}
+  protected editTranslation (index: number): void {}
 
   /**
    * Emit an index and event to the parent to handle removal.
    * @param index The active index which is subject to removal.
    */
-  @Emit('removeNameTranslation')
+  @Emit('removeTranslation')
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  private emitRemoveName (index: number): void {}
+  protected removeTranslation (index: number): void {}
 }
 </script>
 

--- a/src/components/common/NameRequestInfo.vue
+++ b/src/components/common/NameRequestInfo.vue
@@ -120,6 +120,7 @@
                 Names that use other writing systems must spell the name phonetically in English or
                 French.
               </p>
+
               <v-btn
                 outlined color="primary"
                 class="mt-6"
@@ -129,33 +130,29 @@
                 <v-icon>mdi-plus</v-icon>
                 <span>Add a Name Translation</span>
               </v-btn>
+
+              <!-- Add Name Translation component -->
+              <div v-if="isAddingNameTranslation" class="mt-6">
+                <AddNameTranslation
+                  :edit-name-translation="editingNameTranslation"
+                  @addTranslation="addNameTranslation($event)"
+                  @cancelTranslation="cancelNameTranslation()"
+                  @removeTranslation="removeNameTranslation(editIndex)"
+                />
+              </div>
+
+              <!-- List Name Translation component -->
+              <div v-if="getNameTranslations && getNameTranslations.length > 0" class="mt-6">
+                <ListNameTranslations
+                  :isAddingNameTranslation="isAddingNameTranslation"
+                  :translationsList="getNameTranslations"
+                  @editTranslation="editNameTranslation($event)"
+                  @removeTranslation="removeNameTranslation($event)"
+                />
+              </div>
             </template>
           </v-col>
         </v-row>
-
-        <!-- Name Translation Components -->
-        <template v-if="hasNameTranslation">
-          <v-row no-gutters id="name-translation-container" class="mt-6">
-            <v-col cols="12" sm="3" />
-
-            <v-col cols="12" sm="9">
-              <AddNameTranslation
-                v-if="isAddingNameTranslation"
-                :edit-name-translation="editingNameTranslation"
-                @addTranslation="addName($event)"
-                @cancelTranslation="cancelNameTranslation()"
-                @removeTranslation="removeNameTranslation(editIndex)"
-              />
-              <ListNameTranslations
-                v-if="getNameTranslations && getNameTranslations.length > 0"
-                :isAddingNameTranslation="isAddingNameTranslation"
-                :translationsList="getNameTranslations"
-                @editNameTranslation="editNameTranslation($event)"
-                @removeNameTranslation="removeNameTranslation($event)"
-              />
-            </v-col>
-          </v-row>
-        </template>
       </div>
     </template>
   </div>
@@ -307,7 +304,7 @@ export default class NameRequestInfo extends Mixins(DateMixin) {
    * Adds or updates a name translation.
    * @param name The name to add
    */
-  protected addName (name: string): void {
+  protected addNameTranslation (name: string): void {
     const nameTranslations = Object.assign([], this.getNameTranslations)
 
     // Handle name translation adds or updates

--- a/tests/unit/AddNameTranslation.spec.ts
+++ b/tests/unit/AddNameTranslation.spec.ts
@@ -3,7 +3,6 @@ import Vuelidate from 'vuelidate'
 import Vuetify from 'vuetify'
 import VueRouter from 'vue-router'
 import mockRouter from './MockRouter'
-import flushPromises from 'flush-promises'
 import { getVuexStore } from '@/store'
 import { createLocalVue, mount } from '@vue/test-utils'
 import AddNameTranslation from '@/components/common/AddNameTranslation.vue'
@@ -15,7 +14,7 @@ const vuetify = new Vuetify({})
 const store = getVuexStore()
 
 // Local references
-const addTranslationInput = '#name-translation-input'
+const nameTranslationInput = '#name-translation-input'
 const doneBtn = '#btn-done'
 const removeBtn = '#btn-remove'
 const cancelBtn = '#btn-cancel'
@@ -31,163 +30,190 @@ describe('Add Name Translation component', () => {
     // Init Store
     store.state.stateModel.nameTranslations = []
 
-    wrapperFactory = (propsData) => {
-      return mount(AddNameTranslation, {
+    wrapperFactory = async (propsData: any) => {
+      const wrapper = mount(AddNameTranslation, {
         localVue,
         router,
         store,
         vuetify,
         propsData: { ...propsData }
       })
+      await Vue.nextTick()
+      return wrapper
     }
   })
 
-  it('displays the input field and buttons in the Add Name Translation form', () => {
-    const wrapper = wrapperFactory()
+  it('displays the input field and buttons', async () => {
+    const wrapper = await wrapperFactory()
 
     // Verify input field
-    expect(wrapper.find(addTranslationInput).exists()).toBeTruthy()
+    expect(wrapper.find(nameTranslationInput).exists()).toBeTruthy()
 
-    // Verify Action btns and there default states
+    // Verify Action btns and their default states
     expect(wrapper.find(doneBtn).exists()).toBeTruthy()
-    expect(wrapper.find(doneBtn).attributes('disabled')).toBeTruthy()
+    expect(wrapper.find(doneBtn).attributes('disabled')).toBe('disabled')
 
     expect(wrapper.find(removeBtn).exists()).toBeTruthy()
-    expect(wrapper.find(removeBtn).attributes('disabled')).toBeTruthy()
+    expect(wrapper.find(removeBtn).attributes('disabled')).toBe('disabled')
 
     expect(wrapper.find(cancelBtn).exists()).toBeTruthy()
-    expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined() // enabled
 
     wrapper.destroy()
   })
 
-  it('enables the Done button when the input field meets validation rules', async () => {
-    const wrapper = wrapperFactory()
+  it('enables the Done button when the input is valid', async () => {
+    const wrapper = await wrapperFactory()
 
     // Verify input field
-    expect(wrapper.find(addTranslationInput).exists()).toBeTruthy()
+    expect(wrapper.find(nameTranslationInput).exists()).toBeTruthy()
 
-    // Set Input field values
-    wrapper.vm.$el.querySelector(addTranslationInput).textContent = 'Mock Name Translation'
-    wrapper.find(addTranslationInput).setValue('MockNameTranslation')
-    wrapper.find(addTranslationInput).trigger('change')
-    await flushPromises()
+    // Set Input field value
+    const validText = 'Valid Name Translation'
+    wrapper.vm.$el.querySelector(nameTranslationInput).textContent = validText
+    await wrapper.find(nameTranslationInput).setValue(validText)
+    await wrapper.find(nameTranslationInput).trigger('change')
 
-    wrapper.find(addTranslationInput).trigger('input')
-    expect(wrapper.find(addTranslationInput).text()).toEqual('Mock Name Translation')
+    expect(wrapper.find(nameTranslationInput).text()).toEqual(validText)
 
-    // Verify Action btns and there states
+    // Verify Action btns and their states
     expect(wrapper.find(doneBtn).exists()).toBeTruthy()
-    expect(wrapper.find(doneBtn).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(doneBtn).attributes('disabled')).toBeUndefined() // enabled
 
     expect(wrapper.find(removeBtn).exists()).toBeTruthy()
-    expect(wrapper.find(removeBtn).attributes('disabled')).toBeTruthy()
+    expect(wrapper.find(removeBtn).attributes('disabled')).toBe('disabled')
 
     expect(wrapper.find(cancelBtn).exists()).toBeTruthy()
-    expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined() // enabled
 
     wrapper.destroy()
   })
 
-  it('enables the Done button when the input field meets validation rules in French characters', async () => {
-    const wrapper = wrapperFactory()
+  it('enables the Done button when the input is valid - French characters', async () => {
+    const wrapper = await wrapperFactory()
 
     // Verify input field
-    expect(wrapper.find(addTranslationInput).exists()).toBeTruthy()
+    expect(wrapper.find(nameTranslationInput).exists()).toBeTruthy()
 
-    // Set Input field values
-    wrapper.vm.$el.querySelector(addTranslationInput).textContent = 'Nom commercial simulé'
-    wrapper.find(addTranslationInput).setValue('Nom commercial simulé')
-    wrapper.find(addTranslationInput).trigger('change')
-    await flushPromises()
+    // Set Input field value
+    const validText = 'Nom Commercial Simulé'
+    wrapper.vm.$el.querySelector(nameTranslationInput).textContent = validText
+    await wrapper.find(nameTranslationInput).setValue(validText)
+    await wrapper.find(nameTranslationInput).trigger('change')
 
-    wrapper.find(addTranslationInput).trigger('input')
-    expect(wrapper.find(addTranslationInput).text()).toEqual('Nom commercial simulé')
+    expect(wrapper.find(nameTranslationInput).text()).toEqual(validText)
 
-    // Verify Action btns and there states
+    // Verify Action btns and their states
     expect(wrapper.find(doneBtn).exists()).toBeTruthy()
-    expect(wrapper.find(doneBtn).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(doneBtn).attributes('disabled')).toBeUndefined() // enabled
 
     expect(wrapper.find(removeBtn).exists()).toBeTruthy()
-    expect(wrapper.find(removeBtn).attributes('disabled')).toBeTruthy()
+    expect(wrapper.find(removeBtn).attributes('disabled')).toBe('disabled')
 
     expect(wrapper.find(cancelBtn).exists()).toBeTruthy()
-    expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined() // enabled
 
     wrapper.destroy()
   })
 
-  it('disables the Done button when the input field does NOT meet validation rules', async () => {
-    const wrapper = wrapperFactory()
+  it('disables the Done button when the input contains an invalid character', async () => {
+    const wrapper = await wrapperFactory()
 
     // Verify input field
-    expect(wrapper.find(addTranslationInput).exists()).toBeTruthy()
+    expect(wrapper.find(nameTranslationInput).exists()).toBeTruthy()
 
-    // Set Input field values
-    wrapper.vm.$el.querySelector(addTranslationInput).textContent = 'Mock Fail 1212'
-    wrapper.find(addTranslationInput).setValue('Mock Fail 1212')
-    wrapper.find(addTranslationInput).trigger('change')
-    await flushPromises()
+    // Set Input field value
+    const invalidText = 'Invalid Name Translation 123'
+    wrapper.vm.$el.querySelector(nameTranslationInput).textContent = invalidText
+    await wrapper.find(nameTranslationInput).setValue(invalidText)
+    await wrapper.find(nameTranslationInput).trigger('change')
 
-    wrapper.find(addTranslationInput).trigger('input')
-    expect(wrapper.find(addTranslationInput).text()).toEqual('Mock Fail 1212')
+    expect(wrapper.find(nameTranslationInput).text()).toEqual(invalidText)
 
-    // Verify Action btns and there states
+    // Verify Action btns and their states
     expect(wrapper.find(doneBtn).exists()).toBeTruthy()
-    expect(wrapper.find(doneBtn).attributes('disabled')).toBeTruthy()
+    expect(wrapper.find(doneBtn).attributes('disabled')).toBe('disabled')
 
     expect(wrapper.find(removeBtn).exists()).toBeTruthy()
-    expect(wrapper.find(removeBtn).attributes('disabled')).toBeTruthy()
+    expect(wrapper.find(removeBtn).attributes('disabled')).toBe('disabled')
 
     expect(wrapper.find(cancelBtn).exists()).toBeTruthy()
-    expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined() // enabled
 
     wrapper.destroy()
   })
 
-  it('opens the Add Name Translation with the correct Name when Editing a Name Translation', async () => {
-    const wrapper = wrapperFactory({ editNameTranslation: 'Mock Name Edit' })
-    await flushPromises()
+  it('disables the Done button when the input is too long', async () => {
+    const wrapper = await wrapperFactory()
 
     // Verify input field
-    expect(wrapper.find(addTranslationInput).exists()).toBeTruthy()
-    expect(wrapper.find(addTranslationInput).element.value).toContain('Mock Name Edit')
+    expect(wrapper.find(nameTranslationInput).exists()).toBeTruthy()
 
-    // Verify Action btns and there states
+    // Set Input field value
+    const invalidText = 'a'.repeat(51)
+    wrapper.vm.$el.querySelector(nameTranslationInput).textContent = invalidText
+    await wrapper.find(nameTranslationInput).setValue(invalidText)
+    await wrapper.find(nameTranslationInput).trigger('change')
+
+    expect(wrapper.find(nameTranslationInput).text()).toEqual(invalidText)
+
+    // Verify Action btns and their states
     expect(wrapper.find(doneBtn).exists()).toBeTruthy()
-    expect(wrapper.find(doneBtn).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(doneBtn).attributes('disabled')).toBe('disabled')
 
     expect(wrapper.find(removeBtn).exists()).toBeTruthy()
-    expect(wrapper.find(removeBtn).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(removeBtn).attributes('disabled')).toBe('disabled')
 
     expect(wrapper.find(cancelBtn).exists()).toBeTruthy()
-    expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined() // enabled
 
     wrapper.destroy()
   })
 
-  it('disables the Done btn when editing a name translation that does NOT meet validation', async () => {
-    const wrapper = wrapperFactory({ editNameTranslation: 'Mock Name Edit' })
-    await flushPromises()
+  it('displays the correct Name when editing a Name Translation', async () => {
+    const wrapper = await wrapperFactory({ editNameTranslation: 'Mock Name Edit' })
 
     // Verify input field
-    expect(wrapper.find(addTranslationInput).exists()).toBeTruthy()
-    expect(wrapper.find(addTranslationInput).element.value).toContain('Mock Name Edit')
+    expect(wrapper.find(nameTranslationInput).exists()).toBeTruthy()
+    expect(wrapper.find(nameTranslationInput).element.value).toContain('Mock Name Edit')
+
+    // Verify Action btns and their states
+    expect(wrapper.find(doneBtn).exists()).toBeTruthy()
+    expect(wrapper.find(doneBtn).attributes('disabled')).toBeUndefined() // enabled
+
+    expect(wrapper.find(removeBtn).exists()).toBeTruthy()
+    expect(wrapper.find(removeBtn).attributes('disabled')).toBeUndefined() // enabled
+
+    expect(wrapper.find(cancelBtn).exists()).toBeTruthy()
+    expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined() // enabled
+
+    wrapper.destroy()
+  })
+
+  it('disables the Done button when editing an invalid name translation', async () => {
+    const wrapper = await wrapperFactory({ editNameTranslation: 'Mock Name Edit' })
+
+    // Verify input field
+    expect(wrapper.find(nameTranslationInput).exists()).toBeTruthy()
+    expect(wrapper.find(nameTranslationInput).element.value).toContain('Mock Name Edit')
 
     // Edit the name
-    wrapper.find(addTranslationInput).setValue('Mock edit fail 1212')
-    wrapper.find(addTranslationInput).trigger('change')
-    await flushPromises()
+    const invalidText = 'Invalid Name Translation 123'
+    wrapper.vm.$el.querySelector(nameTranslationInput).textContent = invalidText
+    await wrapper.find(nameTranslationInput).setValue(invalidText)
+    await wrapper.find(nameTranslationInput).trigger('change')
 
-    // Verify Action btns and there states
+    expect(wrapper.find(nameTranslationInput).text()).toEqual(invalidText)
+
+    // Verify Action btns and their states
     expect(wrapper.find(doneBtn).exists()).toBeTruthy()
-    expect(wrapper.find(doneBtn).attributes('disabled')).toBeTruthy()
+    expect(wrapper.find(doneBtn).attributes('disabled')).toBe('disabled')
 
     expect(wrapper.find(removeBtn).exists()).toBeTruthy()
-    expect(wrapper.find(removeBtn).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(removeBtn).attributes('disabled')).toBeUndefined() // enabled
 
     expect(wrapper.find(cancelBtn).exists()).toBeTruthy()
-    expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined()
+    expect(wrapper.find(cancelBtn).attributes('disabled')).toBeUndefined() // enabled
 
     wrapper.destroy()
   })

--- a/tests/unit/ListNameTranslations.spec.ts
+++ b/tests/unit/ListNameTranslations.spec.ts
@@ -15,7 +15,7 @@ const store = getVuexStore()
 document.body.setAttribute('data-app', 'true')
 
 // Local references
-const nameTranslationsUi = '#name-translations-list'
+const nameTranslationsUi = '#list-name-translations'
 const nameTranslationsList = [
   { name: 'First mock name translation ltd.' },
   { name: 'Second mock name translation inc' },
@@ -109,11 +109,11 @@ describe('List Name Translation component', () => {
 
     // Select the first name to edit
     await editBtns.at(0).trigger('click')
-    expect(wrapper.emitted('editNameTranslation').pop()).toEqual([0])
+    expect(wrapper.emitted('editTranslation').pop()).toEqual([0])
 
     // Select the third name to edit
     await editBtns.at(2).trigger('click')
-    expect(wrapper.emitted('editNameTranslation').pop()).toEqual([2])
+    expect(wrapper.emitted('editTranslation').pop()).toEqual([2])
 
     wrapper.destroy()
   })
@@ -137,7 +137,7 @@ describe('List Name Translation component', () => {
     expect(removeBtns.at(0).attributes('disabled')).toBeUndefined()
     await removeBtns.at(0).trigger('click')
 
-    expect(wrapper.emitted('removeNameTranslation').pop()).toEqual([0])
+    expect(wrapper.emitted('removeTranslation').pop()).toEqual([0])
 
     wrapper.destroy()
   })

--- a/tests/unit/NameRequestInfo.spec.ts
+++ b/tests/unit/NameRequestInfo.spec.ts
@@ -299,38 +299,12 @@ describe('Name Request Info component without a NR', () => {
 describe('Name Request Info component - Name Translation section', () => {
   let wrapper: any
 
-  const mockNrData = {
-    nrNumber: 'NR 1234567',
-    entityType: 'BEN',
-    filingId: null,
-    applicant: {
-      addressLine1: '45 Frasier Drive',
-      addressLine2: null,
-      addressLine3: null,
-      city: 'Victoria',
-      countryTypeCode: 'CA',
-      postalCode: 'V9E 2A1',
-      stateProvinceCode: 'BC',
-      emailAddress: 'test@gov.bc.ca',
-      phoneNumber: '250-356-9090',
-      firstName: 'John',
-      middleName: 'Joe',
-      lastName: 'Doe'
-    },
-    details: {
-      approvedName: 'MADRONA BREAD BASKET INC.',
-      consentFlag: null,
-      expirationDate: '2020-06-24T07:00:00+00:00',
-      status: 'APPROVED'
-    }
-  }
-
   beforeEach(() => {
     // Entity type will always be set with or without an NR
     store.state.stateModel.entityType = 'BEN'
     // Temp Id will always be set with or without an NR
     store.state.stateModel.tempId = 'T1234567'
-    store.state.stateModel.nameRequest.nrNumber = null // mockNrData.nrNumber
+    store.state.stateModel.nameRequest.nrNumber = null
     wrapper = mount(NameRequestInfo, { vuetify, store })
   })
 

--- a/tests/unit/NameRequestInfo.spec.ts
+++ b/tests/unit/NameRequestInfo.spec.ts
@@ -12,34 +12,34 @@ const vuetify = new Vuetify({})
 const store = getVuexStore()
 document.body.setAttribute('data-app', 'true')
 
-describe('Name Request Info component', () => {
-  let wrapper: any
-
-  const mockNrData = {
-    nrNumber: 'NR 1234567',
-    entityType: 'BEN',
-    filingId: null,
-    applicant: {
-      addressLine1: '45 Frasier Drive',
-      addressLine2: null,
-      addressLine3: null,
-      city: 'Victoria',
-      countryTypeCode: 'CA',
-      postalCode: 'V9E 2A1',
-      stateProvinceCode: 'BC',
-      emailAddress: 'test@gov.bc.ca',
-      phoneNumber: '250-356-9090',
-      firstName: 'John',
-      middleName: 'Joe',
-      lastName: 'Doe'
-    },
-    details: {
-      approvedName: 'MADRONA BREAD BASKET INC.',
-      consentFlag: null,
-      expirationDate: '2020-06-24T07:00:00+00:00',
-      status: 'APPROVED'
-    }
+const mockNrData = {
+  nrNumber: 'NR 1234567',
+  entityType: 'BEN',
+  filingId: null,
+  applicant: {
+    addressLine1: '45 Frasier Drive',
+    addressLine2: null,
+    addressLine3: null,
+    city: 'Victoria',
+    countryTypeCode: 'CA',
+    postalCode: 'V9E 2A1',
+    stateProvinceCode: 'BC',
+    emailAddress: 'test@gov.bc.ca',
+    phoneNumber: '250-356-9090',
+    firstName: 'John',
+    middleName: 'Joe',
+    lastName: 'Doe'
+  },
+  details: {
+    approvedName: 'MADRONA BREAD BASKET INC.',
+    consentFlag: null,
+    expirationDate: '2020-06-24T07:00:00+00:00',
+    status: 'APPROVED'
   }
+}
+
+describe('Name Request Info with a NR', () => {
+  let wrapper: any
 
   beforeEach(() => {
     // Entity type will always be set with or without an NR
@@ -83,9 +83,7 @@ describe('Name Request Info component', () => {
   })
 
   it('renders the Name Request information with data', async () => {
-    store.state.stateModel.nameRequest = { ...mockNrData }
-
-    await Vue.nextTick()
+    await wrapper.vm.$store.commit('mutateNameRequestState', { ...mockNrData })
 
     const nrListSelector = '#name-request-info ul li'
     const itemCount = wrapper.vm.$el.querySelectorAll(nrListSelector).length
@@ -105,9 +103,7 @@ describe('Name Request Info component', () => {
   })
 
   it('renders the Name Request applicant information with data', async () => {
-    store.state.stateModel.nameRequest = { ...mockNrData }
-
-    await Vue.nextTick()
+    await wrapper.vm.$store.commit('mutateNameRequestState', { ...mockNrData })
 
     const nrListSelector = '#name-request-applicant-info ul li'
     const itemCount = wrapper.vm.$el.querySelectorAll(nrListSelector).length
@@ -126,7 +122,6 @@ describe('Name Request Info component', () => {
   it('renders the Name Request applicant information with no data', () => {
     const nrListSelector = '#name-request-applicant-info ul li'
     const itemCount = wrapper.vm.$el.querySelectorAll(nrListSelector).length
-
     expect(itemCount).toEqual(4)
 
     const name = wrapper.vm.$el.querySelectorAll(nrListSelector)[0]
@@ -144,7 +139,6 @@ describe('Name Request Info component', () => {
     store.state.stateModel.nameRequest.applicant.addressLine1 = 'line 1'
     store.state.stateModel.nameRequest.applicant.addressLine2 = 'line 2'
     store.state.stateModel.nameRequest.applicant.addressLine3 = 'line 3'
-
     await Vue.nextTick()
 
     const nrListSelector = '#name-request-applicant-info ul li'
@@ -165,7 +159,6 @@ describe('Name Request Info component', () => {
     store.state.stateModel.nameRequest = { ...mockNrData }
     store.state.stateModel.nameRequest.details.status = 'CONDITIONAL'
     store.state.stateModel.nameRequest.details.consentFlag = null
-
     await Vue.nextTick()
 
     const nrListSelector = '#name-request-info ul li'
@@ -190,7 +183,6 @@ describe('Name Request Info component', () => {
     store.state.stateModel.nameRequest = { ...mockNrData }
     store.state.stateModel.nameRequest.details.status = 'CONDITIONAL'
     store.state.stateModel.nameRequest.details.consentFlag = 'R'
-
     await Vue.nextTick()
 
     const nrListSelector = '#name-request-info ul li'
@@ -215,7 +207,6 @@ describe('Name Request Info component', () => {
     store.state.stateModel.nameRequest = { ...mockNrData }
     store.state.stateModel.nameRequest.details.status = 'CONDITIONAL'
     store.state.stateModel.nameRequest.details.consentFlag = 'N'
-
     await Vue.nextTick()
 
     const nrListSelector = '#name-request-info ul li'
@@ -240,7 +231,6 @@ describe('Name Request Info component', () => {
     store.state.stateModel.nameRequest = { ...mockNrData }
     store.state.stateModel.nameRequest.details.status = 'CONDITIONAL'
     store.state.stateModel.nameRequest.details.consentFlag = 'Y'
-
     await Vue.nextTick()
 
     const nrListSelector = '#name-request-info ul li'
@@ -261,49 +251,9 @@ describe('Name Request Info component', () => {
     expect(status.textContent).toContain('Status: CONDITIONAL')
     expect(conditionConsent.textContent).toContain('Condition/Consent: Not Received')
   })
-
-  it('renders the option for name translation', async () => {
-    store.state.stateModel.nameRequest = { ...mockNrData }
-
-    expect(wrapper.find('#name-translation-info').exists()).toBeTruthy()
-    expect(wrapper.vm.hasNameTranslation).toBe(false)
-
-    expect(wrapper.find('#name-translation-container').exists()).toBeFalsy()
-  })
-
-  it('renders the add name translation component', async () => {
-    store.state.stateModel.nameRequest = { ...mockNrData }
-
-    expect(wrapper.find('#name-translation-info').exists()).toBeTruthy()
-    expect(wrapper.vm.hasNameTranslation).toBe(false)
-
-    wrapper.find('#name-translation-checkbox').trigger('click')
-
-    await Vue.nextTick()
-
-    expect(wrapper.find('#name-translation-container').exists()).toBeTruthy()
-    expect(wrapper.findComponent(AddNameTranslation).exists()).toBeTruthy()
-    expect(wrapper.findComponent(ListNameTranslations).exists()).toBeFalsy()
-  })
-
-  it('renders the list name translation component', async () => {
-    store.state.stateModel.nameTranslations = ['Mock Name Translation', 'Another Mock Name Translation']
-    store.state.stateModel.nameRequest = { ...mockNrData }
-
-    await Vue.nextTick()
-
-    expect(wrapper.find('#name-translation-info').exists()).toBeTruthy()
-    expect(wrapper.vm.hasNameTranslation).toBe(true)
-
-    await Vue.nextTick()
-
-    expect(wrapper.findComponent('#name-translation-container').exists()).toBeTruthy()
-    expect(wrapper.findComponent(AddNameTranslation).exists()).toBeFalsy()
-    expect(wrapper.findComponent(ListNameTranslations).exists()).toBeTruthy()
-  })
 })
 
-describe('Name Request Info component without an NR', () => {
+describe('Name Request Info component without a NR', () => {
   let wrapper: any
 
   beforeEach(() => {
@@ -343,5 +293,84 @@ describe('Name Request Info component without an NR', () => {
     expect(bulletOne.textContent).toContain('You will be filing this Incorporation Application')
     expect(bulletTwo.textContent).toContain('Your Incorporation Number will be generated at the end')
     expect(bulletThree.textContent).toContain('It is not possible to request a specific Incorporation Number')
+  })
+})
+
+describe('Name Request Info component - Name Translation section', () => {
+  let wrapper: any
+
+  const mockNrData = {
+    nrNumber: 'NR 1234567',
+    entityType: 'BEN',
+    filingId: null,
+    applicant: {
+      addressLine1: '45 Frasier Drive',
+      addressLine2: null,
+      addressLine3: null,
+      city: 'Victoria',
+      countryTypeCode: 'CA',
+      postalCode: 'V9E 2A1',
+      stateProvinceCode: 'BC',
+      emailAddress: 'test@gov.bc.ca',
+      phoneNumber: '250-356-9090',
+      firstName: 'John',
+      middleName: 'Joe',
+      lastName: 'Doe'
+    },
+    details: {
+      approvedName: 'MADRONA BREAD BASKET INC.',
+      consentFlag: null,
+      expirationDate: '2020-06-24T07:00:00+00:00',
+      status: 'APPROVED'
+    }
+  }
+
+  beforeEach(() => {
+    // Entity type will always be set with or without an NR
+    store.state.stateModel.entityType = 'BEN'
+    // Temp Id will always be set with or without an NR
+    store.state.stateModel.tempId = 'T1234567'
+    store.state.stateModel.nameRequest.nrNumber = null // mockNrData.nrNumber
+    wrapper = mount(NameRequestInfo, { vuetify, store })
+  })
+
+  afterEach(() => {
+    wrapper.destroy()
+  })
+
+  it('renders the option for name translation', async () => {
+    await wrapper.vm.$store.commit('mutateNameRequestState', { ...mockNrData })
+
+    expect(wrapper.find('#name-translation-info').exists()).toBeTruthy()
+    expect(wrapper.vm.hasNameTranslation).toBe(false)
+
+    expect(wrapper.findComponent(AddNameTranslation).exists()).toBeFalsy()
+    expect(wrapper.findComponent(ListNameTranslations).exists()).toBeFalsy()
+  })
+
+  it('renders the add name translation component', async () => {
+    await wrapper.vm.$store.commit('mutateNameRequestState', { ...mockNrData })
+
+    expect(wrapper.find('#name-translation-info').exists()).toBeTruthy()
+    expect(wrapper.vm.hasNameTranslation).toBe(false)
+
+    await wrapper.find('#name-translation-checkbox').trigger('click')
+
+    expect(wrapper.findComponent(AddNameTranslation).exists()).toBeTruthy()
+    expect(wrapper.findComponent(ListNameTranslations).exists()).toBeFalsy()
+  })
+
+  it('renders the list name translation component', async () => {
+    await wrapper.vm.$store.commit('mutateNameTranslation', [
+      'Mock Name Translation',
+      'Another Mock Name Translation'
+    ])
+    await wrapper.vm.$store.commit('mutateNameRequestState', { ...mockNrData })
+
+    expect(wrapper.find('#name-translation-info').exists()).toBeTruthy()
+    expect(wrapper.vm.hasNameTranslation).toBe(true)
+
+    expect(wrapper.findComponent(AddNameTranslation).exists()).toBeFalsy()
+    expect(wrapper.findComponent(ListNameTranslations).exists()).toBeTruthy()
   })
 })


### PR DESCRIPTION
*Issue #:* bcgov/entity#13345

*Description of changes:*
- changed max name translation length to 50
- fixed actions column (auto)
- fixed row spacing
- misc cleanup
- updated unit tests
- app version = 4.3.11

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).