### PR TITLE
14789 Create UI throwing schema error when court order is not entered

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "4.5.0",
+      "version": "4.5.1",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/Actions.vue
+++ b/src/components/common/Actions.vue
@@ -174,6 +174,7 @@ export default class Actions extends Vue {
       // clear flag
       this.setHaveChanges(false)
     } catch (error) {
+      console.log('Error on onClickSave(): ', error)
       this.$root.$emit('save-error-event', error)
       this.setIsSaving(false)
       return

--- a/src/components/common/Actions.vue
+++ b/src/components/common/Actions.vue
@@ -203,6 +203,7 @@ export default class Actions extends Vue {
       // clear flag
       this.setHaveChanges(false)
     } catch (error) {
+      console.log('Error on onClickSaveResume(): ', error)
       this.$root.$emit('save-error-event', error)
       this.setIsSavingResuming(false)
       return
@@ -246,6 +247,7 @@ export default class Actions extends Vue {
         try {
           await this.validateNameRequest(this.getNameRequestNumber)
         } catch (error) {
+          console.log('Error on onClickFilePay(): ', error)
           this.setIsFilingPaying(false)
           return
         }
@@ -261,6 +263,7 @@ export default class Actions extends Vue {
         // clear flag
         this.setHaveChanges(false)
       } catch (error) {
+        console.log('Error on onClickFilePay(): ', error)
         this.$root.$emit('save-error-event', error)
         this.setIsFilingPaying(false)
         return

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -82,7 +82,6 @@ export default class FilingTemplateMixin extends DateMixin {
   @Getter getStaffPaymentStep!: StaffPaymentStepIF
   @Getter getCourtOrderStep!: CourtOrderStepIF
   @Getter isRoleStaff!: boolean
-  @Getter isBaseCompany!: boolean
   @Getter getDissolutionStatementStep!: DissolutionStatementIF
   @Getter getDissolutionCustodian!: OrgPersonIF
   @Getter getFolioNumber!: string

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -82,7 +82,7 @@ export default class FilingTemplateMixin extends DateMixin {
   @Getter getStaffPaymentStep!: StaffPaymentStepIF
   @Getter getCourtOrderStep!: CourtOrderStepIF
   @Getter isRoleStaff!: boolean
-  @Getter isTypeBcUlcCompany!: boolean
+  @Getter isBaseCompany!: boolean
   @Getter getDissolutionStatementStep!: DissolutionStatementIF
   @Getter getDissolutionCustodian!: OrgPersonIF
   @Getter getFolioNumber!: string
@@ -198,15 +198,12 @@ export default class FilingTemplateMixin extends DateMixin {
           agreementType: this.getIncorporationAgreementStep.agreementType
         }
 
-        if (this.isTypeBcUlcCompany) {
-          // Add Court Order ONLY when it is required and applied.
-          const courtOrder = this.getCourtOrderStep.courtOrder
-          if (courtOrder.hasPlanOfArrangement || courtOrder.fileNumber) {
-            filing.incorporationApplication.courtOrder = {
-              fileNumber: courtOrder.fileNumber,
-              effectOfOrder: courtOrder.hasPlanOfArrangement ? EffectOfOrders.PLAN_OF_ARRANGEMENT : '',
-              hasPlanOfArrangement: courtOrder.hasPlanOfArrangement
-            }
+        const courtOrder = this.getCourtOrderStep.courtOrder
+        if (courtOrder && (courtOrder.hasPlanOfArrangement || courtOrder.fileNumber)) {
+          filing.incorporationApplication.courtOrder = {
+            fileNumber: courtOrder.fileNumber,
+            effectOfOrder: courtOrder.hasPlanOfArrangement ? EffectOfOrders.PLAN_OF_ARRANGEMENT : '',
+            hasPlanOfArrangement: courtOrder.hasPlanOfArrangement
           }
         }
         break
@@ -318,11 +315,9 @@ export default class FilingTemplateMixin extends DateMixin {
         this.setIncorporationAgreementStepData({
           agreementType: draftFiling.incorporationApplication.incorporationAgreement?.agreementType
         })
-
-        if (this.isTypeBcUlcCompany) {
-          this.setCourtOrderFileNumber(draftFiling.incorporationApplication.courtOrder?.fileNumber || '')
-          this.setHasPlanOfArrangement(draftFiling.incorporationApplication.courtOrder?.hasPlanOfArrangement || false)
-        }
+        // set courtOrder attribute
+        this.setCourtOrderFileNumber(draftFiling.incorporationApplication.courtOrder?.fileNumber || '')
+        this.setHasPlanOfArrangement(draftFiling.incorporationApplication.courtOrder?.hasPlanOfArrangement || false)
         break
     }
 

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -199,11 +199,14 @@ export default class FilingTemplateMixin extends DateMixin {
         }
 
         if (this.isTypeBcUlcCompany) {
+          // Add Court Order ONLY when it is required and applied.
           const courtOrder = this.getCourtOrderStep.courtOrder
-          filing.incorporationApplication.courtOrder = {
-            fileNumber: courtOrder.fileNumber,
-            effectOfOrder: courtOrder.hasPlanOfArrangement ? EffectOfOrders.PLAN_OF_ARRANGEMENT : '',
-            hasPlanOfArrangement: courtOrder.hasPlanOfArrangement
+          if (courtOrder.hasPlanOfArrangement || courtOrder.fileNumber) {
+            filing.incorporationApplication.courtOrder = {
+              fileNumber: courtOrder.fileNumber,
+              effectOfOrder: courtOrder.hasPlanOfArrangement ? EffectOfOrders.PLAN_OF_ARRANGEMENT : '',
+              hasPlanOfArrangement: courtOrder.hasPlanOfArrangement
+            }
           }
         }
         break
@@ -317,8 +320,8 @@ export default class FilingTemplateMixin extends DateMixin {
         })
 
         if (this.isTypeBcUlcCompany) {
-          this.setCourtOrderFileNumber(draftFiling.incorporationApplication.courtOrder?.fileNumber)
-          this.setHasPlanOfArrangement(draftFiling.incorporationApplication.courtOrder?.hasPlanOfArrangement)
+          this.setCourtOrderFileNumber(draftFiling.incorporationApplication.courtOrder?.fileNumber || '')
+          this.setHasPlanOfArrangement(draftFiling.incorporationApplication.courtOrder?.hasPlanOfArrangement || false)
         }
         break
     }
@@ -714,8 +717,8 @@ export default class FilingTemplateMixin extends DateMixin {
     this.setAffidavit(uploadAffidavit)
 
     // restore Court Order data
-    this.setCourtOrderFileNumber(draftFiling.dissolution.courtOrder?.fileNumber)
-    this.setHasPlanOfArrangement(draftFiling.dissolution.courtOrder?.hasPlanOfArrangement)
+    this.setCourtOrderFileNumber(draftFiling.dissolution.courtOrder?.fileNumber || '')
+    this.setHasPlanOfArrangement(draftFiling.dissolution.courtOrder?.hasPlanOfArrangement || false)
 
     // NB: do not restore/overwrite Folio Number - just use the FN from auth info (see App.vue)
 

--- a/src/store/getters/state-getters.ts
+++ b/src/store/getters/state-getters.ts
@@ -493,7 +493,8 @@ export const isIncorporationApplicationValid = (state: StateIF): boolean => {
   const isBaseStepsValid = (
     getCreateShareStructureStep(state).valid &&
     getEffectiveDateTime(state).valid &&
-    getIncorporationAgreementStep(state).valid
+    getIncorporationAgreementStep(state).valid &&
+    getCourtOrderStep(state).valid
   )
 
   // Coop steps

--- a/src/views/Incorporation/IncorporationReviewConfirm.vue
+++ b/src/views/Incorporation/IncorporationReviewConfirm.vue
@@ -142,7 +142,7 @@
           :autoValidation="getValidateSteps"
           :draftCourtOrderNumber="getCourtOrderStep.courtOrder.fileNumber"
           :hasDraftPlanOfArrangement="getCourtOrderStep.courtOrder.hasPlanOfArrangement"
-          :courtOrderNumberRequired="true"
+          :courtOrderNumberRequired="false"
           :invalidSection="isCourtOrderInvalid"
           @emitCourtNumber="setCourtOrderFileNumber($event)"
           @emitPoa="setHasPlanOfArrangement($event)"

--- a/src/views/Incorporation/IncorporationReviewConfirm.vue
+++ b/src/views/Incorporation/IncorporationReviewConfirm.vue
@@ -125,7 +125,7 @@
     </section>
 
     <!-- Court Order and Plan of Arrangement -->
-    <section id="court-order-poa-section" class="mt-10" v-if="isTypeBcUlcCompany">
+    <section id="court-order-poa-section" class="mt-10" v-if="isBaseCompany">
       <header>
         <h2>Court Order and Plan of Arrangement</h2>
         <p class="mt-4">

--- a/tests/unit/Actions.spec.ts
+++ b/tests/unit/Actions.spec.ts
@@ -143,6 +143,7 @@ describe('Emits error event if NR validation fails in file and pay', () => {
     store.state.stateModel.createShareStructureStep = { valid: true }
     store.state.stateModel.incorporationAgreementStep = { valid: true }
     store.state.stateModel.effectiveDateTime = { valid: true }
+    store.state.stateModel.courtOrderStep = { valid: true }
 
     const localVue = createLocalVue()
     localVue.use(VueRouter)

--- a/tests/unit/IncorporationReviewConfirm.spec.ts
+++ b/tests/unit/IncorporationReviewConfirm.spec.ts
@@ -56,7 +56,7 @@ for (const test of reviewConfirmTestCases) {
       expect(wrapper.find('#certify-section').exists()).toBe(true)
     })
 
-    it('displays Court Order and Plan of Arrangement section only for ULC', () => {
+    it('displays Court Order and Plan of Arrangement section only for BEN, ULC, CC, BC', () => {
       wrapper = shallowWrapperFactory(
         IncorporationReviewConfirm,
         null,
@@ -67,8 +67,7 @@ for (const test of reviewConfirmTestCases) {
         IncorporationResources
       )
 
-      const expected = (test.entityType === 'ULC')
-      expect(wrapper.find('#court-order-poa-section').exists()).toBe(test.entityType === 'ULC')
+      expect(wrapper.find('#court-order-poa-section').exists()).toBe(['BEN', 'ULC', 'CC', 'BC'].includes(test.entityType))
     })
 
     // FUTURE: Expand unit testing for validation on step 5. Include routing to appropriate steps from error links.

--- a/tests/unit/filing-template-mixin.spec.ts
+++ b/tests/unit/filing-template-mixin.spec.ts
@@ -493,3 +493,41 @@ describe('Staff Payment', () => {
     })
   })
 })
+
+for (const entityType of ['BEN', 'BC', 'CC', 'ULC']) {
+  describe('Base corporate incorporation filing: ' + entityType, () => {
+    // load coop filing data
+    let ia = require('./test-data/incorpApp.json')
+    ia.filing.business.legalType = entityType
+    ia.filing.incorporationApplication.nameRequest.legalType = entityType
+    let wrapper: any
+
+    beforeEach(() => {
+      wrapper = wrapperFactory(MixinTester, null, {})
+    })
+
+    afterEach(() => {
+      wrapper.destroy()
+    })
+
+    it('courtOrder attribute is not required', () => {
+      wrapper.vm.parseIncorporationDraft(ia.filing)
+      const filing = wrapper.vm.buildIncorporationFiling()
+      expect(filing.incorporationApplication).not.toHaveProperty('courtNumber')
+    })
+
+    it('can include courtOrder attribute', () => {
+      ia.filing.incorporationApplication.courtOrder = {
+        'fileNumber': '12034567',
+        'hasPlanOfArrangement': true
+      }
+      wrapper.vm.parseIncorporationDraft(ia.filing)
+      const filing = wrapper.vm.buildIncorporationFiling()
+      expect(filing.incorporationApplication.courtOrder).toEqual({
+        fileNumber: '12034567',
+        effectOfOrder: 'planOfArrangement',
+        hasPlanOfArrangement: true
+      })
+    })
+  })
+}

--- a/tests/unit/test-data/incorpApp.json
+++ b/tests/unit/test-data/incorpApp.json
@@ -1,0 +1,169 @@
+{
+	"filing": {
+		"business": {
+			"identifier": "id123abc",
+			"legalType": "BC"
+		},
+		"documents": [],
+		"header": {
+			"affectedFilings": [],
+			"availableOnPaperOnly": false,
+			"certifiedBy": "BCREGTEST Rosette ELEVEN",
+			"colinIds": [],
+			"comments": [],
+			"date": "2021-10-26T20:30:00.230581+00:00",
+			"effectiveDate": "2021-10-26T20:30:00.230609+00:00",
+			"filingId": 112950,
+			"inColinOnly": false,
+			"isCorrected": false,
+			"isCorrectionPending": false,
+			"isFutureEffective": false,
+			"name": "incorporationApplication",
+			"paymentStatusCode": "COMPLETED",
+			"paymentToken": "13408",
+			"status": "PAID",
+			"submitter": "bcsc/iaptaestlb6ita56a3sqwhvvdulxqsl5"
+		},
+		"incorporationApplication": {
+			"contactPoint": {
+				"email": "eleven@email.com",
+				"phone": "(555) 555-5555"
+			},
+			"nameRequest": {
+				"legalName": "TEST INC IA",
+				"legalType": "CP",
+				"nrNumber": "NR 5269136"
+			},
+			"nameTranslations": [],
+			"offices": {
+				"registeredOffice": {
+					"deliveryAddress": {
+						"addressCity": "Victoria",
+						"addressCountry": "CA",
+						"addressRegion": "BC",
+						"deliveryInstructions": "",
+						"postalCode": "V8W 3H2",
+						"streetAddress": "735 Broughton St",
+						"streetAddressAdditional": ""
+					},
+					"mailingAddress": {
+						"addressCity": "Victoria",
+						"addressCountry": "CA",
+						"addressRegion": "BC",
+						"deliveryInstructions": "",
+						"postalCode": "V8W 3H2",
+						"streetAddress": "735 Broughton St",
+						"streetAddressAdditional": ""
+					}
+				}
+			},
+			"parties": [
+				{
+					"deliveryAddress": {
+						"addressCity": "Smithers",
+						"addressCountry": "CA",
+						"addressRegion": "BC",
+						"postalCode": "V0J 2N2",
+						"streetAddress": "5-6421 Airport Rd",
+						"streetAddressAdditional": ""
+					},
+					"mailingAddress": {
+						"addressCity": "Smithers",
+						"addressCountry": "CA",
+						"addressRegion": "BC",
+						"postalCode": "V0J 2N2",
+						"streetAddress": "5-6421 Airport Rd",
+						"streetAddressAdditional": ""
+					},
+					"officer": {
+						"email": "a@test.com",
+						"firstName": "BCREGTEST Rosette",
+						"id": "79825708-ca1d-41f6-86b0-fa7f30f93c5d",
+						"lastName": "ELEVEN",
+						"middleName": "",
+						"organizationName": "",
+						"partyType": "person"
+					},
+					"roles": [
+						{
+							"appointmentDate": "2021-10-26",
+							"roleType": "Completing Party"
+						},
+						{
+							"appointmentDate": "2021-10-26",
+							"roleType": "Director"
+						}
+					]
+				},
+				{
+					"deliveryAddress": {
+						"addressCity": "Victoria",
+						"addressCountry": "CA",
+						"addressRegion": "BC",
+						"deliveryInstructions": "",
+						"postalCode": "V8W 3H2",
+						"streetAddress": "735 Broughton St",
+						"streetAddressAdditional": ""
+					},
+					"mailingAddress": {
+						"addressCity": "Victoria",
+						"addressCountry": "CA",
+						"addressRegion": "BC",
+						"deliveryInstructions": "",
+						"postalCode": "V8W 3H2",
+						"streetAddress": "735 Broughton St",
+						"streetAddressAdditional": ""
+					},
+					"officer": {
+						"firstName": "John",
+						"id": "7b755f98-c183-4e04-96fd-027715f06c49",
+						"lastName": "Test",
+						"middleName": "",
+						"organizationName": "",
+						"partyType": "person"
+					},
+					"roles": [
+						{
+							"appointmentDate": "2021-10-26",
+							"roleType": "Director"
+						}
+					]
+				},
+				{
+					"deliveryAddress": {
+						"addressCity": "Victoria",
+						"addressCountry": "CA",
+						"addressRegion": "BC",
+						"deliveryInstructions": "",
+						"postalCode": "V8W 3H2",
+						"streetAddress": "735 Broughton St",
+						"streetAddressAdditional": ""
+					},
+					"mailingAddress": {
+						"addressCity": "Victoria",
+						"addressCountry": "CA",
+						"addressRegion": "BC",
+						"deliveryInstructions": "",
+						"postalCode": "V8W 3H2",
+						"streetAddress": "735 Broughton St",
+						"streetAddressAdditional": ""
+					},
+					"officer": {
+						"firstName": "Anna",
+						"id": "1d759481-7395-4826-87bc-666b5518d4d6",
+						"lastName": "Test",
+						"middleName": "",
+						"organizationName": "",
+						"partyType": "person"
+					},
+					"roles": [
+						{
+							"appointmentDate": "2021-10-26",
+							"roleType": "Director"
+						}
+					]
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14789

*Description of changes:*

Fix bug that caused schema error when submitting an incorporation application without a court order.

![14789_court_order_error_D](https://user-images.githubusercontent.com/25233684/210907712-3a460eda-e142-4be8-84ee-7840d8c2c26c.png)

Here's the relevant snippet of the payload that was causing the error:
```    
"courtOrder": {
      "fileNumber": "",
      "hasPlanOfArrangement": false
}
```

The fix removes the "courtOrder" attribute unless either the fileNumber is populated or "hasPlanOfArrangement" is true.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
