### PR TITLE
17216 - Show start date for a firm dissolution filing 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.5.1",
+      "version": "5.5.2",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.5.2",
+      "version": "5.5.3",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1166,6 +1166,7 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
     this.setLastDirectorChangeDate(business.lastDirectorChangeDate) // may be empty
     this.setWarnings(Array.isArray(business.warnings) ? business.warnings : [])
     this.setGoodStanding(business.goodStanding)
+    this.setBusinessStartDate(business.startDate)
   }
 
   /** Fetches authorizations and verifies roles. */

--- a/src/components/Dissolution/AssociationDetails.vue
+++ b/src/components/Dissolution/AssociationDetails.vue
@@ -177,6 +177,7 @@ export default class AssociationDetails extends Mixins(CommonMixin, DateMixin) {
   @Getter(useStore) getBusinessId!: string
   @Getter(useStore) getBusinessLegalName!: string
   @Getter(useStore) getBusinessOfficeAddress!: OfficeAddressIF
+  @Getter(useStore) getBusinessStartDate!: string
   @Getter(useStore) getCompanyDisplayName!: string
   @Getter(useStore) getCooperativeType!: CoopTypes
   @Getter(useStore) getEntityType!: CorpTypeCd
@@ -203,8 +204,7 @@ export default class AssociationDetails extends Mixins(CommonMixin, DateMixin) {
 
   /** The business start date. */
   get businessStartDate (): string {
-    // it will be same as foundingDate
-    return this.dateToPacificDate(this.apiToDate(this.getBusinessFoundingDate), true)
+    return this.yyyyMmDdToPacificDate(this.getBusinessStartDate, true)
   }
 
   /** Whether the address object is empty. */

--- a/src/interfaces/filing-interfaces/filing-interfaces.ts
+++ b/src/interfaces/filing-interfaces/filing-interfaces.ts
@@ -140,6 +140,7 @@ export interface DissolutionFilingIF {
     identifier: string
     legalName: string
     foundingDate: string
+    startDate: string
   }
   dissolution: {
     dissolutionDate: string

--- a/src/interfaces/filing-interfaces/filing-interfaces.ts
+++ b/src/interfaces/filing-interfaces/filing-interfaces.ts
@@ -140,7 +140,7 @@ export interface DissolutionFilingIF {
     identifier: string
     legalName: string
     foundingDate: string
-    startDate: string
+    startDate: string // Populated/used only (not NULL) in Firm Dissolution filing
   }
   dissolution: {
     dissolutionDate: string

--- a/src/interfaces/store-interfaces/state-interfaces/business-interface.ts
+++ b/src/interfaces/store-interfaces/state-interfaces/business-interface.ts
@@ -38,5 +38,6 @@ export interface BusinessIF {
   taxId?: string // aka Business Number // may be undefined
   state: EntityState
   stateFiling?: string
+  startDate: ApiDateTimeUtc | string
   submitter: string // not used
 }

--- a/src/interfaces/store-interfaces/state-interfaces/business-interface.ts
+++ b/src/interfaces/store-interfaces/state-interfaces/business-interface.ts
@@ -38,6 +38,6 @@ export interface BusinessIF {
   taxId?: string // aka Business Number // may be undefined
   state: EntityState
   stateFiling?: string
-  startDate: ApiDateTimeUtc | string
+  startDate: ApiDateTimeUtc
   submitter: string // not used
 }

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -711,7 +711,8 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
         legalType: this.getEntityType,
         identifier: this.getBusinessId,
         legalName: this.getBusinessLegalName,
-        foundingDate: this.getBusinessFoundingDate
+        foundingDate: this.getBusinessFoundingDate,
+        startDate: this.getBusinessStartDate
       },
       dissolution: {
         dissolutionDate: this.getCurrentDate,
@@ -831,7 +832,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
     this.setEntityType(draftFiling.business.legalType || this.getBusinessLegalType)
     this.setLegalName(draftFiling.business.legalName || this.getBusinessLegalName)
     this.setFoundingDate(draftFiling.business.foundingDate || this.getBusinessFoundingDate)
-    this.setBusinessStartDate(this.getBusinessStartDate)
+    this.setBusinessStartDate(draftFiling.business.startDate || this.getBusinessStartDate)
 
     // restore Dissolution data
     this.setBusinessAddress(draftFiling.dissolution.custodialOffice)

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -29,6 +29,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
   @Getter(useStore) getBusinessLegalName!: string
   @Getter(useStore) getBusinessLegalType!: CorpTypeCd
   @Getter(useStore) getBusinessOfficeAddress!: OfficeAddressIF
+  @Getter(useStore) getBusinessStartDate!: string
   @Getter(useStore) getCertifyState!: CertifyIF
   @Getter(useStore) getCompletingParty!: CompletingPartyIF
   @Getter(useStore) getCorrectNameOption!: CorrectNameOptions
@@ -111,6 +112,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
   @Action(useStore) setRules!: (x: CreateRulesIF) => void
   @Action(useStore) setShareClasses!: (x: ShareClassIF[]) => void
   @Action(useStore) setStaffPayment!: (x: StaffPaymentIF) => void
+  @Action(useStore) setBusinessStartDate!: (x: string) => void
   @Action(useStore) setTransactionalFolioNumber!: (x: string) => void
 
   /**
@@ -829,6 +831,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
     this.setEntityType(draftFiling.business.legalType || this.getBusinessLegalType)
     this.setLegalName(draftFiling.business.legalName || this.getBusinessLegalName)
     this.setFoundingDate(draftFiling.business.foundingDate || this.getBusinessFoundingDate)
+    this.setBusinessStartDate(this.getBusinessStartDate)
 
     // restore Dissolution data
     this.setBusinessAddress(draftFiling.dissolution.custodialOffice)

--- a/src/store/state/state-model.ts
+++ b/src/store/state/state-model.ts
@@ -55,6 +55,7 @@ export const stateModel: StateModelIF = {
     taxId: '',
     state: null,
     stateFiling: '',
+    startDate: '',
     submitter: ''
   },
   businessContact: { ...EmptyContactPoint },

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -280,6 +280,11 @@ export const useStore = defineStore('store', {
       return this.stateModel.business.foundingDate
     },
 
+    /** The Business Start Date. */
+    getBusinessStartDate (): string {
+      return this.stateModel.business.startDate
+    },
+
     /** The Business Office Address. */
     getBusinessOfficeAddress (): OfficeAddressIF {
       return this.stateModel.business.officeAddress
@@ -864,6 +869,9 @@ export const useStore = defineStore('store', {
     },
     setBusinessAddress (address: OfficeAddressIF) {
       this.stateModel.business.officeAddress = address
+    },
+    setBusinessStartDate (startDate: string) {
+      this.stateModel.business.startDate = startDate
     },
     setLegalName (legalName: string) {
       this.stateModel.business.legalName = legalName


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17216

*Description of changes:*

Show start date for a firm dissolution filing

Business start date in Business info section:
![image](https://github.com/bcgov/business-create-ui/assets/116035339/42f9bc4c-dd55-473b-a225-33869b3bd104)

Before:
![image](https://github.com/bcgov/business-create-ui/assets/116035339/980972af-07d8-459f-a1fc-76cf62d39b3b)


After:
![image](https://github.com/bcgov/business-create-ui/assets/116035339/21ed93ca-b7d8-48b4-a494-b2c49994d4ce)


Note: Dissolution date rules do not need to be updated. It is working as expected. Confirmed with Mihai.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
