### PR TITLE
14798 Changed restorations to use "registration" people-roles components + misc updates (incremental)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "4.5.4",
+  "version": "4.5.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "4.5.4",
+      "version": "4.5.5",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "4.5.4",
+  "version": "4.5.5",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/AddEditOrgPerson.vue
+++ b/src/components/common/AddEditOrgPerson.vue
@@ -65,7 +65,7 @@
           >
             <!-- Person's Name -->
             <article v-if="isPerson">
-              <div class="font-weight-bold">Person's Name</div>
+              <label>Person's Name</label>
               <div class="form__row three-column mt-4">
                 <!-- NB: only staff can change Completing Party names -->
                 <v-text-field
@@ -100,7 +100,7 @@
 
             <!-- Org's Name -->
             <article v-if="isOrg">
-              <div class="font-weight-bold">Corporation or Firm Name</div>
+              <label>Corporation or Firm Name</label>
               <div class="org-name-container mt-4">
                 <v-text-field
                   filled
@@ -115,13 +115,10 @@
 
             <!-- Roles -->
             <article class="mt-2">
-              <div class="font-weight-bold">{{ getPeopleAndRolesResource.rolesTitle || 'Roles' }}</div>
-              <div v-if="getPeopleAndRolesResource.rolesSubtitle">
-                {{ getPeopleAndRolesResource.rolesSubtitle }}
-              </div>
+              <label>Roles</label>
               <div class="form__row three-column mt-4">
                 <v-card flat rounded="sm" class="item gray-card px-4">
-                  <v-row no-gutters class="align-center mt-4">
+                  <v-row no-gutters class="align-center mt-5">
                     <v-col cols="4" v-if="showCompletingPartyRole">
                       <v-checkbox
                         id="cp-checkbox"
@@ -159,76 +156,14 @@
                         @click="updateSameAsMailingChkBox()"
                       />
                     </v-col>
-
-                    <v-col cols="4" v-if="showHeirLegalRepRole">
-                      <v-checkbox
-                        id="heir-legal-rep-checkbox"
-                        class="mt-0"
-                        v-model="selectedRoles"
-                        :value="RoleTypes.HEIR_LEGAL_REP"
-                        :label="RoleTypes.HEIR_LEGAL_REP"
-                        :disabled="disableHeirLegalRepRole"
-                        :rules="enableRules ? roleRules : []"
-                      />
-                    </v-col>
-
-                    <v-col cols="4" v-if="showOfficerRole">
-                      <v-checkbox
-                        id="officer-checkbox"
-                        class="mt-0"
-                        v-model="selectedRoles"
-                        :value="RoleTypes.OFFICER"
-                        :label="RoleTypes.OFFICER"
-                        :disabled="disableOfficerRole"
-                        :rules="enableRules ? roleRules : []"
-                      />
-                    </v-col>
-
-                    <v-col cols="4" v-if="showShareholderRole">
-                      <v-checkbox
-                        id="shareholder-checkbox"
-                        class="mt-0"
-                        v-model="selectedRoles"
-                        :value="RoleTypes.SHAREHOLDER"
-                        :label="RoleTypes.SHAREHOLDER"
-                        :disabled="disableShareholderRole"
-                        :rules="enableRules ? roleRules : []"
-                      />
-                    </v-col>
-
-                    <v-col cols="4" v-if="showCourtOrderedPartyRole">
-                      <v-checkbox
-                        id="court-ordered-party-checkbox"
-                        class="mt-0"
-                        v-model="selectedRoles"
-                        :value="RoleTypes.COURT_ORDERED_PARTY"
-                        :label="RoleTypes.COURT_ORDERED_PARTY"
-                        :disabled="disableCourtOrderedPartyRole"
-                        :rules="enableRules ? roleRules : []"
-                      />
-                    </v-col>
-
-                    <v-col cols="4" v-if="showOtherRole">
-                      <v-checkbox
-                        id="other-checkbox"
-                        class="mt-0"
-                        v-model="selectedRoles"
-                        :value="RoleTypes.OTHER"
-                        :label="RoleTypes.OTHER"
-                        :disabled="disableOtherRole"
-                        :rules="enableRules ? roleRules : []"
-                      />
-                    </v-col>
                   </v-row>
                 </v-card>
               </div>
             </article>
 
-            <!-- *** TODO: add email address here for restorations -->
-
             <!-- Mailing Address -->
             <article class="mt-8">
-              <div class="font-weight-bold">Mailing Address</div>
+              <label>Mailing Address</label>
               <MailingAddress
                 ref="mailingAddressNew"
                 class="mt-4"
@@ -254,8 +189,8 @@
                 v-model="inheritMailingAddress"
               />
 
-              <article v-if="!inheritMailingAddress">
-                <div class="font-weight-bold mt-4">Delivery Address</div>
+              <article v-if="!inheritMailingAddress" class="mt-6">
+                <label>Delivery Address</label>
                 <DeliveryAddress
                   ref="deliveryAddressNew"
                   class="mt-4"
