### PR TITLE
15241 minio upgrade fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.1.1",
+      "version": "5.1.2",
       "dependencies": {
         "@babel/compat-data": "^7.19.1",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/utils/AxiosInstance.ts
+++ b/src/utils/AxiosInstance.ts
@@ -4,10 +4,14 @@ import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 const instance = axios.create()
 
 instance.interceptors.request.use(
-  config => {
+  request => {
+    if (request.url?.startsWith('https://minio')) {
+      return request
+    }
+
     const kcToken = sessionStorage.getItem(SessionStorageKeys.KeyCloakToken)
-    config.headers.common['Authorization'] = `Bearer ${kcToken}`
-    return config
+    request.headers.common['Authorization'] = `Bearer ${kcToken}`
+    return request
   },
   error => Promise.reject(error)
 )


### PR DESCRIPTION
*Issue #:* https://github.com/bcgov/entity/issues/15241

*Description of changes:*
Axios defaults to sending an Authorization header for any request it makes - newer version of Minio does not like this header, and throws 400 errors. This change will not auto-add the header for urls with minio in them.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
