### PR TITLE
ops-support-3105 Fixed previewImageSource()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.4.2",
+  "version": "5.4.2a",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.4.2",
+      "version": "5.4.2a",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.4.2",
+  "version": "5.4.2a",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dissolution/CompleteResolution.vue
+++ b/src/components/Dissolution/CompleteResolution.vue
@@ -570,14 +570,12 @@ export default class CompleteResolution extends Mixins(CommonMixin, DateMixin) {
     return this.getShowErrors && !this.isConfirmResolutionValid
   }
 
-  previewImageSource (): string {
+  previewImageSource (): URL {
     // Note: the image file path did not resolve correctly when using the require function directly.  In order
     // to get the image path resolving correctly, needed to get the image context first and use that to build
     // the final image file path
-
-    if (this.isVitestRunning) { return '' }
-    const images = require.context('@/assets/images/', false, /\.png$/)
-    return images('./' + this.getCreateResolutionResource.sampleFormSection.previewImagePath)
+    const imagePath = this.getCreateResolutionResource.sampleFormSection.previewImagePath
+    return new URL(`@/assets/images/${imagePath}`, import.meta.url)
   }
 
   get confirmLabel (): string {


### PR DESCRIPTION
*Issue #:* ops-support # 3105

*Description of changes:*
- app version = 5.4.2a
- fixed previewImageSource()

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).