@@ -305,8 +240,6 @@ import { Component } from 'vue-property-decorator'
 import BaseAddress from 'sbc-common-components/src/components/BaseAddress.vue'
 import { ConfirmDialog } from '@bcrs-shared-components/confirm-dialog'
 import { AddEditOrgPersonMixin } from '@/mixins'
-import { PeopleAndRolesResourceIF } from '@/interfaces'
-import { Getter } from 'vuex-class'
 
 /** This is a sub-component of PeopleAndRoles. */
 @Component({
@@ -320,9 +253,6 @@ import { Getter } from 'vuex-class'
   ]
 })
 export default class AddEditOrgPerson extends Vue {
-  @Getter isBaseCompany!: boolean
-  @Getter getPeopleAndRolesResource!: PeopleAndRolesResourceIF
-
   //
   // NB: see mixin for common properties, methods, etc.
   //

--- a/src/components/common/PeopleAndRoles.vue
+++ b/src/components/common/PeopleAndRoles.vue
@@ -55,18 +55,6 @@
             <v-icon v-else>mdi-circle-small</v-icon>
             <span class="rule-item-txt">{{rule.text}}</span>
           </li>
-          <li v-if="rule.id === RuleIds.NUM_APPLICANT_PERSON" :key="index">
-            <v-icon v-if="validApplicantPerson" color="green darken-2" class="dir-valid">mdi-check</v-icon>
-            <v-icon v-else-if="getShowErrors" color="error" class="dir-invalid">mdi-close</v-icon>
-            <v-icon v-else>mdi-circle-small</v-icon>
-            <span class="rule-item-txt">{{rule.text}}</span>
-          </li>
-          <li v-if="rule.id === RuleIds.NUM_APPLICANT_ORG" :key="index">
-            <v-icon v-if="validApplicantOrg" color="green darken-2" class="dir-valid">mdi-check</v-icon>
-            <v-icon v-else-if="getShowErrors" color="error" class="dir-invalid">mdi-close</v-icon>
-            <v-icon v-else>mdi-circle-small</v-icon>
-            <span class="rule-item-txt">{{rule.text}}</span>
-          </li>
         </template>
       </ul>
     </section>
@@ -113,7 +101,6 @@
         <span>Add a Person</span>
       </v-btn>
 
-      <!-- *** TODO: do not add as Incorporator for restorations -->
       <v-btn
         v-if="getPeopleAndRolesResource.addOrganization"
         id="btn-add-organization"
@@ -124,7 +111,7 @@
         @click="addOrgPerson(RoleTypes.INCORPORATOR, PartyTypes.ORGANIZATION)"
       >
         <v-icon>mdi-domain-plus</v-icon>
-        <span>{{getPeopleAndRolesResource.addOrganization}}</span>
+        <span>Add a Corporation or Firm</span>
       </v-btn>
     </div>
 
@@ -136,6 +123,7 @@
           :initialValue="currentOrgPerson"
           :activeIndex="activeIndex"
           :existingCompletingParty="completingParty"
+          :addIncorporator="getPeopleAndRolesResource.addIncorporator"
           @addEditPerson="onAddEditPerson($event)"
           @removePerson="onRemovePerson($event)"
           @resetEvent="resetData()"
@@ -188,8 +176,16 @@ export default class PeopleAndRoles extends Vue {
     // first assign empty org/person object
     this.currentOrgPerson = cloneDeep(EmptyOrgPerson)
 
-    // assign pre-selected role if any
-    this.currentOrgPerson.roles = roleType ? [{ roleType }] : []
+    if (roleType) {
+      // a role was provided - pre-select it
+      this.currentOrgPerson.roles = [{ roleType }]
+    } else if (this.validNumCompletingParty && !this.getPeopleAndRolesResource.addIncorporator) {
+      // only Director role is possible - pre-select it
+      this.currentOrgPerson.roles = [{ roleType: RoleTypes.DIRECTOR }]
+    } else {
+      // no roles pre-selected
+      this.currentOrgPerson.roles = []
+    }
 
     // assign party type (org or person)
     this.currentOrgPerson.officer.partyType = partyType

--- a/src/components/common/RegAddEditOrgPerson.vue
+++ b/src/components/common/RegAddEditOrgPerson.vue
@@ -45,11 +45,12 @@
             </p>
           </v-card>
 
+          <div v-if="isCompletingParty && !isRoleStaff" class="mt-8" />
+
           <v-form
             lazy-validation
             ref="addPersonOrgForm"
             class="appoint-form"
-            :class="{ 'mt-8': isCompletingParty && !isRoleStaff}"
             v-model="addPersonOrgFormValid"
             v-on:submit.prevent
           >
@@ -180,40 +181,115 @@
 
             <!-- Roles -->
             <article class="mt-8">
-              <label>Roles</label>
-              <v-card flat rounded="sm" class="gray-card mt-4 px-4">
-                <v-row class="align-center">
-                  <v-col cols="4" v-if="showCompletingPartyRole" class="py-0">
-                    <v-checkbox
-                      class="mt-5"
-                      v-model="selectedRoles"
-                      :value="RoleTypes.COMPLETING_PARTY"
-                      :label="RoleTypes.COMPLETING_PARTY"
-                      :disabled="true"
-                    />
-                  </v-col>
+              <label>{{ getPeopleAndRolesResource.rolesTitle || 'Roles' }}</label>
+              <div v-if="getPeopleAndRolesResource.rolesSubtitle">
+                {{ getPeopleAndRolesResource.rolesSubtitle }}
+              </div>
+              <div class="form__row three-column mt-4">
+                <v-card flat rounded="sm" class="item gray-card px-4">
+                  <v-row no-gutters class="align-center mt-5">
+                    <v-col cols="4" v-if="showCompletingPartyRole">
+                      <v-checkbox
+                        id="cp-checkbox"
+                        class="mt-0"
+                        v-model="selectedRoles"
+                        :value="RoleTypes.COMPLETING_PARTY"
+                        :label="RoleTypes.COMPLETING_PARTY"
+                        :disabled="isTypeSoleProp || isTypePartnership"
+                      />
+                    </v-col>
 
-                  <v-col cols="4" v-if="showProprietorRole" class="py-0">
-                    <v-checkbox
-                      class="mt-5"
-                      v-model="selectedRoles"
-                      :value="RoleTypes.PROPRIETOR"
-                      :label="RoleTypes.PROPRIETOR"
-                      :disabled="true"
-                    />
-                  </v-col>
+                    <v-col cols="4" v-if="showProprietorRole">
+                      <v-checkbox
+                        id="proprietor-checkbox"
+                        class="mt-0"
+                        v-model="selectedRoles"
+                        :value="RoleTypes.PROPRIETOR"
+                        :label="RoleTypes.PROPRIETOR"
+                        :disabled="isTypeSoleProp || isTypePartnership"
+                      />
+                    </v-col>
 
-                  <v-col cols="4" v-if="showPartnerRole" class="py-0">
-                    <v-checkbox
-                      class="mt-5"
-                      v-model="selectedRoles"
-                      :value="RoleTypes.PARTNER"
-                      :label="RoleTypes.PARTNER"
-                      :disabled="true"
-                    />
-                  </v-col>
-                </v-row>
-              </v-card>
+                    <v-col cols="4" v-if="showPartnerRole">
+                      <v-checkbox
+                        id="partner-checkbox"
+                        class="mt-0"
+                        v-model="selectedRoles"
+                        :value="RoleTypes.PARTNER"
+                        :label="RoleTypes.PARTNER"
+                        :disabled="isTypeSoleProp || isTypePartnership"
+                      />
+                    </v-col>
+
+                    <v-col cols="4" v-if="showDirectorRole">
+                      <v-checkbox
+                        id="director-checkbox"
+                        class="mt-0"
+                        v-model="selectedRoles"
+                        :value="RoleTypes.DIRECTOR"
+                        :label="RoleTypes.DIRECTOR"
+                        :rules="enableRules ? roleRules : []"
+                        @click="updateSameAsMailingChkBox()"
+                      />
+                    </v-col>
+
+                    <v-col cols="4" v-if="showHeirLegalRepRole">
+                      <v-checkbox
+                        id="heir-legal-rep-checkbox"
+                        class="mt-0"
+                        v-model="selectedRoles"
+                        :value="RoleTypes.HEIR_LEGAL_REP"
+                        :label="RoleTypes.HEIR_LEGAL_REP"
+                        :rules="enableRules ? roleRules : []"
+                      />
+                    </v-col>
+
+                    <v-col cols="4" v-if="showOfficerRole">
+                      <v-checkbox
+                        id="officer-checkbox"
+                        class="mt-0"
+                        v-model="selectedRoles"
+                        :value="RoleTypes.OFFICER"
+                        :label="RoleTypes.OFFICER"
+                        :rules="enableRules ? roleRules : []"
+                      />
+                    </v-col>
+
+                    <v-col cols="4" v-if="showShareholderRole">
+                      <v-checkbox
+                        id="shareholder-checkbox"
+                        class="mt-0"
+                        v-model="selectedRoles"
+                        :value="RoleTypes.SHAREHOLDER"
+                        :label="RoleTypes.SHAREHOLDER"
+                        :rules="enableRules ? roleRules : []"
+                      />
+                    </v-col>
+
+                    <v-col cols="4" v-if="showCourtOrderedPartyRole">
+                      <v-checkbox
+                        id="court-ordered-party-checkbox"
+                        class="mt-0"
+                        v-model="selectedRoles"
+                        :value="RoleTypes.COURT_ORDERED_PARTY"
+                        :label="RoleTypes.COURT_ORDERED_PARTY"
+                        :rules="enableRules ? roleRules : []"
+                      />
+                    </v-col>
+
+                    <v-col cols="4" v-if="showOtherRole">
+                      <v-checkbox
+                        id="other-checkbox"
+                        class="mt-0"
+                        v-model="selectedRoles"
+                        :value="RoleTypes.OTHER"
+                        :label="RoleTypes.OTHER"
+                        :rules="enableRules ? roleRules : []"
+                      />
+                    </v-col>
+                  </v-row>
+                </v-card>
+              </div>
             </article>
 
             <!-- Email Address -->
@@ -237,7 +313,7 @@
               <label>Mailing Address</label>
               <MailingAddress
                 ref="mailingAddressNew"
-                class="mt-4 mb-n6"
+                class="mt-4"
                 :editing="true"
                 :schema="PersonAddressSchema"
                 :address="inProgressMailingAddress"
@@ -252,7 +328,7 @@
             </article>
 
             <!-- Delivery Address (for proprietors and partners only) -->
-            <div v-if="isProprietor || isPartner" class="mt-8">
+            <div v-if="isProprietor || isPartner">
               <v-checkbox
                 class="inherit-checkbox"
                 hide-details
@@ -260,11 +336,11 @@
                 v-model="inheritMailingAddress"
               />
 
-              <article v-if="!inheritMailingAddress" class="mt-8">
+              <article v-if="!inheritMailingAddress" class="mt-6">
                 <label>Delivery Address</label>
                 <DeliveryAddress
                   ref="deliveryAddressNew"
-                  class="mt-4 mb-n6"
+                  class="mt-4"
                   :editing="true"
                   :schema="PersonAddressSchema"
                   :address="inProgressDeliveryAddress"
@@ -281,19 +357,21 @@
             </div>
 
             <!-- Action Buttons -->
-            <div class="form__btns mt-10">
+            <div class="form__btns mt-6">
               <v-btn
+                id="btn-remove"
                 large outlined color="error"
-                class="btn-outlined-error btn-remove"
+                class="btn-outlined-error"
                 :disabled="isNaN(activeIndex)"
                 @click="emitRemovePerson(activeIndex)">Remove</v-btn>
               <v-btn
+                id="btn-done"
                 large color="primary"
-                class="ml-auto btn-done"
+                class="ml-auto"
                 @click="validateAddPersonOrgForm()">Done</v-btn>
               <v-btn
+                id="btn-cancel"
                 large outlined color="primary"
-                class="btn-cancel"
                 @click="resetAddPersonData(true)">Cancel</v-btn>
             </div>
           </v-form>
@@ -312,7 +390,6 @@ import { ConfirmDialog } from '@bcrs-shared-components/confirm-dialog'
 import { BusinessLookup } from '@bcrs-shared-components/business-lookup'
 import HelpContactUs from '@/components/Registration/HelpContactUs.vue'
 import { AddEditOrgPersonMixin } from '@/mixins'
-import { Rules } from '@/rules'
 import { BusinessLookupServices } from '@/services'
 import { VuetifyRuleFunction } from '@/types'
 
@@ -342,9 +419,6 @@ export default class RegAddEditOrgPerson extends Vue {
     v => !!v?.trim() || 'Business or corporation name is required',
     v => (v?.length <= 150) || 'Cannot exceed 150 characters' // maximum character count
   ]
-
-  // Rules for template
-  readonly Rules = Rules
 
   readonly BusinessLookupServices = BusinessLookupServices
 }

--- a/src/components/common/RegPeopleAndRoles.vue
+++ b/src/components/common/RegPeopleAndRoles.vue
@@ -36,6 +36,18 @@
             <v-icon v-else>mdi-circle-small</v-icon>
             <span class="rule-item-txt">{{rule.text}}</span>
           </li>
+          <li v-if="rule.id === RuleIds.NUM_APPLICANT_PERSON" :key="index">
+            <v-icon v-if="validApplicantPerson" color="green darken-2" class="dir-valid">mdi-check</v-icon>
+            <v-icon v-else-if="getShowErrors" color="error" class="dir-invalid">mdi-close</v-icon>
+            <v-icon v-else>mdi-circle-small</v-icon>
+            <span class="rule-item-txt">{{rule.text}}</span>
+          </li>
+          <li v-if="rule.id === RuleIds.NUM_APPLICANT_ORG" :key="index">
+            <v-icon v-if="validApplicantOrg" color="green darken-2" class="dir-valid">mdi-check</v-icon>
+            <v-icon v-else-if="getShowErrors" color="error" class="dir-invalid">mdi-close</v-icon>
+            <v-icon v-else>mdi-circle-small</v-icon>
+            <span class="rule-item-txt">{{rule.text}}</span>
+          </li>
         </template>
       </ul>
     </section>
@@ -50,11 +62,12 @@
     </template>
 
     <!-- Start by Adding the Completing Party -->
-    <div v-if="orgPersonList.length === 0">
+    <div v-if="(orgPersonList.length === 0) && requireCompletingParty">
       <v-btn
+        id="btn-start-add-cp"
         outlined
         color="primary"
-        class="btn-outlined-primary mt-6 btn-start-add-cp"
+        class="btn-outlined-primary mt-6"
         :disabled="showOrgPersonForm"
         @click="addOrgPerson(RoleTypes.COMPLETING_PARTY, PartyTypes.PERSON)"
       >
@@ -64,12 +77,13 @@
     </div>
 
     <!-- Add a Person or Organization -->
-    <div v-if="orgPersonList.length > 0">
+    <div v-if="(orgPersonList.length > 0) || !requireCompletingParty">
       <v-btn
-        v-if="!validNumCompletingParty"
+        v-if="requireCompletingParty && !validNumCompletingParty"
+        id="btn-add-cp"
         outlined
         color="primary"
-        class="btn-outlined-primary mt-6 btn-add-cp"
+        class="btn-outlined-primary mt-6"
         :disabled="showOrgPersonForm"
         @click="addOrgPerson(RoleTypes.COMPLETING_PARTY, PartyTypes.PERSON)"
       >
@@ -80,9 +94,10 @@
       <template v-if="isTypeSoleProp">
         <v-btn
           v-if="!validNumProprietors"
+          id="btn-add-person"
           outlined
           color="primary"
-          class="btn-outlined-primary mt-6 btn-add-person"
+          class="btn-outlined-primary mt-6"
           :disabled="showOrgPersonForm"
           @click="addOrgPerson(RoleTypes.PROPRIETOR, PartyTypes.PERSON)"
         >
@@ -92,9 +107,10 @@
 
         <v-btn
           v-if="!validNumProprietors"
+          id="btn-add-organization"
           outlined
           color="primary"
-          class="btn-outlined-primary mt-6 btn-add-organization"
+          class="btn-outlined-primary mt-6"
           :disabled="showOrgPersonForm"
           @click="addOrgPerson(RoleTypes.PROPRIETOR, PartyTypes.ORGANIZATION)"
         >
@@ -105,9 +121,10 @@
 
       <template v-if="isTypePartnership">
         <v-btn
+          id="btn-add-person"
           outlined
           color="primary"
-          class="btn-outlined-primary mt-6 btn-add-person"
+          class="btn-outlined-primary mt-6"
           :disabled="showOrgPersonForm"
           @click="addOrgPerson(RoleTypes.PARTNER, PartyTypes.PERSON)"
         >
@@ -116,11 +133,38 @@
         </v-btn>
 
         <v-btn
+          id="btn-add-organization"
           outlined
           color="primary"
-          class="btn-outlined-primary mt-6 btn-add-organization"
+          class="btn-outlined-primary mt-6"
           :disabled="showOrgPersonForm"
           @click="addOrgPerson(RoleTypes.PARTNER, PartyTypes.ORGANIZATION)"
+        >
+          <v-icon>mdi-domain-plus</v-icon>
+          <span>Add a Business or a Corporation</span>
+        </v-btn>
+      </template>
+
+      <template v-if="isFullRestorationFiling || isLimitedRestorationFiling">
+        <v-btn
+          id="btn-add-person"
+          outlined
+          color="primary"
+          class="btn-outlined-primary mt-6"
+          :disabled="showOrgPersonForm"
+          @click="addOrgPerson(null, PartyTypes.PERSON)"
+        >
+          <v-icon>mdi-account-plus</v-icon>
+          <span>Add a Person</span>
+        </v-btn>
+
+        <v-btn
+          id="btn-add-organization"
+          outlined
+          color="primary"
+          class="btn-outlined-primary mt-6"
+          :disabled="showOrgPersonForm"
+          @click="addOrgPerson(null, PartyTypes.ORGANIZATION)"
         >
           <v-icon>mdi-domain-plus</v-icon>
           <span>Add a Business or a Corporation</span>
@@ -166,7 +210,7 @@ import { PeopleRolesMixin } from '@/mixins'
 import { ConfirmDialog } from '@bcrs-shared-components/confirm-dialog'
 import HelpSection from '@/components/common/HelpSection.vue'
 import ListPeopleAndRoles from '@/components/common/ListPeopleAndRoles.vue'
-import RegAddEditOrgPerson from '@/components/Registration/RegAddEditOrgPerson.vue'
+import RegAddEditOrgPerson from '@/components/common/RegAddEditOrgPerson.vue'
 
 /**
  * This is similar to the common PeopleAndRoles component but this

--- a/src/interfaces/filing-interfaces/filing-interfaces.ts
+++ b/src/interfaces/filing-interfaces/filing-interfaces.ts
@@ -184,9 +184,9 @@ export interface RestorationFilingIF {
   }
   // *** TODO: update according to schema
   restoration: {
-    date: string
+    date: string // today, as YYYY-MM-DD
     type: RestorationTypes
-    expiry: string
+    expiry?: string // YYYY-MM-DD
     nameTranslations: NameTranslationIF[]
     nameRequest: RegistrationNameRequestIF
     parties: PartyIF[]

--- a/src/interfaces/stepper-interfaces/AddPeopleAndRole/people-and-roles-resource-interface.ts
+++ b/src/interfaces/stepper-interfaces/AddPeopleAndRole/people-and-roles-resource-interface.ts
@@ -14,7 +14,8 @@ export interface PeopleAndRolesResourceIF {
     helpText: Array<string>
   }
   blurb2?: string | Array<string>
-  addOrganization?: string
+  addIncorporator?: boolean
+  addOrganization?: boolean
   addBusiness?: boolean
   rolesTitle?: string // restorations only
   rolesSubtitle?: string | Array<string> // restorations only

--- a/src/interfaces/store-interfaces/state-interfaces/restoration-state-interface.ts
+++ b/src/interfaces/store-interfaces/state-interfaces/restoration-state-interface.ts
@@ -11,9 +11,9 @@ export interface RestorationStateIF {
   applicantInfoValid: boolean
   businessInfoValid: boolean
   businessNameValid: boolean
-  date: string // FUTURE: describe format here
+  date: string // YYYY-MM-DD
   type: RestorationTypes
-  expiry?: string // FUTURE: describe format here
+  expiry?: string // YYYY-MM-DD
   // defineBusinessValid: boolean
   // startDate: string
   // businessAddress: BusinessAddressIF

--- a/src/mixins/add-edit-org-person-mixin.ts
+++ b/src/mixins/add-edit-org-person-mixin.ts
@@ -32,6 +32,7 @@ export default class AddEditOrgPersonMixin extends Vue {
   @Getter getCurrentDate!: string
   @Getter isRoleStaff!: boolean
   @Getter isSbcStaff!: boolean
+  @Getter isBaseCompany!: boolean
   @Getter isTypeBcomp!: boolean
   @Getter isTypeCoop!: boolean
   @Getter isTypeSoleProp!: boolean
@@ -199,44 +200,15 @@ export default class AddEditOrgPersonMixin extends Vue {
   }
 
   /** Whether the Incorporator role should be disabled. */
-  // *** TODO: test this (should be disabled if it's the only role displayed)
   get disableIncorporatorRole (): boolean {
     // disable this role if it's the only role displayed
     return (!this.showCompletingPartyRole && !this.showDirectorRole && this.showIncorporatorRole)
   }
 
   /** Whether the Director role should be disabled. */
-  // *** TODO: test this (should be disabled if it's the only role displayed)
   get disableDirectorRole (): boolean {
-    // always enable this role for restoration filings
-    if (this.isFullRestorationFiling || this.isLimitedRestorationFiling) return false
     // disable this role if it's the only role displayed
     return (!this.showCompletingPartyRole && !this.showIncorporatorRole && this.showDirectorRole)
-  }
-
-  /** Whether the Heir or Legal Representative role should be disabled. */
-  get disableHeirLegalRepRole (): boolean {
-    return false
-  }
-
-  /** Whether the Officer role should be disabled. */
-  get disableOfficerRole (): boolean {
-    return false
-  }
-
-  /** Whether the Shareholder role should be disabled. */
-  get disableShareholderRole (): boolean {
-    return false
-  }
-
-  /** Whether the Court Ordered Party role should be disabled. */
-  get disableCourtOrderedPartyRole (): boolean {
-    return false
-  }
-
-  /** Whether the Other role should be disabled. */
-  get disableOtherRole (): boolean {
-    return false
   }
 
   /**

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -391,8 +391,9 @@ export default class FilingTemplateMixin extends DateMixin {
         foundingDate: this.getBusinessFoundingDate
       },
       // *** TODO: add/remove properties as needed
+      // *** TODO: add expiry date option for future resume
       restoration: {
-        date: this.getRestoration.date,
+        date: this.getCurrentDate,
         type: this.getRestoration.type,
         expiry: this.getRestoration.expiry || undefined, // can't be null
         nameRequest: {
@@ -522,6 +523,7 @@ export default class FilingTemplateMixin extends DateMixin {
     this.setFoundingDate(draftFiling.business.foundingDate)
 
     // restore Restoration data
+    // *** TODO: restore expiry date option, not date (which is computed)
     this.setRestorationDate(draftFiling.restoration.date)
     this.setRestorationType(draftFiling.restoration.type)
     this.setRestorationExpiry(draftFiling.restoration.expiry || null)

--- a/src/mixins/people-roles-mixin.ts
+++ b/src/mixins/people-roles-mixin.ts
@@ -28,6 +28,8 @@ export default class PeopleRolesMixin extends Vue {
   @Getter isTypePartnership!: boolean
   @Getter isRoleStaff!: boolean
   @Getter isSbcStaff!: boolean
+  @Getter isFullRestorationFiling!: boolean
+  @Getter isLimitedRestorationFiling: boolean
 
   @Action setOrgPersonList!: ActionBindingIF
   @Action setAddPeopleAndRoleStepValidity!: ActionBindingIF

--- a/src/resources/Incorporation/BC.ts
+++ b/src/resources/Incorporation/BC.ts
@@ -16,7 +16,8 @@ export const IncorporationResourceBc: IncorporationResourceIF = {
     blurb: `Add the people and Corporations/firms who will have a role in your company. People
       can have multiple roles; Corporations/firms can only be Incorporators.`,
     helpSection: null,
-    addOrganization: 'Add a Corporation or Firm',
+    addIncorporator: true,
+    addOrganization: true,
     rules: [
       {
         id: RuleIds.NUM_COMPLETING_PARTY,

--- a/src/resources/Incorporation/BEN.ts
+++ b/src/resources/Incorporation/BEN.ts
@@ -16,7 +16,8 @@ export const IncorporationResourceBen: IncorporationResourceIF = {
     blurb: `Add the people and Corporations/firms who will have a role in your company. People
       can have multiple roles; Corporations/firms can only be Incorporators.`,
     helpSection: null,
-    addOrganization: 'Add a Corporation or Firm',
+    addIncorporator: true,
+    addOrganization: true,
     rules: [
       {
         id: RuleIds.NUM_COMPLETING_PARTY,

--- a/src/resources/Incorporation/CC.ts
+++ b/src/resources/Incorporation/CC.ts
@@ -16,7 +16,8 @@ export const IncorporationResourceCc: IncorporationResourceIF = {
     blurb: `Add the people and Corporations/firms who will have a role in your company. People
       can have multiple roles; Corporations/firms can only be Incorporators.`,
     helpSection: null,
-    addOrganization: 'Add a Corporation or Firm',
+    addIncorporator: true,
+    addOrganization: true,
     rules: [
       {
         id: RuleIds.NUM_COMPLETING_PARTY,

--- a/src/resources/Incorporation/ULC.ts
+++ b/src/resources/Incorporation/ULC.ts
@@ -16,7 +16,8 @@ export const IncorporationResourceUlc: IncorporationResourceIF = {
     blurb: `Add the people and Corporations/firms who will have a role in your company. People
       can have multiple roles; Corporations/firms can only be Incorporators.`,
     helpSection: null,
-    addOrganization: 'Add a Corporation or Firm',
+    addIncorporator: true,
+    addOrganization: true,
     rules: [
       {
         id: RuleIds.NUM_COMPLETING_PARTY,

--- a/src/resources/Restoration/BC.ts
+++ b/src/resources/Restoration/BC.ts
@@ -22,7 +22,6 @@ export const RestorationResourceBc: RestorationResourceIF = {
     header: 'Add Applicant Information',
     blurb: null,
     helpSection: null,
-    addOrganization: 'Add a Business or a Corporation',
     rolesTitle: 'Relationship to the Company to be Restored',
     rolesSubtitle: [
       // order matters - see resource-getters.ts

--- a/src/resources/Restoration/BEN.ts
+++ b/src/resources/Restoration/BEN.ts
@@ -22,7 +22,6 @@ export const RestorationResourceBen: RestorationResourceIF = {
     header: 'Add Applicant Information',
     blurb: null,
     helpSection: null,
-    addOrganization: 'Add a Business or a Corporation',
     rolesTitle: 'Relationship to the Company to be Restored',
     rolesSubtitle: [
       // order matters - see resource-getters.ts

--- a/src/resources/Restoration/CC.ts
+++ b/src/resources/Restoration/CC.ts
@@ -22,7 +22,6 @@ export const RestorationResourceCc: RestorationResourceIF = {
     header: 'Add Applicant Information',
     blurb: null,
     helpSection: null,
-    addOrganization: 'Add a Business or a Corporation',
     rolesTitle: 'Relationship to the Company to be Restored',
     rolesSubtitle: [
       // order matters - see resource-getters.ts

--- a/src/resources/Restoration/ULC.ts
+++ b/src/resources/Restoration/ULC.ts
@@ -22,7 +22,6 @@ export const RestorationResourceUlc: RestorationResourceIF = {
     header: 'Add Applicant Information',
     blurb: null,
     helpSection: null,
-    addOrganization: 'Add a Business or a Corporation',
     rolesTitle: 'Relationship to the Company to be Restored',
     rolesSubtitle: [
       // order matters - see resource-getters.ts

--- a/src/store/state/resource-model.ts
+++ b/src/store/state/resource-model.ts
@@ -10,6 +10,7 @@ const incorporationResourceModel: IncorporationResourceIF = {
     blurb: null,
     helpSection: null,
     blurb2: null,
+    addIncorporator: null,
     addOrganization: null,
     addBusiness: null,
     rules: []

--- a/src/views/Registration/RegistrationPeopleRoles.vue
+++ b/src/views/Registration/RegistrationPeopleRoles.vue
@@ -17,7 +17,7 @@ import { Getter } from 'vuex-class'
 import { PeopleAndRoleIF, PeopleAndRolesResourceIF } from '@/interfaces'
 import { CommonMixin } from '@/mixins'
 import { RouteNames } from '@/enums'
-import RegPeopleAndRoles from '@/components/Registration/RegPeopleAndRoles.vue'
+import RegPeopleAndRoles from '@/components/common/RegPeopleAndRoles.vue'
 
 @Component({
   components: {

--- a/src/views/Restoration/RestorationApplicantInformation.vue
+++ b/src/views/Restoration/RestorationApplicantInformation.vue
@@ -5,7 +5,7 @@
         <h2>{{ getPeopleAndRolesResource.header }}</h2>
       </header>
 
-      <PeopleAndRoles />
+      <RegPeopleAndRoles />
     </section>
   </div>
 </template>
@@ -17,11 +17,11 @@ import { Getter } from 'vuex-class'
 import { PeopleAndRoleIF, PeopleAndRolesResourceIF } from '@/interfaces'
 import { CommonMixin } from '@/mixins'
 import { RouteNames } from '@/enums'
-import PeopleAndRoles from '@/components/common/PeopleAndRoles.vue'
+import RegPeopleAndRoles from '@/components/common/RegPeopleAndRoles.vue'
 
 @Component({
   components: {
-    PeopleAndRoles
+    RegPeopleAndRoles
   },
   mixins: [
     CommonMixin

--- a/tests/unit/AddEditOrgPerson.spec.ts
+++ b/tests/unit/AddEditOrgPerson.spec.ts
@@ -132,6 +132,7 @@ function createComponent (
   initialValue: any, // person
   activeIndex: number,
   existingCompletingParty: any,
+  addIncorporator = true,
   computed = null
 ): Wrapper<AddEditOrgPerson> {
   const localVue = createLocalVue()
@@ -142,7 +143,8 @@ function createComponent (
     propsData: {
       initialValue,
       activeIndex,
-      existingCompletingParty
+      existingCompletingParty,
+      addIncorporator
     },
     computed,
     store,
@@ -335,6 +337,7 @@ describe('Add/Edit Org/Person component', () => {
       validIncorporator,
       NaN,
       validPersonData,
+      null,
       { requireCompletingParty: () => true }
     )
 
@@ -354,6 +357,7 @@ describe('Add/Edit Org/Person component', () => {
       validIncorporator,
       NaN,
       validPersonData,
+      null,
       { requireCompletingParty: () => true }
     )
 

--- a/tests/unit/RegAddEditOrgPerson.spec.ts
+++ b/tests/unit/RegAddEditOrgPerson.spec.ts
@@ -5,7 +5,7 @@ import { mount, Wrapper } from '@vue/test-utils'
 import flushPromises from 'flush-promises'
 import { getLastEvent } from '../get-last-event'
 import { getVuexStore } from '@/store'
-import RegAddEditOrgPerson from '@/components/Registration/RegAddEditOrgPerson.vue'
+import RegAddEditOrgPerson from '@/components/common/RegAddEditOrgPerson.vue'
 import { EmptyOrgPerson } from '@/interfaces'
 
 // mock the console.warn function to hide "[Vuetify] Unable to locate target XXX"
@@ -30,9 +30,9 @@ const lastNameSelector = '.last-name'
 const confirmCheckboxSelector = '.confirm-checkbox'
 const orgNameSelector = '.org-name'
 const emailAddressSelector = '.email-address'
-const buttonRemoveSelector = '.btn-remove'
-const buttonDoneSelector = '.btn-done'
-const buttonCancelSelector = '.btn-cancel'
+const buttonRemoveSelector = '#btn-remove'
+const buttonDoneSelector = '#btn-done'
+const buttonCancelSelector = '#btn-cancel'
 
 const validCompletingParty = {
   officer: {

--- a/tests/unit/RegPeopleAndRoles.spec.ts
+++ b/tests/unit/RegPeopleAndRoles.spec.ts
@@ -4,10 +4,10 @@ import Vuetify from 'vuetify'
 import flushPromises from 'flush-promises'
 import { getVuexStore } from '@/store'
 import { mount } from '@vue/test-utils'
-import RegPeopleAndRoles from '@/components/Registration/RegPeopleAndRoles.vue'
+import RegPeopleAndRoles from '@/components/common/RegPeopleAndRoles.vue'
 import { RegistrationResourceSp } from '@/resources/Registration/SP'
 import { RegistrationResourceGp } from '@/resources/Registration/GP'
-import RegAddEditOrgPerson from '@/components/Registration/RegAddEditOrgPerson.vue'
+import RegAddEditOrgPerson from '@/components/common/RegAddEditOrgPerson.vue'
 import ListPeopleAndRoles from '@/components/common/ListPeopleAndRoles.vue'
 
 // mock the console.warn function to hide "[Vuetify] Unable to locate target XXX"
@@ -20,10 +20,10 @@ const vuetify = new Vuetify({})
 const store = getVuexStore()
 
 // selectors to test changes to the DOM elements
-const btnStartAddCompletingParty = '.btn-start-add-cp'
-const btnAddCompletingParty = '.btn-add-cp'
-const btnAddPerson = '.btn-add-person'
-const btnAddOrganization = '.btn-add-organization'
+const btnStartAddCompletingParty = '#btn-start-add-cp'
+const btnAddCompletingParty = '#btn-add-cp'
+const btnAddPerson = '#btn-add-person'
+const btnAddOrganization = '#btn-add-organization'
 const checkCompletingParty = '.cp-valid'
 const checkProprietor = '.proprietor-valid'
 const checkPartner = '.partner-valid'


### PR DESCRIPTION
*Issue #:* bcgov/entity#14798

*Description of changes:*
- reverted restoration changes from IA people and roles components
- added restoration changes to Reg people and roles components
- fixed misc layout and component ids
- moved RegXXX (people and roles components) from components/Registration/ to components/common/
- changed restoration to use RegXXX components (which support business lookup)
- updated unit tests
- app version = 4.5.5

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).