### PR TITLE
14788 Save and resume IA not saving the Records office info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "4.5.1",
+      "version": "4.5.2",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/AddEditOrgPerson.vue
+++ b/src/components/common/AddEditOrgPerson.vue
@@ -8,6 +8,7 @@
       <v-row no-gutters>
         <v-col cols="12" sm="3" class="pr-4 d-none d-sm-block">
           <!-- Title for org -->
+          <!-- check isTypeBcomp below ... needed? -->
           <label
             v-if="isOrg && isTypeBcomp"
             class="add-org-header"

--- a/src/components/common/AddEditOrgPerson.vue
+++ b/src/components/common/AddEditOrgPerson.vue
@@ -8,7 +8,6 @@
       <v-row no-gutters>
         <v-col cols="12" sm="3" class="pr-4 d-none d-sm-block">
           <!-- Title for org -->
-          <!-- check isTypeBcomp below ... needed? -->
           <label
             v-if="isOrg && isTypeBcomp"
             class="add-org-header"

--- a/src/components/common/AddEditOrgPerson.vue
+++ b/src/components/common/AddEditOrgPerson.vue
@@ -9,7 +9,7 @@
         <v-col cols="12" sm="3" class="pr-4 d-none d-sm-block">
           <!-- Title for org -->
           <label
-            v-if="isOrg && isTypeBcomp"
+            v-if="isOrg && isBaseCompany"
             class="add-org-header"
             :class="{'error-text': !addPersonOrgFormValid}"
           >
@@ -236,6 +236,7 @@ import { Component } from 'vue-property-decorator'
 import BaseAddress from 'sbc-common-components/src/components/BaseAddress.vue'
 import { ConfirmDialog } from '@bcrs-shared-components/confirm-dialog'
 import { AddEditOrgPersonMixin } from '@/mixins'
+import { Getter } from 'vuex-class'
 
 /** This is a sub-component of PeopleAndRoles. */
 @Component({
@@ -249,6 +250,7 @@ import { AddEditOrgPersonMixin } from '@/mixins'
   ]
 })
 export default class AddEditOrgPerson extends Vue {
+  @Getter isBaseCompany!: boolean
   //
   // NB: see mixin for common properties, methods, etc.
   //

--- a/src/components/common/OfficeAddresses.vue
+++ b/src/components/common/OfficeAddresses.vue
@@ -230,7 +230,7 @@ export default class OfficeAddresses extends Vue {
   @Prop({ default: false }) readonly showErrors!: boolean
 
   @Getter getDefineCompanyStep!: DefineCompanyIF
-  @Getter isTypeBcomp!: boolean
+  @Getter isBaseCompany!: boolean
   @Getter isTypeCoop!: boolean
   @Getter getEntityType!: CorpTypeCd
 
@@ -311,8 +311,8 @@ export default class OfficeAddresses extends Vue {
           )
         }
       }
-
-      if (this.isTypeBcomp) {
+      // check isTypeBcomp below ... needed?
+      if (this.isBaseCompany) {
         this.recMailingAddress = this.addresses.recordsOffice?.mailingAddress
         this.recDeliveryAddress = this.addresses.recordsOffice?.deliveryAddress
 

--- a/src/components/common/OfficeAddresses.vue
+++ b/src/components/common/OfficeAddresses.vue
@@ -311,7 +311,6 @@ export default class OfficeAddresses extends Vue {
           )
         }
       }
-      // check isTypeBcomp below ... needed?
       if (this.isBaseCompany) {
         this.recMailingAddress = this.addresses.recordsOffice?.mailingAddress
         this.recDeliveryAddress = this.addresses.recordsOffice?.deliveryAddress

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -53,7 +53,6 @@ import {
  */
 @Component({})
 export default class FilingTemplateMixin extends DateMixin {
-  @Getter isTypeBcomp!: boolean
   @Getter isTypeCoop!: boolean
   @Getter isTypeSoleProp!: boolean
   @Getter getAffidavitStep!: UploadAffidavitIF

--- a/src/views/Incorporation/IncorporationDefineCompany.vue
+++ b/src/views/Incorporation/IncorporationDefineCompany.vue
@@ -159,7 +159,7 @@ import OfficeAddresses from '@/components/common/OfficeAddresses.vue'
 export default class IncorporationDefineCompany extends Vue {
   @Getter isEntityType!: boolean
   @Getter isPremiumAccount!: boolean
-  @Getter isTypeBcomp!: boolean
+  @Getter isBaseCompany!: boolean
   @Getter isTypeCoop!: boolean
   @Getter getDefineCompanyStep!: DefineCompanyIF
   @Getter getShowErrors!: boolean
@@ -214,7 +214,7 @@ export default class IncorporationDefineCompany extends Vue {
       streetAddressAdditional: ''
     }
 
-    if (this.isTypeBcomp) {
+    if (this.isBaseCompany) {
       this.setOfficeAddresses({
         registeredOffice: {
           mailingAddress: defaultAddress,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14788

When a user starts any IA filing say for ex a ULC filing and then hit on Save and Resume, Now upon returning and resuming the filing from the draft state the entered Records office addresses aren't being saved.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
