### PR TITLE
14403 Cleaned up NR handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "4.3.18",
+  "version": "4.3.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "4.3.18",
+      "version": "4.3.19",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "4.3.18",
+  "version": "4.3.19",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -296,20 +296,21 @@ export default class App extends Mixins(
   @Action setShowErrors!: ActionBindingIF
   @Action setFeePrices!: ActionBindingIF
   @Action setFilingType!: ActionBindingIF
-  @Action setNameRequestState!: ActionBindingIF
+  @Action setNameRequest!: ActionBindingIF
+  @Action setNameRequestApprovedName!: ActionBindingIF
   @Action setCompletingParty!: ActionBindingIF
   @Action setParties!: ActionBindingIF
   @Action setAdminFreeze!: ActionBindingIF
-  @Action setBusinessNumber: ActionBindingIF
-  @Action setIdentifier: ActionBindingIF
-  @Action setEntityName: ActionBindingIF
-  @Action setEntityState: ActionBindingIF
-  @Action setEntityFoundingDate: ActionBindingIF
-  @Action setLastAnnualReportDate: ActionBindingIF
-  @Action setLastAddressChangeDate: ActionBindingIF
-  @Action setLastDirectorChangeDate: ActionBindingIF
-  @Action setWarnings: ActionBindingIF
-  @Action setGoodStanding: ActionBindingIF
+  @Action setBusinessNumber!: ActionBindingIF
+  @Action setIdentifier!: ActionBindingIF
+  @Action setEntityName!: ActionBindingIF
+  @Action setEntityState!: ActionBindingIF
+  @Action setEntityFoundingDate!: ActionBindingIF
+  @Action setLastAnnualReportDate!: ActionBindingIF
+  @Action setLastAddressChangeDate!: ActionBindingIF
+  @Action setLastDirectorChangeDate!: ActionBindingIF
+  @Action setWarnings!: ActionBindingIF
+  @Action setGoodStanding!: ActionBindingIF
   @Action setWindowWidth!: ActionBindingIF
 
   // Local properties
@@ -852,19 +853,16 @@ export default class App extends Mixins(
       }
 
       // ensure NR is valid
-      if (!this.isNrValid(nrResponse)) {
-        console.log('NR is not valid') // eslint-disable-line no-console
+      const error = this.isNrInvalid(nrResponse)
+      if (error) {
+        console.log(error) // eslint-disable-line no-console
         this.nameRequestInvalidType = NameRequestStates.INVALID
         this.nameRequestInvalidErrorDialog = true
         return
       }
 
       // ensure types match
-      if (nrResponse.legalType === 'CCC' && this.getEntityType === CorpTypeCd.BC_CCC) {
-        // TEMPORARY FIX:
-        // at the moment, Namex API is passing CCC instead of CC
-        // remove this when no longer needed
-      } else if (nrResponse.legalType !== this.getEntityType) {
+      if (nrResponse.legalType !== this.getEntityType) {
         console.log('NR legal type doesn\'t match entity type') // eslint-disable-line no-console
         this.nameRequestInvalidType = NameRequestStates.INVALID
         this.nameRequestInvalidErrorDialog = true
@@ -880,9 +878,12 @@ export default class App extends Mixins(
         return
       }
 
-      // if we get this far, the NR is good to go!
-      const nameRequestState = this.generateNameRequestState(nrResponse, filing.Id)
-      this.setNameRequestState(nameRequestState)
+      // save the NR
+      this.setNameRequest(nrResponse)
+
+      // save the approved name
+      const approvedName = this.getNrApprovedName(nrResponse)
+      this.setNameRequestApprovedName(approvedName)
     } catch (error) {
       // errors should be handled above
       console.error('Unhandled error in processNameRequest() =', error) // eslint-disable-line no-console

--- a/src/components/Dissolution/AssociationDetails.vue
+++ b/src/components/Dissolution/AssociationDetails.vue
@@ -126,7 +126,6 @@ export default class AssociationDetails extends Mixins(CommonMixin, DateMixin) {
   @Prop({ default: true }) readonly showContactInfo!: boolean
 
   // Global getters
-  @Getter getApprovedName!: string
   @Getter getFolioNumber!: string
   @Getter getBusinessId!: string
   @Getter getBusiness!: BusinessIF

--- a/src/components/Dissolution/CompleteResolution.vue
+++ b/src/components/Dissolution/CompleteResolution.vue
@@ -316,7 +316,6 @@ import {
   CreateResolutionIF,
   CreateResolutionResourceIF,
   FormIF,
-  NameRequestDetailsIF,
   ValidationDetailIF,
   PersonIF,
   EmptyPerson
@@ -361,7 +360,6 @@ export default class CompleteResolution extends Mixins(CommonMixin, DateMixin) {
 
   @Getter getShowErrors!: boolean
   @Getter isTypeCoop!: boolean
-  @Getter getNameRequestDetails!: NameRequestDetailsIF
   @Getter getCreateResolutionResource!: CreateResolutionResourceIF
   @Getter getCreateResolutionStep!: CreateResolutionIF
   @Getter getBusinessLegalName!: string

--- a/src/components/Incorporation/SummaryDefineCompany.vue
+++ b/src/components/Incorporation/SummaryDefineCompany.vue
@@ -18,7 +18,7 @@
             <label id="company-label">Name</label>
           </v-col>
           <v-col cols="12" sm="9" class="pt-4 pt-sm-0">
-            <div id="company-name">{{ getApprovedName || '[Incorporation Number] B.C. Ltd.' }}</div>
+            <div id="company-name">{{ getNameRequestApprovedName || '[Incorporation Number] B.C. Ltd.' }}</div>
             <div id="company-description">{{ entityDescription }}</div>
           </v-col>
         </v-row>
@@ -113,8 +113,11 @@ import { CoopTypeToDescription } from '@/utils'
   }
 })
 export default class SummaryDefineCompany extends Vue {
+  // for template
+  readonly RouteNames = RouteNames
+
   // Getters
-  @Getter getApprovedName!: string
+  @Getter getNameRequestApprovedName!: string
   @Getter getCooperativeType!: CoopTypes
   @Getter isDefineCompanyValid!: boolean
   @Getter isPremiumAccount!: boolean
@@ -125,14 +128,12 @@ export default class SummaryDefineCompany extends Vue {
   @Getter getFolioNumber!: string
   @Getter getEntityType!: CorpTypeCd
 
-  /** The entity description  */
+  /** The entity description. */
   get entityDescription (): string {
     return GetCorpFullDescription(this.getEntityType)
   }
 
-  // for template
-  readonly RouteNames = RouteNames
-
+  /** The coop description. */
   get coopDescription (): string {
     return (this.getCooperativeType ? CoopTypeToDescription(this.getCooperativeType) : '(Not Entered)')
   }

--- a/src/components/Incorporation/UploadMemorandum.vue
+++ b/src/components/Incorporation/UploadMemorandum.vue
@@ -120,7 +120,7 @@
                   <v-col cols="1"><v-icon>mdi-circle-small</v-icon></v-col>
                   <v-col cols="11">
                     The Cooperative name is identified <b>exactly</b> as follows throughout the Memorandum:
-                    <p class="font-weight-bold mb-0">{{getNameRequestDetails.approvedName}}</p>
+                    <p class="font-weight-bold mb-0">{{getNameRequestApprovedName}}</p>
                   </v-col>
                 </v-row>
               </li>
@@ -240,7 +240,6 @@ import {
   CreateMemorandumIF,
   CreateMemorandumResourceIF,
   DocumentUpload,
-  NameRequestDetailsIF,
   FormIF,
   ValidationDetailIF
 } from '@/interfaces'
@@ -275,7 +274,7 @@ export default class UploadMemorandum extends Mixins(CommonMixin, DocumentMixin)
   protected helpToggle = false
 
   @Getter getShowErrors!: boolean
-  @Getter getNameRequestDetails!: NameRequestDetailsIF
+  @Getter getNameRequestApprovedName!: string
   @Getter getCreateMemorandumResource!: CreateMemorandumResourceIF
   @Getter getCreateMemorandumStep!: CreateMemorandumIF
   @Getter getUserKeycloakGuid!: string

--- a/src/components/Incorporation/UploadRules.vue
+++ b/src/components/Incorporation/UploadRules.vue
@@ -140,7 +140,7 @@
                       The Cooperative name is identified <b>exactly</b> as follows throughout
                       the Rules of the Association:
                     </p>
-                    <div class="mt-2 mb-0 font-weight-bold">{{getNameRequestDetails.approvedName}}</div>
+                    <div class="mt-2 mb-0 font-weight-bold">{{getNameRequestApprovedName}}</div>
                   </v-col>
                 </v-row>
               </li>
@@ -212,7 +212,6 @@ import {
   CreateRulesIF,
   CreateRulesResourceIF,
   DocumentUpload,
-  NameRequestDetailsIF,
   FormIF,
   ValidationDetailIF
 } from '@/interfaces'
@@ -241,7 +240,7 @@ export default class UploadRules extends Mixins(CommonMixin, DocumentMixin) {
   protected helpToggle = false
 
   @Getter getShowErrors!: boolean
-  @Getter getNameRequestDetails!: NameRequestDetailsIF
+  @Getter getNameRequestApprovedName!: string
   @Getter getCreateRulesResource!: CreateRulesResourceIF
   @Getter getCreateRulesStep!: CreateRulesIF
   @Getter getUserKeycloakGuid!: string

--- a/src/components/Registration/DefineRegistrationSummary.vue
+++ b/src/components/Registration/DefineRegistrationSummary.vue
@@ -18,7 +18,7 @@
             <label id="company-label">Name</label>
           </v-col>
           <v-col cols="12" sm="9" class="pt-4 pt-sm-0">
-            <div id="company-name">{{ getApprovedName || 'Unavailable' }}</div>
+            <div id="company-name">{{ getNameRequestApprovedName || 'Unavailable' }}</div>
             <div id="company-description">{{ entityDescription }}</div>
           </v-col>
         </v-row>
@@ -122,7 +122,7 @@ import { GetCorpFullDescription } from '@bcrs-shared-components/corp-type-module
 })
 export default class DefineRegistrationSummary extends Mixins(DateMixin) {
   // Getters
-  @Getter getApprovedName!: string
+  @Getter getNameRequestApprovedName!: string
   // @Getter isPremiumAccount!: boolean // DISABLED PER TICKET # 12306
   @Getter getBusinessContact!: ContactPointIF
   @Getter getFolioNumber!: string

--- a/src/components/common/Actions.vue
+++ b/src/components/common/Actions.vue
@@ -117,6 +117,7 @@ export default class Actions extends Mixins(DateMixin, FilingTemplateMixin, Name
   @Getter isSaving!: boolean
   @Getter isSavingResuming!: boolean
   @Getter isFilingPaying!: boolean
+  @Getter getNameRequestNumber!: string
 
   @Action setIsSaving!: ActionBindingIF
   @Action setIsSavingResuming!: ActionBindingIF
@@ -233,7 +234,7 @@ export default class Actions extends Mixins(DateMixin, FilingTemplateMixin, Name
       // from the processNameRequest method in App.vue. This method shows a generic message if
       // the Name Request is not valid and clicking ok in the pop up redirects to the Manage Businesses
       // dashboard.
-      if (this.isNamedBusiness) {
+      if (this.getNameRequestNumber) {
         try {
           await this.validateNameRequest(this.getNameRequestNumber)
         } catch (error) {
@@ -304,9 +305,17 @@ export default class Actions extends Mixins(DateMixin, FilingTemplateMixin, Name
       throw new Error(error)
     })
 
-    if (!nrResponse || !this.isNrValid(nrResponse)) {
+    // ensure NR was found
+    if (!nrResponse) {
       this.$root.$emit('name-request-invalid-error', NameRequestStates.INVALID)
       throw new Error('Invalid Name Request')
+    }
+
+    // ensure NR is valid
+    const error = this.isNrInvalid(nrResponse)
+    if (error) {
+      this.$root.$emit('name-request-invalid-error', NameRequestStates.INVALID)
+      throw new Error(error)
     }
 
     // ensure NR is consumable

--- a/src/components/common/EntityInfo.vue
+++ b/src/components/common/EntityInfo.vue
@@ -86,7 +86,7 @@ export default class EntityInfo extends Mixins(DateMixin) {
   @Getter getEntityType!: CorpTypeCd
   @Getter getFilingName!: FilingNames
   @Getter getNameRequestNumber!: string
-  @Getter getApprovedName!: string
+  @Getter getNameRequestApprovedName!: string
   @Getter getFilingType!: FilingTypes
   @Getter getRegistration!: RegistrationStateIF
   @Getter isEntityType!: boolean
@@ -148,9 +148,9 @@ export default class EntityInfo extends Mixins(DateMixin) {
       case FilingTypes.VOLUNTARY_DISSOLUTION:
         return this.getBusinessLegalName
       case FilingTypes.INCORPORATION_APPLICATION:
-        return this.getApprovedName
+        return this.getNameRequestApprovedName
       case FilingTypes.REGISTRATION:
-        return this.getApprovedName
+        return this.getNameRequestApprovedName
     }
   }
 }

--- a/src/dialogs/FileAndPayInvalidNameRequestDialog.vue
+++ b/src/dialogs/FileAndPayInvalidNameRequestDialog.vue
@@ -8,7 +8,7 @@
           <p>
             <b>
               The Name Request {{ getNameRequestNumber }} and the Incorporation Application for
-              {{ getApprovedName }} are no longer valid.
+              {{ getNameRequestApprovedName }} are no longer valid.
             </b>
           </p>
           <p>If you still wish to incorporate a Benefit Company, please contact Registry Staff as soon as possible.</p>
@@ -52,7 +52,7 @@ export default class FileAndPayInvalidNameRequestDialog extends Vue {
   @Prop({ default: '' }) readonly attach!: string
 
   @Getter getNameRequestNumber!: string
-  @Getter getApprovedName!: string
+  @Getter getNameRequestApprovedName!: string
 
   @Emit() protected okay (): void {}
 }

--- a/src/interfaces/store-interfaces/state-interface.ts
+++ b/src/interfaces/store-interfaces/state-interface.ts
@@ -38,6 +38,7 @@ export interface StateModelIF {
   businessContact: ContactPointIF
   dissolution: DissolutionStateIF
   nameRequest: NameRequestIF
+  nameRequestApprovedName: string
   nameTranslations: NameTranslationIF[]
   currentDate: string
   effectiveDateTime: EffectiveDateTimeIF

--- a/src/interfaces/store-interfaces/state-interfaces/name-request-interface.ts
+++ b/src/interfaces/store-interfaces/state-interfaces/name-request-interface.ts
@@ -1,43 +1,56 @@
-import { CorpTypeCd, NameRequestStates } from '@/enums'
+import { CorpTypeCd, NameRequestStates, NameRequestTypes } from '@/enums'
 
-/** Name request response details interface. */
-export interface NameRequestDetailsIF {
-  approvedName: string
-  status: NameRequestStates
-  consentFlag: string
-  expirationDate: string
-}
-
-/** Name request applicant details interface. */
+/**
+ * Name request applicant interface.
+ * Includes only the properties we care about.
+ */
 export interface NameRequestApplicantIF {
-  firstName: string
-  middleName: string
-  lastName: string
-  emailAddress: string
-  phoneNumber: string
-  addressLine1: string
-  addressLine2: string
-  addressLine3: string
+  addrLine1: string
+  addrLine2: string
+  addrLine3: string
   city: string
-  countryTypeCode: string
-  postalCode: string
-  stateProvinceCode: string
+  countryTypeCd: string
+  emailAddress: string
+  firstName: string
+  lastName: string
+  middleName: string
+  phoneNumber: string
+  postalCd: string
+  stateProvinceCd: string
 }
 
-/** Name Request state interface. */
+/**
+ * Name request name interaface.
+ * Includes only the properties we care about.
+ */
+export interface NameRequestNameIF {
+  name: string
+  state: NameRequestStates
+}
+
+/**
+ * Name request interface.
+ * Includes only the properties we care about.
+ */
 export interface NameRequestIF {
-  nrNumber: string
-  entityType: CorpTypeCd
-  details: NameRequestDetailsIF
-  applicant: NameRequestApplicantIF
-  filingId: number
+  applicants: NameRequestApplicantIF
+  consentFlag: string
+  expirationDate: string // yyyy-mm-ddRhh:mm:ss+00:00
+  legalType: CorpTypeCd
+  names: Array<NameRequestNameIF>
+  nrNum: string
+  request_action_cd: NameRequestTypes // eslint-disable-line camelcase
+  state: NameRequestStates
 }
 
 // NB: use cloneDeep when assigning EmptyOrgPerson
 export const EmptyNameRequest: NameRequestIF = {
-  nrNumber: '',
-  entityType: null,
-  details: {} as NameRequestDetailsIF,
-  applicant: {} as NameRequestApplicantIF,
-  filingId: null
+  applicants: {} as NameRequestApplicantIF,
+  consentFlag: null,
+  expirationDate: null,
+  legalType: null,
+  names: [],
+  nrNum: '',
+  request_action_cd: null,
+  state: null
 }

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -31,7 +31,6 @@ import {
   RegistrationStateIF,
   RegistrationFilingIF,
   EmptyNaics,
-  NameRequestIF,
   PartyIF,
   CompletingPartyIF
 } from '@/interfaces'
@@ -56,10 +55,9 @@ export default class FilingTemplateMixin extends DateMixin {
   @Getter isTypeBcomp!: boolean
   @Getter isTypeCoop!: boolean
   @Getter isTypeSoleProp!: boolean
-  @Getter isNamedBusiness!: boolean
   @Getter getAffidavitStep!: UploadAffidavitIF
   @Getter getNameRequestNumber!: string
-  @Getter getApprovedName!: string
+  @Getter getNameRequestApprovedName!: string
   @Getter getBusiness!: BusinessIF
   @Getter getBusinessLegalName!: string
   @Getter getBusinessFoundingDate!: string
@@ -93,7 +91,6 @@ export default class FilingTemplateMixin extends DateMixin {
   @Getter isPremiumAccount!: boolean
   @Getter getRegistration!: RegistrationStateIF
   @Getter getFilingId!: number
-  @Getter getNameRequest!: NameRequestIF
   @Getter getCompletingParty!: CompletingPartyIF
   @Getter getDissolutionDate!: string
   @Getter isTypeFirm!: boolean
@@ -214,9 +211,9 @@ export default class FilingTemplateMixin extends DateMixin {
     }
 
     // If this is a named IA then add Name Request Number and Approved Name.
-    if (this.isNamedBusiness) {
+    if (this.getNameRequestNumber) {
       filing.incorporationApplication.nameRequest.nrNumber = this.getNameRequestNumber
-      filing.incorporationApplication.nameRequest.legalName = this.getApprovedName
+      filing.incorporationApplication.nameRequest.legalName = this.getNameRequestApprovedName
     }
 
     // If this is a future effective filing then save the effective date.
@@ -384,9 +381,9 @@ export default class FilingTemplateMixin extends DateMixin {
             : {}
         },
         nameRequest: {
-          legalName: this.getNameRequest.details.approvedName,
+          legalName: this.getNameRequestApprovedName,
           legalType: this.getEntityType,
-          nrNumber: this.getNameRequest.nrNumber
+          nrNumber: this.getNameRequestNumber
         },
         parties: this.orgPersonsToParties(this.getAddPeopleAndRoleStep.orgPeople),
         startDate: this.getRegistration.startDate,

--- a/src/mixins/name-request-mixin.ts
+++ b/src/mixins/name-request-mixin.ts
@@ -1,92 +1,48 @@
-// Libraries
+import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
 import { NameRequestStates, NameRequestTypes } from '@/enums'
 import { NameRequestIF } from '@/interfaces'
-import { DateMixin } from '@/mixins'
 
 /**
- * Mixin for processing Name Request objects.
+ * Mixin that provides some useful Name Request utilities.
  */
 @Component({})
-export default class NameRequestMixin extends DateMixin {
+export default class NameRequestMixin extends Vue {
   /**
-   * Generates Name Request state for the store.
+   * Returns error message if the Name Request data is invalid.
    * @param nr the name request response payload
-   * @param filingId the filing id
    */
-  generateNameRequestState (nr: any, filingId: number): NameRequestIF {
-    return {
-      nrNumber: nr.nrNum,
-      entityType: nr.legalType,
-      filingId,
-      applicant: {
-        // Address Information
-        addressLine1: nr.applicants.addrLine1,
-        addressLine2: nr.applicants.addrLine2,
-        addressLine3: nr.applicants.addrLine3,
-        city: nr.applicants.city,
-        countryTypeCode: nr.applicants.countryTypeCd,
-        postalCode: nr.applicants.postalCd,
-        stateProvinceCode: nr.applicants.stateProvinceCd,
-
-        // Contact information
-        emailAddress: nr.applicants.emailAddress,
-        phoneNumber: nr.applicants.phoneNumber,
-
-        // Name information
-        firstName: nr.applicants.firstName,
-        middleName: nr.applicants.middleName,
-        lastName: nr.applicants.lastName
-      },
-      details: {
-        approvedName: this.getNrApprovedName(nr) || '',
-        consentFlag: nr.consentFlag,
-        expirationDate: nr.expirationDate,
-        status: nr.state
-      }
-    }
-  }
-
-  /**
-   * Returns True if the Name Request data is valid.
-   * @param nr the name request response payload
-   * */
-  isNrValid (nr: any): boolean {
-    // check all expected fields
-    // FUTURE: add more checks here as needed
-    return Boolean(
-      nr &&
-      nr.nrNum &&
-      nr.applicants &&
-      nr.state &&
-      nr.expirationDate &&
-      nr.legalType &&
-      (nr.request_action_cd === NameRequestTypes.NEW) &&
-      !!this.getNrApprovedName(nr)
-    )
+  isNrInvalid (nr: NameRequestIF): string {
+    if (!nr) return 'Invalid NR object'
+    if (!nr.applicants) return 'Invalid NR applicants'
+    if (!nr.expirationDate) return 'Invalid NR expiration date'
+    if (!nr.legalType) return 'Invalid NR legal type'
+    if (!this.getNrApprovedName(nr)) return 'Invalid NR approved name'
+    if (!nr.nrNum) return 'Invalid NR number'
+    if (nr.request_action_cd !== NameRequestTypes.NEW) return 'Invalid NR action code'
+    if (!nr.state) return 'Invalid NR state'
+    return null
   }
 
   /**
    * Returns the Name Request's state.
    * @param nr the name request response payload
    */
-  getNrState (nr: any): NameRequestStates {
+  getNrState (nr: NameRequestIF): NameRequestStates {
     // Ensure a NR payload is provided.
-    if (!nr) {
-      return null
-    }
+    if (!nr) return null
 
     // If the NR is awaiting consent, it is not consumable.
     // null = consent not required
     // R = consent received
     // N = consent waived
+    // Y = consent required
     if (nr.state === NameRequestStates.CONDITIONAL &&
       nr.consentFlag !== null && nr.consentFlag !== 'R' && nr.consentFlag !== 'N') {
       return NameRequestStates.NEED_CONSENT
     }
 
-    // If the NR's root state is not APPROVED or CONDITIONAL, it is not consumable.
-    // EXPIRED or CONSUMED should not return NOT_APPROVED.
+    // If the NR's root state is not APPROVED / CONDITIONAL / EXPIRED / CONSUMED, it is not consumable.
     if (![NameRequestStates.APPROVED, NameRequestStates.CONDITIONAL,
       NameRequestStates.EXPIRED, NameRequestStates.CONSUMED].includes(nr.state)) {
       return NameRequestStates.NOT_APPROVED
@@ -100,7 +56,7 @@ export default class NameRequestMixin extends DateMixin {
    * Returns the Name Request's approved name (or undefined or null if not found).
    * @param nr the name request response payload
    */
-  getNrApprovedName (nr: any): string {
+  getNrApprovedName (nr: NameRequestIF): string {
     if (nr?.names?.length > 0) {
       return nr.names
         .find(name => [NameRequestStates.APPROVED, NameRequestStates.CONDITION].includes(name.state))?.name

--- a/src/resources/BreadCrumbResource.ts
+++ b/src/resources/BreadCrumbResource.ts
@@ -9,12 +9,12 @@ const store = getVuexStore()
 function getLegalName (): string {
   const getFilingType: FilingTypes = store.getters.getFilingType
   const getBusinessLegalName: string = store.getters.getBusinessLegalName
-  const getApprovedName: string = store.getters.getApprovedName
+  const getNameRequestApprovedName: string = store.getters.getNameRequestApprovedName
 
   switch (getFilingType) {
     case FilingTypes.VOLUNTARY_DISSOLUTION: return getBusinessLegalName
-    case FilingTypes.INCORPORATION_APPLICATION: return getApprovedName
-    case FilingTypes.REGISTRATION: return getApprovedName
+    case FilingTypes.INCORPORATION_APPLICATION: return getNameRequestApprovedName
+    case FilingTypes.REGISTRATION: return getNameRequestApprovedName
   }
 }
 

--- a/src/services/legal-services.ts
+++ b/src/services/legal-services.ts
@@ -1,7 +1,8 @@
 // Libraries
 import { AxiosInstance as axios } from '@/utils'
 import { StatusCodes } from 'http-status-codes'
-import { DissolutionFilingIF, IncorporationFilingIF, RegistrationFilingIF } from '@/interfaces'
+import { DissolutionFilingIF, IncorporationFilingIF, NameRequestIF, RegistrationFilingIF }
+  from '@/interfaces'
 import { FilingTypes } from '@/enums'
 
 /**
@@ -105,7 +106,7 @@ export default class LegalServices {
    * @param nrNumber the name request number (eg, NR 1234567)
    * @returns a promise to return the NR data, or null if not found
    */
-  static async fetchNameRequest (nrNumber: string): Promise<any> {
+  static async fetchNameRequest (nrNumber: string): Promise<NameRequestIF> {
     if (!nrNumber) throw new Error('Invalid parameter \'nrNumber\'')
 
     const url = `nameRequests/${nrNumber}`

--- a/src/store/actions/actions-model.ts
+++ b/src/store/actions/actions-model.ts
@@ -148,8 +148,12 @@ export const setOrgInformation: ActionIF = ({ commit }, orgInfo: OrgInformationI
   commit('mutateOrgInformation', orgInfo)
 }
 
-export const setNameRequestState: ActionIF = ({ commit }, nameRequestState: NameRequestIF): void => {
-  commit('mutateNameRequestState', nameRequestState)
+export const setNameRequest: ActionIF = ({ commit }, nameRequest: NameRequestIF): void => {
+  commit('mutateNameRequest', nameRequest)
+}
+
+export const setNameRequestApprovedName: ActionIF = ({ commit }, name: string): void => {
+  commit('mutateNameRequestApprovedName', name)
 }
 
 export const setNameTranslationState: ActionIF = ({ commit }, nameTranslationState: NameTranslationIF): void => {

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -6,7 +6,8 @@ import {
   DissolutionTypes,
   FilingNames,
   FilingTypes,
-  FilingTypesSubTitle
+  FilingTypesSubTitle,
+  NameRequestStates
 } from '@/enums'
 import {
   AccountInformationIF,
@@ -25,8 +26,6 @@ import {
   EffectiveDateTimeIF,
   FeesIF,
   IncorporationAgreementIF,
-  NameRequestApplicantIF,
-  NameRequestDetailsIF,
   NameRequestIF,
   NameTranslationIF,
   OrgPersonIF,
@@ -251,20 +250,19 @@ export const getBusiness = (state: StateIF): BusinessIF => {
   return state.stateModel.business
 }
 
-/** Whether this IA is for a Named Business. */
-export const isNamedBusiness = (state: StateIF): boolean => {
-  // a named business has a NR number
-  return !!getNameRequestNumber(state)
+/** The Name Request object. */
+export const getNameRequest = (state: StateIF): NameRequestIF => {
+  return state.stateModel.nameRequest
 }
 
-/** The Number of a Name Request. */
+/** The Name Request approved name. */
+export const getNameRequestApprovedName = (state: StateIF): string => {
+  return state.stateModel.nameRequestApprovedName
+}
+
+/** The Name Request number. */
 export const getNameRequestNumber = (state: StateIF): string => {
-  return getNameRequest(state).nrNumber
-}
-
-/** The Approved Name of a Name Request. */
-export const getApprovedName = (state: StateIF): string => {
-  return (getNameRequestDetails(state) as NameRequestDetailsIF).approvedName
+  return getNameRequest(state)?.nrNum
 }
 
 /** The Tombstone object. */
@@ -356,21 +354,6 @@ export const getCreateResolutionStep = (state: StateIF): CreateResolutionIF => {
 /** The Effective Date-Time object. */
 export const getEffectiveDateTime = (state: StateIF): EffectiveDateTimeIF => {
   return state.stateModel.effectiveDateTime
-}
-
-/** The Name Request object. */
-export const getNameRequest = (state: StateIF): NameRequestIF => {
-  return state.stateModel.nameRequest
-}
-
-/** The Name Request Details object. */
-export const getNameRequestDetails = (state: StateIF): NameRequestDetailsIF | object => {
-  return getNameRequest(state).details
-}
-
-/** The Name Request Applicant object. */
-export const getNameRequestApplicant = (state: StateIF): NameRequestApplicantIF | object => {
-  return getNameRequest(state).applicant
 }
 
 /** The Name Translations object array. */

--- a/src/store/mutations/mutations-model.ts
+++ b/src/store/mutations/mutations-model.ts
@@ -182,8 +182,12 @@ export const mutateOrgInformation = (state: StateIF, orgInfo: OrgInformationIF) 
   state.stateModel.orgInformation = orgInfo
 }
 
-export const mutateNameRequestState = (state: StateIF, nameRequestState: NameRequestIF) => {
-  state.stateModel.nameRequest = nameRequestState
+export const mutateNameRequest = (state: StateIF, nameRequest: NameRequestIF) => {
+  state.stateModel.nameRequest = nameRequest
+}
+
+export const mutateNameRequestApprovedName = (state: StateIF, name: string) => {
+  state.stateModel.nameRequestApprovedName = name
 }
 
 export const mutateNameTranslation = (state: StateIF, nameTranslationState: NameTranslationIF[]) => {

--- a/src/store/state/state-model.ts
+++ b/src/store/state/state-model.ts
@@ -85,6 +85,7 @@ export const stateModel: StateModelIF = {
   accountInformation: { ...EmptyAccountInformation },
   orgInformation: null,
   nameRequest: cloneDeep(EmptyNameRequest),
+  nameRequestApprovedName: null,
   nameTranslations: [],
   currentDate: '',
   effectiveDateTime: {

--- a/tests/unit/Actions.spec.ts
+++ b/tests/unit/Actions.spec.ts
@@ -124,10 +124,10 @@ describe('Emits error event if NR validation fails in file and pay', () => {
     // init store
     store.state.stateModel.currentDate = '2020/01/29'
     store.state.stateModel.nameRequest = {
-      entityType: 'BEN',
-      nrNumber: 'NR 1234567',
-      details: { approvedName: 'My Name Request Inc.' }
+      legalType: 'BEN',
+      nrNum: 'NR 1234567'
     }
+    store.state.stateModel.nameRequestApprovedName = 'My Name Request Inc.'
     store.state.stateModel.tombstone = {
       authRoles: [],
       filingType: 'incorporationApplication',
@@ -371,10 +371,10 @@ describe('Actions component - Filing Functionality', () => {
     // init store
     store.state.stateModel.currentDate = '2020/01/29'
     store.state.stateModel.nameRequest = {
-      entityType: 'BEN',
-      nrNumber: 'NR 1234567',
-      details: { approvedName: 'My Name Request Inc.' }
+      legalType: 'BEN',
+      nrNum: 'NR 1234567'
     }
+    store.state.stateModel.nameRequestApprovedName = 'My Name Request Inc.'
     store.state.stateModel.nameTranslations = []
     store.state.stateModel.tombstone = {
       authRoles: [],

--- a/tests/unit/AgreementType.spec.ts
+++ b/tests/unit/AgreementType.spec.ts
@@ -1,4 +1,4 @@
-import { getShowErrors } from './../../src/store/getters/state-getters';
+import { getShowErrors } from './../../src/store/getters/state-getters'
 import Vue from 'vue'
 import { wrapperFactory } from '../jest-wrapper-factory'
 import AgreementType from '@/components/common/AgreementType.vue'

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -241,16 +241,10 @@ const nrData = {
   expirationDate: 'Thu, 31 Dec 2099 23:59:59 GMT',
   names: [
     {
-      choice: 1,
-      consumptionDate: null,
-      corpNum: null,
       name: 'ABC 1234',
       state: 'APPROVED'
     },
     {
-      choice: 2,
-      consumptionDate: null,
-      corpNum: null,
       name: 'CDE 1234',
       state: 'NE'
     }
@@ -391,31 +385,18 @@ describe('Incorporation - Define Company page for a BEN (numbered)', () => {
   })
 
   it('does not load a name request into the store', () => {
-    // All Name request specific fields should be empty
-    expect(store.state.stateModel.nameRequest.nrNumber).toEqual('')
-    expect(store.state.stateModel.filingId).toBe(54321)
+    // Validate empty Name Request fields
+    expect(store.state.stateModel.nameRequest.applicants).toEqual({})
+    expect(store.state.stateModel.nameRequest.consentFlag).toBeNull()
+    expect(store.state.stateModel.nameRequest.expirationDate).toBeNull()
+    expect(store.state.stateModel.nameRequest.legalType).toBeNull()
+    expect(store.state.stateModel.nameRequest.names).toEqual([])
+    expect(store.state.stateModel.nameRequest.nrNum).toBe('')
+    expect(store.state.stateModel.nameRequest.request_action_cd).toBeNull()
+    expect(store.state.stateModel.nameRequest.state).toBeNull()
 
-    // Validate no NR Details
-    expect(store.state.stateModel.nameRequest.details.approvedName).toBeUndefined()
-    expect(store.state.stateModel.nameRequest.details.status).toBeUndefined()
-    expect(store.state.stateModel.nameRequest.details.consentFlag).toBeUndefined()
-    expect(store.state.stateModel.nameRequest.details.expirationDate).toBeUndefined()
-
-    // Validate no NR Applicant
-    expect(store.state.stateModel.nameRequest.applicant.firstName).toBeUndefined()
-    expect(store.state.stateModel.nameRequest.applicant.middleName).toBeUndefined()
-    expect(store.state.stateModel.nameRequest.applicant.lastName).toBeUndefined()
-    expect(store.state.stateModel.nameRequest.applicant.emailAddress).toBeUndefined()
-    expect(store.state.stateModel.nameRequest.applicant.phoneNumber).toBeUndefined()
-    expect(store.state.stateModel.nameRequest.applicant.addressLine1).toBeUndefined()
-    expect(store.state.stateModel.nameRequest.applicant.addressLine2).toBeUndefined()
-    expect(store.state.stateModel.nameRequest.applicant.addressLine3).toBeUndefined()
-    expect(store.state.stateModel.nameRequest.applicant.city).toBeUndefined()
-    expect(store.state.stateModel.nameRequest.applicant.countryTypeCode)
-      .toBeUndefined()
-    expect(store.state.stateModel.nameRequest.applicant.postalCode).toBeUndefined()
-    expect(store.state.stateModel.nameRequest.applicant.stateProvinceCode)
-      .toBeUndefined()
+    // Validate empty Approved Name
+    expect(store.state.stateModel.nameRequestApprovedName).toBeNull()
   })
 })
 
@@ -571,32 +552,41 @@ describe('Incorporation - Define Company page for a BEN (named)', () => {
   })
 
   it('loads a name request into the store', () => {
-    // Validate Name Request
     expect(store.state.stateModel.entityType).toBe('BEN')
-    expect(store.state.stateModel.nameRequest.nrNumber).toBe(nrData.nrNum)
     expect(store.state.stateModel.filingId).toBe(12345)
-    expect(store.state.stateModel.nameRequest.details).toBeDefined()
-    expect(store.state.stateModel.nameRequest.applicant).toBeDefined()
 
-    // Validate NR Details
-    expect(store.state.stateModel.nameRequest.details.approvedName).toBe(nrData.names[0].name)
-    expect(store.state.stateModel.nameRequest.details.status).toBe(nrData.state)
-    expect(store.state.stateModel.nameRequest.details.consentFlag).toBe(nrData.consentFlag)
-    expect(store.state.stateModel.nameRequest.details.expirationDate).toBe(nrData.expirationDate)
+    // Validate Name Request fields
+    expect(store.state.stateModel.nameRequest.consentFlag).toBe(nrData.consentFlag)
+    expect(store.state.stateModel.nameRequest.expirationDate).toBe(nrData.expirationDate)
+    expect(store.state.stateModel.nameRequest.legalType).toBe(nrData.legalType)
+    expect(store.state.stateModel.nameRequest.nrNum).toBe(nrData.nrNum)
+    expect(store.state.stateModel.nameRequest.request_action_cd).toBe(nrData.request_action_cd)
+    expect(store.state.stateModel.nameRequest.state).toBe(nrData.state)
 
     // Validate NR Applicant
-    expect(store.state.stateModel.nameRequest.applicant.firstName).toBe(nrData.applicants.firstName)
-    expect(store.state.stateModel.nameRequest.applicant.middleName).toBe(nrData.applicants.middleName)
-    expect(store.state.stateModel.nameRequest.applicant.lastName).toBe(nrData.applicants.lastName)
-    expect(store.state.stateModel.nameRequest.applicant.emailAddress).toBe(nrData.applicants.emailAddress)
-    expect(store.state.stateModel.nameRequest.applicant.phoneNumber).toBe(nrData.applicants.phoneNumber)
-    expect(store.state.stateModel.nameRequest.applicant.addressLine1).toBe(nrData.applicants.addrLine1)
-    expect(store.state.stateModel.nameRequest.applicant.addressLine2).toBe(nrData.applicants.addrLine2)
-    expect(store.state.stateModel.nameRequest.applicant.addressLine3).toBe(nrData.applicants.addrLine3)
-    expect(store.state.stateModel.nameRequest.applicant.city).toBe(nrData.applicants.city)
-    expect(store.state.stateModel.nameRequest.applicant.countryTypeCode).toBe(nrData.applicants.countryTypeCd)
-    expect(store.state.stateModel.nameRequest.applicant.postalCode).toBe(nrData.applicants.postalCd)
-    expect(store.state.stateModel.nameRequest.applicant.stateProvinceCode).toBe(nrData.applicants.stateProvinceCd)
+    expect(store.state.stateModel.nameRequest.applicants).toBeDefined()
+    expect(store.state.stateModel.nameRequest.applicants.firstName).toBe(nrData.applicants.firstName)
+    expect(store.state.stateModel.nameRequest.applicants.middleName).toBe(nrData.applicants.middleName)
+    expect(store.state.stateModel.nameRequest.applicants.lastName).toBe(nrData.applicants.lastName)
+    expect(store.state.stateModel.nameRequest.applicants.emailAddress).toBe(nrData.applicants.emailAddress)
+    expect(store.state.stateModel.nameRequest.applicants.phoneNumber).toBe(nrData.applicants.phoneNumber)
+    expect(store.state.stateModel.nameRequest.applicants.addrLine1).toBe(nrData.applicants.addrLine1)
+    expect(store.state.stateModel.nameRequest.applicants.addrLine2).toBe(nrData.applicants.addrLine2)
+    expect(store.state.stateModel.nameRequest.applicants.addrLine3).toBe(nrData.applicants.addrLine3)
+    expect(store.state.stateModel.nameRequest.applicants.city).toBe(nrData.applicants.city)
+    expect(store.state.stateModel.nameRequest.applicants.countryTypeCd).toBe(nrData.applicants.countryTypeCd)
+    expect(store.state.stateModel.nameRequest.applicants.postalCd).toBe(nrData.applicants.postalCd)
+    expect(store.state.stateModel.nameRequest.applicants.stateProvinceCd).toBe(nrData.applicants.stateProvinceCd)
+
+    // Validate NR Names
+    expect(store.state.stateModel.nameRequest.names).toBeDefined()
+    expect(store.state.stateModel.nameRequest.names[0].name).toBe(nrData.names[0].name)
+    expect(store.state.stateModel.nameRequest.names[0].state).toBe(nrData.names[0].state)
+    expect(store.state.stateModel.nameRequest.names[1].name).toBe(nrData.names[1].name)
+    expect(store.state.stateModel.nameRequest.names[1].state).toBe(nrData.names[1].state)
+
+    // Validate Approved Name
+    expect(store.state.stateModel.nameRequestApprovedName).toBe(nrData.names[0].name)
   })
 
   it('shows confirm popup if exiting before saving changes', async () => {

--- a/tests/unit/EntityInfo.spec.ts
+++ b/tests/unit/EntityInfo.spec.ts
@@ -12,11 +12,9 @@ const mockEntityInfo = [
     numberedDesc: 'Numbered Cooperative Association',
     tempId: 'T1234567',
     nameRequest: {
-      nrNumber: 'NR 1234567',
-      details: {
-        approvedName: 'Xyz Ltd.'
-      }
-    }
+      nrNum: 'NR 1234567'
+    },
+    nameRequestApprovedName: 'Xyz Ltd.'
   },
   {
     entityType: 'BEN',
@@ -27,11 +25,9 @@ const mockEntityInfo = [
     numberedDesc: 'Numbered Benefit Company',
     tempId: 'T1234567',
     nameRequest: {
-      nrNumber: 'NR 1234567',
-      details: {
-        approvedName: 'Xyz Ltd.'
-      }
-    }
+      nrNum: 'NR 1234567'
+    },
+    nameRequestApprovedName: 'Xyz Ltd.'
   },
   {
     entityType: 'BC',
@@ -42,11 +38,9 @@ const mockEntityInfo = [
     numberedDesc: 'Numbered Limited Company',
     tempId: 'T1234567',
     nameRequest: {
-      nrNumber: 'NR 1234567',
-      details: {
-        approvedName: 'Xyz Ltd.'
-      }
-    }
+      nrNum: 'NR 1234567'
+    },
+    nameRequestApprovedName: 'Xyz Ltd.'
   },
   {
     entityType: 'ULC',
@@ -57,11 +51,9 @@ const mockEntityInfo = [
     numberedDesc: 'Numbered Unlimited Liability Company',
     tempId: 'T1234567',
     nameRequest: {
-      nrNumber: 'NR 1234567',
-      details: {
-        approvedName: 'Xyz Ltd.'
-      }
-    }
+      nrNum: 'NR 1234567'
+    },
+    nameRequestApprovedName: 'Xyz Ltd.'
   },
   {
     entityType: 'CC',
@@ -72,11 +64,9 @@ const mockEntityInfo = [
     numberedDesc: '',
     tempId: 'T1234567',
     nameRequest: {
-      nrNumber: 'NR 1234567',
-      details: {
-        approvedName: 'Xyz Ltd.'
-      }
-    }
+      nrNum: 'NR 1234567'
+    },
+    nameRequestApprovedName: 'Xyz Ltd.'
   }
 ]
 
@@ -88,7 +78,7 @@ const mockEntityInfo = [
 // warnings, which should be cleaned up.
 //
 for (const mock of mockEntityInfo) {
-  describe(`Entity Info component with an NR for a ${mock.entityType}`, () => {
+  describe(`Entity Info component for a ${mock.entityType} with a NR`, () => {
     let wrapper: any
 
     beforeEach(() => {
@@ -96,11 +86,12 @@ for (const mock of mockEntityInfo) {
         tombstone: mock.tombstone,
         entityType: mock.entityType,
         tempId: mock.tempId,
-        nameRequest: mock.nameRequest
+        nameRequest: mock.nameRequest,
+        nameRequestApprovedName: mock.nameRequestApprovedName
       }, 'incorporation-define-company')
     })
 
-    it(`renders the Name Request header when the EntityType(${mock.entityType}) is present`, async () => {
+    it('renders the Name Request header', async () => {
       expect(wrapper.vm.$el.querySelector('#entity-legal-name').textContent)
         .toContain('Xyz Ltd.')
 
@@ -112,7 +103,7 @@ for (const mock of mockEntityInfo) {
     })
   })
 
-  describe(`Entity Info component without an NR for a ${mock.entityType}`, () => {
+  describe(`Entity Info component for a ${mock.entityType} without a NR`, () => {
     let wrapper: any
 
     beforeEach(() => {
@@ -120,22 +111,17 @@ for (const mock of mockEntityInfo) {
         tombstone: mock.tombstone,
         entityType: mock.entityType,
         tempId: mock.tempId,
-        nameRequest: {
-          nrNumber: null,
-          details: {
-            approvedName: null
-          }
-        }
+        nameRequest: { nrNum: null },
+        nameRequestApprovedName: null
       }, 'incorporation-define-company')
     })
 
-    it(`renders the Numbered Company header when the EntityType(${mock.entityType}) is present with no NR`,
-      async () => {
-        expect(wrapper.vm.$el.querySelector('#entity-legal-name').textContent)
-          .toContain(`${mock.numberedDesc}`)
+    it('renders the Numbered Company header', async () => {
+      expect(wrapper.vm.$el.querySelector('#entity-legal-name').textContent)
+        .toContain(`${mock.numberedDesc}`)
 
-        expect(wrapper.vm.$el.querySelector('#entity-description').textContent)
-          .toContain(`${mock.description} Incorporation Application`)
-      })
+      expect(wrapper.vm.$el.querySelector('#entity-description').textContent)
+        .toContain(`${mock.description} Incorporation Application`)
+    })
   })
 }

--- a/tests/unit/FileAndPayInvalidNameRequestDialog.spec.ts
+++ b/tests/unit/FileAndPayInvalidNameRequestDialog.spec.ts
@@ -10,10 +10,10 @@ const vuetify = new Vuetify({})
 const store = getVuexStore()
 
 store.state.stateModel.nameRequest = {
-  entityType: 'BEN',
-  nrNumber: 'NR 1234567',
-  details: { approvedName: 'My Name Request Inc.' }
+  legalType: 'BEN',
+  nrNum: 'NR 1234567'
 }
+store.state.stateModel.nameRequestApprovedName = 'My Name Request Inc.'
 
 describe('FileAndPayInvalidNameRequestDialog - Verify that dialog is displayed correctly', () => {
   it('displays dialog with the proper store data', async () => {

--- a/tests/unit/NameRequestInfo.spec.ts
+++ b/tests/unit/NameRequestInfo.spec.ts
@@ -13,29 +13,33 @@ const store = getVuexStore()
 document.body.setAttribute('data-app', 'true')
 
 const mockNrData = {
-  nrNumber: 'NR 1234567',
-  entityType: 'BEN',
-  filingId: null,
-  applicant: {
-    addressLine1: '45 Frasier Drive',
-    addressLine2: null,
-    addressLine3: null,
+  applicants: {
+    addrLine1: '45 Frasier Drive',
+    addrLine2: null,
+    addrLine3: null,
     city: 'Victoria',
-    countryTypeCode: 'CA',
-    postalCode: 'V9E 2A1',
-    stateProvinceCode: 'BC',
+    countryTypeCd: 'CA',
+    postalCd: 'V9E 2A1',
+    stateProvinceCd: 'BC',
     emailAddress: 'test@gov.bc.ca',
     phoneNumber: '250-356-9090',
     firstName: 'John',
     middleName: 'Joe',
     lastName: 'Doe'
   },
-  details: {
-    approvedName: 'MADRONA BREAD BASKET INC.',
-    consentFlag: null,
-    expirationDate: '2020-06-24T07:00:00+00:00',
-    status: 'APPROVED'
-  }
+  consentFlag: null,
+  expirationDate: '2020-06-24T07:00:00+00:00',
+  legalType: 'BEN',
+  names: [
+    {
+      name: 'MADRONA BREAD BASKET INC.',
+      state: 'APPROVED'
+    }
+  ],
+  nrNum: 'NR 1234567',
+  request_action_cd: 'NEW',
+  state: 'APPROVED'
+  // }
 }
 
 describe('Name Request Info with a NR', () => {
@@ -46,7 +50,7 @@ describe('Name Request Info with a NR', () => {
     store.state.stateModel.entityType = 'BEN'
     // Temp Id will always be set with or without an NR
     store.state.stateModel.tempId = 'T1234567'
-    store.state.stateModel.nameRequest.nrNumber = mockNrData.nrNumber
+    store.state.stateModel.nameRequest.nrNum = mockNrData.nrNum
     wrapper = mount(NameRequestInfo, { vuetify, store })
   })
 
@@ -83,7 +87,8 @@ describe('Name Request Info with a NR', () => {
   })
 
   it('renders the Name Request information with data', async () => {
-    await wrapper.vm.$store.commit('mutateNameRequestState', { ...mockNrData })
+    await wrapper.vm.$store.commit('mutateNameRequest', { ...mockNrData })
+    await wrapper.vm.$store.commit('mutateNameRequestApprovedName', mockNrData.names[0].name )
 
     const nrListSelector = '#name-request-info ul li'
     const itemCount = wrapper.vm.$el.querySelectorAll(nrListSelector).length
@@ -103,7 +108,7 @@ describe('Name Request Info with a NR', () => {
   })
 
   it('renders the Name Request applicant information with data', async () => {
-    await wrapper.vm.$store.commit('mutateNameRequestState', { ...mockNrData })
+    await wrapper.vm.$store.commit('mutateNameRequest', { ...mockNrData })
 
     const nrListSelector = '#name-request-applicant-info ul li'
     const itemCount = wrapper.vm.$el.querySelectorAll(nrListSelector).length
@@ -136,9 +141,9 @@ describe('Name Request Info with a NR', () => {
 
   it('renders the Name Request applicant information with multi address line data', async () => {
     store.state.stateModel.nameRequest = { ...mockNrData }
-    store.state.stateModel.nameRequest.applicant.addressLine1 = 'line 1'
-    store.state.stateModel.nameRequest.applicant.addressLine2 = 'line 2'
-    store.state.stateModel.nameRequest.applicant.addressLine3 = 'line 3'
+    store.state.stateModel.nameRequest.applicants.addrLine1 = 'line 1'
+    store.state.stateModel.nameRequest.applicants.addrLine2 = 'line 2'
+    store.state.stateModel.nameRequest.applicants.addrLine3 = 'line 3'
     await Vue.nextTick()
 
     const nrListSelector = '#name-request-applicant-info ul li'
@@ -157,8 +162,9 @@ describe('Name Request Info with a NR', () => {
 
   it('renders the Name Request information with consent not required', async () => {
     store.state.stateModel.nameRequest = { ...mockNrData }
-    store.state.stateModel.nameRequest.details.status = 'CONDITIONAL'
-    store.state.stateModel.nameRequest.details.consentFlag = null
+    store.state.stateModel.nameRequest.state = 'CONDITIONAL'
+    store.state.stateModel.nameRequest.consentFlag = null
+    store.state.stateModel.nameRequestApprovedName = mockNrData.names[0].name
     await Vue.nextTick()
 
     const nrListSelector = '#name-request-info ul li'
@@ -181,8 +187,9 @@ describe('Name Request Info with a NR', () => {
 
   it('renders the Name Request information with consent received', async () => {
     store.state.stateModel.nameRequest = { ...mockNrData }
-    store.state.stateModel.nameRequest.details.status = 'CONDITIONAL'
-    store.state.stateModel.nameRequest.details.consentFlag = 'R'
+    store.state.stateModel.nameRequest.state = 'CONDITIONAL'
+    store.state.stateModel.nameRequest.consentFlag = 'R'
+    store.state.stateModel.nameRequestApprovedName = mockNrData.names[0].name
     await Vue.nextTick()
 
     const nrListSelector = '#name-request-info ul li'
@@ -205,8 +212,9 @@ describe('Name Request Info with a NR', () => {
 
   it('renders the Name Request information with consent waived', async () => {
     store.state.stateModel.nameRequest = { ...mockNrData }
-    store.state.stateModel.nameRequest.details.status = 'CONDITIONAL'
-    store.state.stateModel.nameRequest.details.consentFlag = 'N'
+    store.state.stateModel.nameRequest.state = 'CONDITIONAL'
+    store.state.stateModel.nameRequest.consentFlag = 'N'
+    store.state.stateModel.nameRequestApprovedName = mockNrData.names[0].name
     await Vue.nextTick()
 
     const nrListSelector = '#name-request-info ul li'
@@ -229,8 +237,9 @@ describe('Name Request Info with a NR', () => {
 
   it('renders the Name Request information with consent required', async () => {
     store.state.stateModel.nameRequest = { ...mockNrData }
-    store.state.stateModel.nameRequest.details.status = 'CONDITIONAL'
-    store.state.stateModel.nameRequest.details.consentFlag = 'Y'
+    store.state.stateModel.nameRequest.state = 'CONDITIONAL'
+    store.state.stateModel.nameRequest.consentFlag = 'Y'
+    store.state.stateModel.nameRequestApprovedName = mockNrData.names[0].name
     await Vue.nextTick()
 
     const nrListSelector = '#name-request-info ul li'
@@ -261,7 +270,7 @@ describe('Name Request Info component without a NR', () => {
     store.state.stateModel.entityType = 'BEN'
     // Temp Id will always be set with or without an NR
     store.state.stateModel.tempId = 'T1234567'
-    store.state.stateModel.nameRequest.nrNumber = null
+    store.state.stateModel.nameRequest.nrNum = null
     wrapper = mount(NameRequestInfo, { vuetify, store })
   })
 
@@ -304,7 +313,7 @@ describe('Name Request Info component - Name Translation section', () => {
     store.state.stateModel.entityType = 'BEN'
     // Temp Id will always be set with or without an NR
     store.state.stateModel.tempId = 'T1234567'
-    store.state.stateModel.nameRequest.nrNumber = null
+    store.state.stateModel.nameRequest.nrNum = null
     wrapper = mount(NameRequestInfo, { vuetify, store })
   })
 
@@ -313,8 +322,6 @@ describe('Name Request Info component - Name Translation section', () => {
   })
 
   it('renders the option for name translation', async () => {
-    await wrapper.vm.$store.commit('mutateNameRequestState', { ...mockNrData })
-
     expect(wrapper.find('#name-translation-info').exists()).toBeTruthy()
     expect(wrapper.vm.hasNameTranslation).toBe(false)
 
@@ -322,9 +329,7 @@ describe('Name Request Info component - Name Translation section', () => {
     expect(wrapper.findComponent(ListNameTranslations).exists()).toBeFalsy()
   })
 
-  it('renders the add name translation component', async () => {
-    await wrapper.vm.$store.commit('mutateNameRequestState', { ...mockNrData })
-
+  it('renders the Add Name Translation component', async () => {
     expect(wrapper.find('#name-translation-info').exists()).toBeTruthy()
     expect(wrapper.vm.hasNameTranslation).toBe(false)
 
@@ -334,12 +339,11 @@ describe('Name Request Info component - Name Translation section', () => {
     expect(wrapper.findComponent(ListNameTranslations).exists()).toBeFalsy()
   })
 
-  it('renders the list name translation component', async () => {
+  it('renders the List Name Translation component', async () => {
     await wrapper.vm.$store.commit('mutateNameTranslation', [
       'Mock Name Translation',
       'Another Mock Name Translation'
     ])
-    await wrapper.vm.$store.commit('mutateNameRequestState', { ...mockNrData })
 
     expect(wrapper.find('#name-translation-info').exists()).toBeTruthy()
     expect(wrapper.vm.hasNameTranslation).toBe(true)

--- a/tests/unit/filing-template-mixin.spec.ts
+++ b/tests/unit/filing-template-mixin.spec.ts
@@ -52,7 +52,6 @@ describe('Registration Filing', () => {
 
     // populate store
     store.state.stateModel.tempId = 'T1234567'
-
     store.state.stateModel.registration.businessAddress = {
       deliveryAddress: {
         addressCity: 'Alpha',
@@ -73,30 +72,24 @@ describe('Registration Filing', () => {
         streetAddressAdditional: 'Suite 2'
       }
     }
-
     store.state.stateModel.registration.naics = {
       naicsCode: '12345',
       naicsDescription: 'Some NAICS Description'
     }
-
     store.state.stateModel.nameRequest = {
-      entityType: 'SP',
-      nrNumber: 'NR 1234567',
-      details: { approvedName: 'My Approved Name' }
+      legalType: 'SP',
+      nrNum: 'NR 1234567'
     }
-
+    store.state.stateModel.nameRequestApprovedName = 'My Approved Name'
     store.state.stateModel.businessContact = {
       email: 'eleven@example.com',
       phone: '(111) 222-3333',
       extension: '444'
     }
-
     store.state.stateModel.entityType = 'SP' // sole prop
     store.state.stateModel.registration.businessType = 'SP' // not DBA
-
     store.state.stateModel.registration.businessNumber = '111222333'
     store.state.stateModel.registration.businessTypeConfirm = false
-
     store.state.stateModel.addPeopleAndRoleStep.orgPeople = [
       {
         officer: {


### PR DESCRIPTION
*Issue #:* bcgov/entity#14403

*Description of changes:*
- log invalid NR message
- removed CCC/CC workaround (obsolete)
- removed generateNameRequestState()
- renamed getApprovedName -> getNrApprovedName
- removed getNameRequestDetails
- removed getNameRequestApplicant
- simplified/cleaned up NameRequestInfo.vue
- cleaned up NR interfaces to make actual data
- used NR types in mixin, service, etc
- updated isNrValid()
- updated unit tests
- app version = 4.3.19

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).