### PR TITLE
16175 Fixed undefined legal name in a dissolution (and also restoration)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.2.0",
+      "version": "5.2.1",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -268,7 +268,6 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
   @Action(useStore) setCurrentJsDate!: ActionBindingIF
   @Action(useStore) setCurrentStep!: ActionBindingIF
   @Action(useStore) setEntityFoundingDate!: ActionBindingIF
-  @Action(useStore) setEntityName!: ActionBindingIF
   @Action(useStore) setEntityState!: ActionBindingIF
   @Action(useStore) setFeePrices!: ActionBindingIF
   @Action(useStore) setFilingType!: ActionBindingIF
@@ -1082,7 +1081,7 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
 
     // FUTURE: change this to a single setter/object?
     this.setAdminFreeze(business.adminFreeze)
-    this.setEntityName(business.legalName)
+    this.setLegalName(business.legalName)
     this.setEntityState(business.state)
     this.setBusinessNumber(business.taxId || null) // may be empty
     this.setIdentifier(business.identifier)

--- a/src/components/Dissolution/AssociationDetails.vue
+++ b/src/components/Dissolution/AssociationDetails.vue
@@ -27,8 +27,8 @@
         <v-col cols="12" sm="4" class="pr-4 pt-4 pt-sm-0">
           <label class="mailing-address-header">Mailing Address</label>
           <MailingAddress
-            v-if="!isEmptyAddress(getBusiness.officeAddress.mailingAddress)"
-            :address="getBusiness.officeAddress.mailingAddress"
+            v-if="!isEmptyAddress(getBusinessOfficeAddress.mailingAddress)"
+            :address="getBusinessOfficeAddress.mailingAddress"
             :editing="false"
           />
           <div v-else>(Not entered)</div>
@@ -37,12 +37,12 @@
         <v-col cols="12" sm="4" class="pr-4 pt-4 pt-sm-0">
           <label class="delivery-address-header">Delivery Address</label>
           <DeliveryAddress
-            v-if="!isEmptyAddress(getBusiness.officeAddress.deliveryAddress) &&
-             !isSame(getBusiness.officeAddress.mailingAddress, getBusiness.officeAddress.deliveryAddress, ['id'])"
-            :address="getBusiness.officeAddress.deliveryAddress"
+            v-if="!isEmptyAddress(getBusinessOfficeAddress.deliveryAddress) &&
+             !isSame(getBusinessOfficeAddress.mailingAddress, getBusinessOfficeAddress.deliveryAddress, ['id'])"
+            :address="getBusinessOfficeAddress.deliveryAddress"
             :editing="false"
           />
-          <div v-else-if="isEmptyAddress(getBusiness.officeAddress.deliveryAddress)">(Not entered)</div>
+          <div v-else-if="isEmptyAddress(getBusinessOfficeAddress.deliveryAddress)">(Not entered)</div>
           <div v-else>Same as Mailing Address</div>
         </v-col>
       </v-row>
@@ -102,7 +102,7 @@ import { Component, Mixins, Prop } from 'vue-property-decorator'
 import { Action, Getter } from 'pinia-class'
 import { useStore } from '@/store/store'
 import { AuthServices } from '@/services/'
-import { ActionBindingIF, AddressIF, ContactPointIF, BusinessIF } from '@/interfaces'
+import { ActionBindingIF, AddressIF, ContactPointIF, OfficeAddressIF } from '@/interfaces'
 import { ContactInfo } from '@bcrs-shared-components/contact-info'
 import BaseAddress from 'sbc-common-components/src/components/BaseAddress.vue'
 import OfficeAddresses from '@/components/common/OfficeAddresses.vue'
