### PR TITLE
14964 - bump CourtOrderPoa to v3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@bcrs-shared-components/confirm-dialog": "1.2.1",
         "@bcrs-shared-components/contact-info": "1.2.4",
         "@bcrs-shared-components/corp-type-module": "1.0.9",
-        "@bcrs-shared-components/court-order-poa": "^3.0.0",
+        "@bcrs-shared-components/court-order-poa": "2.1.4",
         "@bcrs-shared-components/date-picker": "1.2.4",
         "@bcrs-shared-components/document-delivery": "1.1.1",
         "@bcrs-shared-components/effective-date-time": "1.1.4",
@@ -1916,9 +1916,9 @@
       "integrity": "sha512-w52/6yvCW92oplOScHuP33gLSA7rsJ9ENyaZ6JKEK78rdrFdCrs1m4/Umr0DQWXUbwZQ43xn2jKXvYWDmIe1Mg=="
     },
     "node_modules/@bcrs-shared-components/court-order-poa": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/court-order-poa/-/court-order-poa-3.0.0.tgz",
-      "integrity": "sha512-/X6K6vMSUHYsAy8XWL2esbfHfSXxy4J2R6rlLcFx+1dU0ajRF2XnlL2sKdYsqWN+4Ov/FXUrNe2jYgz/yShI7A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/court-order-poa/-/court-order-poa-2.1.4.tgz",
+      "integrity": "sha512-dw2eMvs5DBa7E6WTymgUbLRoeTsr4Zlmx4CzViA4cIU5fePrppoNcP4IGz38ep9FRUoq7zKz8j5lBSJi+U/xAw==",
       "dependencies": {
         "@bcrs-shared-components/interfaces": "^1.0.47",
         "vue-property-decorator": "^9.1.2"
@@ -25596,9 +25596,9 @@
       "integrity": "sha512-w52/6yvCW92oplOScHuP33gLSA7rsJ9ENyaZ6JKEK78rdrFdCrs1m4/Umr0DQWXUbwZQ43xn2jKXvYWDmIe1Mg=="
     },
     "@bcrs-shared-components/court-order-poa": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/court-order-poa/-/court-order-poa-3.0.0.tgz",
-      "integrity": "sha512-/X6K6vMSUHYsAy8XWL2esbfHfSXxy4J2R6rlLcFx+1dU0ajRF2XnlL2sKdYsqWN+4Ov/FXUrNe2jYgz/yShI7A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/court-order-poa/-/court-order-poa-2.1.4.tgz",
+      "integrity": "sha512-dw2eMvs5DBa7E6WTymgUbLRoeTsr4Zlmx4CzViA4cIU5fePrppoNcP4IGz38ep9FRUoq7zKz8j5lBSJi+U/xAw==",
       "requires": {
         "@bcrs-shared-components/interfaces": "^1.0.47",
         "vue-property-decorator": "^9.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@bcrs-shared-components/confirm-dialog": "1.2.1",
         "@bcrs-shared-components/contact-info": "1.2.4",
         "@bcrs-shared-components/corp-type-module": "1.0.9",
-        "@bcrs-shared-components/court-order-poa": "2.1.4",
+        "@bcrs-shared-components/court-order-poa": "^3.0.0",
         "@bcrs-shared-components/date-picker": "1.2.4",
         "@bcrs-shared-components/document-delivery": "1.1.1",
         "@bcrs-shared-components/effective-date-time": "1.1.4",
@@ -1916,9 +1916,9 @@
       "integrity": "sha512-w52/6yvCW92oplOScHuP33gLSA7rsJ9ENyaZ6JKEK78rdrFdCrs1m4/Umr0DQWXUbwZQ43xn2jKXvYWDmIe1Mg=="
     },
     "node_modules/@bcrs-shared-components/court-order-poa": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/court-order-poa/-/court-order-poa-2.1.4.tgz",
-      "integrity": "sha512-dw2eMvs5DBa7E6WTymgUbLRoeTsr4Zlmx4CzViA4cIU5fePrppoNcP4IGz38ep9FRUoq7zKz8j5lBSJi+U/xAw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/court-order-poa/-/court-order-poa-3.0.0.tgz",
+      "integrity": "sha512-/X6K6vMSUHYsAy8XWL2esbfHfSXxy4J2R6rlLcFx+1dU0ajRF2XnlL2sKdYsqWN+4Ov/FXUrNe2jYgz/yShI7A==",
       "dependencies": {
         "@bcrs-shared-components/interfaces": "^1.0.47",
         "vue-property-decorator": "^9.1.2"
@@ -25596,9 +25596,9 @@
       "integrity": "sha512-w52/6yvCW92oplOScHuP33gLSA7rsJ9ENyaZ6JKEK78rdrFdCrs1m4/Umr0DQWXUbwZQ43xn2jKXvYWDmIe1Mg=="
     },
     "@bcrs-shared-components/court-order-poa": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/court-order-poa/-/court-order-poa-2.1.4.tgz",
