### PR TITLE
16375 fix "None is not a String" filing error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.2.3",
+      "version": "5.2.4",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/interfaces/filing-interfaces/filing-interfaces.ts
+++ b/src/interfaces/filing-interfaces/filing-interfaces.ts
@@ -179,7 +179,6 @@ export interface RestorationFilingIF {
   business: {
     foundingDate: string
     identifier: string
-    legalName: string
     legalType: CorpTypeCd
   }
   restoration: {

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -413,7 +413,6 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
       business: {
         legalType: this.getEntityType,
         identifier: this.getBusinessId,
-        legalName: this.getBusinessLegalName,
         foundingDate: this.getBusinessFoundingDate
       },
       restoration: {


### PR DESCRIPTION
*Issue #:* bcgov/entity#16375

*Description of changes:*
- app version = 5.2.4
- don't save legal name in restoration business object

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).