@@ -128,17 +128,18 @@ export default class AssociationDetails extends Mixins(CommonMixin, DateMixin) {
   @Prop({ default: true }) readonly showContactInfo!: boolean
 
   // Global getters
-  @Getter(useStore) getFolioNumber!: string
-  @Getter(useStore) getBusinessId!: string
-  @Getter(useStore) getBusiness!: BusinessIF
   @Getter(useStore) getBusinessContact!: ContactPointIF
+  @Getter(useStore) getBusinessFoundingDate!: string
+  @Getter(useStore) getBusinessId!: string
+  @Getter(useStore) getBusinessLegalName!: string
+  @Getter(useStore) getBusinessOfficeAddress!: OfficeAddressIF
   @Getter(useStore) getCompanyDisplayName!: string
   @Getter(useStore) getCooperativeType!: CoopTypes
-  @Getter(useStore) getBusinessLegalName!: string
+  @Getter(useStore) getEntityType!: CorpTypeCd
+  @Getter(useStore) getFolioNumber!: string
   @Getter(useStore) isPremiumAccount!: boolean
   @Getter(useStore) isTypeCoop!: boolean
-  @Getter(useStore) getEntityType!: CorpTypeCd
-  @Getter(useStore) getBusinessFoundingDate!: string
+
   // Global setters
   @Action(useStore) setBusinessContact!: ActionBindingIF
   @Action(useStore) setIgnoreChanges!: ActionBindingIF

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -2,12 +2,12 @@ import { Component, Mixins } from 'vue-property-decorator'
 import { Getter, Action } from 'pinia-class'
 import { useStore } from '@/store/store'
 import { DateMixin } from '@/mixins'
-import { ActionBindingIF, BusinessIF, ContactPointIF, CertifyIF, CompletingPartyIF, CourtOrderStepIF,
+import { ActionBindingIF, ContactPointIF, CertifyIF, CompletingPartyIF, CourtOrderStepIF,
   CreateMemorandumIF, CreateResolutionIF, CreateRulesIF, DefineCompanyIF, DissolutionFilingIF,
   DissolutionStatementIF, DocumentDeliveryIF, EffectiveDateTimeIF, EmptyNaics, IncorporationAgreementIF,
-  IncorporationFilingIF, NameRequestFilingIF, NameTranslationIF, OrgPersonIF, PartyIF, PeopleAndRoleIF,
-  RegistrationFilingIF, RegistrationStateIF, RestorationFilingIF, RestorationStateIF, ShareStructureIF,
-  SpecialResolutionIF, StaffPaymentStepIF, UploadAffidavitIF } from '@/interfaces'
+  IncorporationFilingIF, NameRequestFilingIF, NameTranslationIF, OfficeAddressIF, OrgPersonIF, PartyIF,
+  PeopleAndRoleIF, RegistrationFilingIF, RegistrationStateIF, RestorationFilingIF, RestorationStateIF,
+  ShareStructureIF, SpecialResolutionIF, StaffPaymentStepIF, UploadAffidavitIF } from '@/interfaces'
 import { DissolutionTypes, EffectOfOrders, FilingTypes, PartyTypes, RoleTypes, StaffPaymentOptions }
   from '@/enums'
 import { CorpTypeCd, CorrectNameOptions } from '@bcrs-shared-components/enums/'
@@ -19,11 +19,12 @@ import { CorpTypeCd, CorrectNameOptions } from '@bcrs-shared-components/enums/'
 export default class FilingTemplateMixin extends Mixins(DateMixin) {
   @Getter(useStore) getAddPeopleAndRoleStep!: PeopleAndRoleIF
   @Getter(useStore) getAffidavitStep!: UploadAffidavitIF
-  @Getter(useStore) getBusiness!: BusinessIF
   @Getter(useStore) getBusinessContact!: ContactPointIF
   @Getter(useStore) getBusinessFoundingDate!: string
   @Getter(useStore) getBusinessId!: string
   @Getter(useStore) getBusinessLegalName!: string
+  @Getter(useStore) getBusinessLegalType!: CorpTypeCd
+  @Getter(useStore) getBusinessOfficeAddress!: OfficeAddressIF
   @Getter(useStore) getCertifyState!: CertifyIF
   @Getter(useStore) getCompletingParty!: CompletingPartyIF
   @Getter(useStore) getCorrectNameOption!: CorrectNameOptions
@@ -571,9 +572,9 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
     this.setFilingId(+draftFiling.header.filingId)
 
     // restore Business data
-    this.setEntityType(draftFiling.business.legalType)
-    this.setLegalName(draftFiling.business.legalName)
-    this.setFoundingDate(draftFiling.business.foundingDate)
+    this.setEntityType(draftFiling.business.legalType || this.getBusinessLegalType)
+    this.setLegalName(draftFiling.business.legalName || this.getBusinessLegalName)
+    this.setFoundingDate(draftFiling.business.foundingDate || this.getBusinessFoundingDate)
 
     // restore Restoration data
     if (draftFiling.restoration.applicationDate) {
@@ -699,7 +700,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
       dissolution: {
         dissolutionDate: this.getCurrentDate,
         affidavitConfirmed: this.getAffidavitStep.validationDetail.validationItemDetails[0]?.valid || false,
-        custodialOffice: this.getBusiness.officeAddress,
+        custodialOffice: this.getBusinessOfficeAddress,
         dissolutionType: this.getDissolutionType,
         parties: [{
           ...this.getDissolutionCustodian,
@@ -811,9 +812,9 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
     this.setFilingId(+draftFiling.header.filingId)
 
     // restore Business data
-    this.setEntityType(draftFiling.business.legalType)
-    this.setLegalName(draftFiling.business.legalName)
-    this.setFoundingDate(draftFiling.business.foundingDate)
+    this.setEntityType(draftFiling.business.legalType || this.getBusinessLegalType)
+    this.setLegalName(draftFiling.business.legalName || this.getBusinessLegalName)
+    this.setFoundingDate(draftFiling.business.foundingDate || this.getBusinessFoundingDate)
 
     // restore Dissolution data
     this.setBusinessAddress(draftFiling.dissolution.custodialOffice)

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -20,7 +20,6 @@ import {
   AddressIF,
   AffidavitResourceIF,
   BusinessAddressIF,
-  BusinessIF,
   BusinessWarningIF,
   CertifyIF,
   CompletingPartyIF,
@@ -48,6 +47,7 @@ import {
   NaicsIF,
   NameRequestIF,
   NameTranslationIF,
+  OfficeAddressIF,
   OrgInformationIF,
   OrgPersonIF,
   PartyIF,
@@ -295,9 +295,9 @@ export const useStore = defineStore('store', {
       return this.stateModel.business.foundingDate
     },
 
-    /** The Business Data. */
-    getBusiness (): BusinessIF {
-      return this.stateModel.business
+    /** The Business Office Address. */
+    getBusinessOfficeAddress (): OfficeAddressIF {
+      return this.stateModel.business.officeAddress
     },
 
     /** The Name Request object. */
@@ -1150,9 +1150,6 @@ export const useStore = defineStore('store', {
     },
     setAdminFreeze (adminFreeze: boolean) {
       this.stateModel.business.adminFreeze = adminFreeze
-    },
-    setEntityName (legalName: string) {
-      this.stateModel.business.legalName = legalName
     },
     setEntityState (entityState: EntityState) {
       this.stateModel.business.state = entityState


### PR DESCRIPTION
*Issue #:* bcgov/entity#16175

*Description of changes:*
- app version = 5.2.1
- deleted setEntityName and used setLegalName instead
- deleted getBusiness and used getBusinessOfficeAddress instead
- fixed undefined legal name -- added fallback for parsing draft without legal name (or legal type or founding date)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).