-      "integrity": "sha512-dw2eMvs5DBa7E6WTymgUbLRoeTsr4Zlmx4CzViA4cIU5fePrppoNcP4IGz38ep9FRUoq7zKz8j5lBSJi+U/xAw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/court-order-poa/-/court-order-poa-3.0.0.tgz",
+      "integrity": "sha512-/X6K6vMSUHYsAy8XWL2esbfHfSXxy4J2R6rlLcFx+1dU0ajRF2XnlL2sKdYsqWN+4Ov/FXUrNe2jYgz/yShI7A==",
       "requires": {
         "@bcrs-shared-components/interfaces": "^1.0.47",
         "vue-property-decorator": "^9.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@bcrs-shared-components/confirm-dialog": "1.2.1",
         "@bcrs-shared-components/contact-info": "1.2.4",
         "@bcrs-shared-components/corp-type-module": "1.0.9",
-        "@bcrs-shared-components/court-order-poa": "^3.0.0",
+        "@bcrs-shared-components/court-order-poa": "3.0.0",
         "@bcrs-shared-components/date-picker": "1.2.4",
         "@bcrs-shared-components/document-delivery": "1.1.1",
         "@bcrs-shared-components/effective-date-time": "1.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "4.5.6",
+  "version": "4.5.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "4.5.6",
+      "version": "4.5.7",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/breadcrumb": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "4.5.6",
+  "version": "4.5.7",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@bcrs-shared-components/confirm-dialog": "1.2.1",
     "@bcrs-shared-components/contact-info": "1.2.4",
     "@bcrs-shared-components/corp-type-module": "1.0.9",
-    "@bcrs-shared-components/court-order-poa": "2.1.4",
+    "@bcrs-shared-components/court-order-poa": "3.0.0",
     "@bcrs-shared-components/date-picker": "1.2.4",
     "@bcrs-shared-components/document-delivery": "1.1.1",
     "@bcrs-shared-components/effective-date-time": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@bcrs-shared-components/confirm-dialog": "1.2.1",
     "@bcrs-shared-components/contact-info": "1.2.4",
     "@bcrs-shared-components/corp-type-module": "1.0.9",
-    "@bcrs-shared-components/court-order-poa": "3.0.0",
+    "@bcrs-shared-components/court-order-poa": "2.1.4",
     "@bcrs-shared-components/date-picker": "1.2.4",
     "@bcrs-shared-components/document-delivery": "1.1.1",
     "@bcrs-shared-components/effective-date-time": "1.1.4",

--- a/src/views/Dissolution/DissolutionReviewConfirm.vue
+++ b/src/views/Dissolution/DissolutionReviewConfirm.vue
@@ -254,7 +254,6 @@
         <CourtOrderPoa
           class="py-8 px-6"
           :class="{ 'invalid-section': isCourtOrderInvalid }"
-          :autoValidation="getValidateSteps"
           :draftCourtOrderNumber="getCourtOrderStep.courtOrder.fileNumber"
           :hasDraftPlanOfArrangement="getCourtOrderStep.courtOrder.hasPlanOfArrangement"
           :courtOrderNumberRequired="true"

--- a/src/views/Dissolution/DissolutionReviewConfirm.vue
+++ b/src/views/Dissolution/DissolutionReviewConfirm.vue
@@ -256,7 +256,7 @@
           :class="{ 'invalid-section': isCourtOrderInvalid }"
           :draftCourtOrderNumber="getCourtOrderStep.courtOrder.fileNumber"
           :hasDraftPlanOfArrangement="getCourtOrderStep.courtOrder.hasPlanOfArrangement"
-          :courtOrderNumberRequired="true"
+          :courtOrderNumberRequired="false"
           :invalidSection="isCourtOrderInvalid"
           @emitCourtNumber="setCourtOrderFileNumber($event)"
           @emitPoa="setHasPlanOfArrangement($event)"

--- a/src/views/DissolutionFirm/DissolutionFirm.vue
+++ b/src/views/DissolutionFirm/DissolutionFirm.vue
@@ -185,7 +185,6 @@
       <v-card flat class="mt-6" :class="{ 'invalid-section': isCourtOrderInvalid }">
         <CourtOrderPoa
           class="py-8 px-6"
-          :autoValidation="getValidateSteps"
           :draftCourtOrderNumber="getCourtOrderStep.courtOrder.fileNumber"
           :hasDraftPlanOfArrangement="getCourtOrderStep.courtOrder.hasPlanOfArrangement"
           :courtOrderNumberRequired="true"

--- a/src/views/DissolutionFirm/DissolutionFirm.vue
+++ b/src/views/DissolutionFirm/DissolutionFirm.vue
@@ -187,7 +187,7 @@
           class="py-8 px-6"
           :draftCourtOrderNumber="getCourtOrderStep.courtOrder.fileNumber"
           :hasDraftPlanOfArrangement="getCourtOrderStep.courtOrder.hasPlanOfArrangement"
-          :courtOrderNumberRequired="true"
+          :courtOrderNumberRequired="false"
           :invalidSection="isCourtOrderInvalid"
           @emitCourtNumber="setCourtOrderFileNumber($event)"
           @emitPoa="setHasPlanOfArrangement($event)"

--- a/src/views/Incorporation/IncorporationReviewConfirm.vue
+++ b/src/views/Incorporation/IncorporationReviewConfirm.vue
@@ -139,7 +139,6 @@
         <CourtOrderPoa
           class="py-8 px-6"
           :class="{ 'invalid-section': isCourtOrderInvalid }"
-          :autoValidation="getValidateSteps"
           :draftCourtOrderNumber="getCourtOrderStep.courtOrder.fileNumber"
           :hasDraftPlanOfArrangement="getCourtOrderStep.courtOrder.hasPlanOfArrangement"
           :courtOrderNumberRequired="false"


### PR DESCRIPTION
*Issue #:* /bcgov/entity14964

The **shared** component CourtOrderPoa has been updated.  This small change updates CourtOrderPoa to the latest version and set the prop `courtOrderNumberRequired` to false when calling the component.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
