### PR TITLE
15863 removed the shift of radio buttons in approval and restoration …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.5.1",
+      "version": "5.5.2",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.5.4",
+  "version": "5.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.5.4",
+      "version": "5.5.3",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.5.3",
+  "version": "5.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.5.3",
+      "version": "5.5.4",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.5.2",
+  "version": "5.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.5.2",
+      "version": "5.5.4",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.5.2",
+  "version": "5.5.4",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.5.4",
+  "version": "5.5.3",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.5.3",
+  "version": "5.5.4",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Restoration/ApprovalType.vue
+++ b/src/components/Restoration/ApprovalType.vue
@@ -3,6 +3,7 @@
     <div
       class="section-container"
       :class="{ 'invalid-section': invalidSection }"
+      :style="invalidSection ? {margin: '0 9px 0 0'} : {}"
     >
       <ApprovalTypeShared
         :courtOrderNumber="getRestoration.courtOrder.fileNumber"

--- a/src/components/Restoration/ApprovalType.vue
+++ b/src/components/Restoration/ApprovalType.vue
@@ -2,8 +2,6 @@
   <div id="approval-type">
     <div
       class="section-container"
-      :class="{ 'invalid-section': invalidSection }"
-      :style="invalidSection ? {margin: '0 9px 0 0'} : {}"
     >
       <ApprovalTypeShared
         :courtOrderNumber="getRestoration.courtOrder.fileNumber"

--- a/src/components/Restoration/RestorationType.vue
+++ b/src/components/Restoration/RestorationType.vue
@@ -3,6 +3,7 @@
     <div
       class="section-container"
       :class="{ 'invalid-section': invalidSection }"
+      :style="invalidSection ? {margin: '0 9px 0 0'} : {}"
     >
       <v-row no-gutters>
         <v-col

--- a/src/components/Restoration/RestorationType.vue
+++ b/src/components/Restoration/RestorationType.vue
@@ -2,8 +2,6 @@
   <div id="restoration-type">
     <div
       class="section-container"
-      :class="{ 'invalid-section': invalidSection }"
-      :style="invalidSection ? {margin: '0 9px 0 0'} : {}"
     >
       <v-row no-gutters>
         <v-col

--- a/src/views/Restoration/RestorationBusinessName.vue
+++ b/src/views/Restoration/RestorationBusinessName.vue
@@ -41,8 +41,8 @@
         flat
         class="mt-5"
       >
-        <RestorationType 
-          id="restoration-type" 
+        <RestorationType
+          id="restoration-type"
           class="mb-n5"
           :class="{ 'approval-restoration-invalid-section': invalidSectionRestoration }"
         />

--- a/src/views/Restoration/RestorationBusinessName.vue
+++ b/src/views/Restoration/RestorationBusinessName.vue
@@ -41,7 +41,11 @@
         flat
         class="mt-5"
       >
-        <RestorationType id="restoration-type" class="mb-n5"/>
+        <RestorationType 
+          id="restoration-type" 
+          class="mb-n5"
+          :class="{ 'approval-restoration-invalid-section': invalidSectionRestoration }"
+        />
 
         <!-- Divider b/w Restoration and Approval type -->
         <v-divider class="mb-11 mr-5 ml-5"></v-divider>
@@ -49,6 +53,7 @@
         <ApprovalType
           id="approval-type"
           class="mt-n10"
+          :class="{ 'approval-restoration-invalid-section': invalidSectionApproval }"
         />
       </v-card>
     </section>
@@ -107,6 +112,15 @@ export default class RestorationBusinessName extends Mixins(CommonMixin) {
     }
   }
 
+  /** This section's validity state for Restoration and Approval (when prompted by app). */
+  get invalidSectionApproval (): boolean {
+    return (this.getShowErrors && !this.getApprovalTypeValid)
+  }
+
+  get invalidSectionRestoration (): boolean {
+    return (this.getShowErrors && !this.getRestorationTypeValid)
+  }
+
   /** Called when component is created. */
   created (): void {
     // temporarily ignore data changes
@@ -145,5 +159,12 @@ h2::before {
 
 header p {
   padding-top: 0.5rem;
+}
+
+/* Invalid Section border for Approval and Restoration Type */
+.approval-restoration-invalid-section{
+  box-shadow: inset 3px 0 0 $app-red;
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
 }
 </style>


### PR DESCRIPTION
…type

*Issue #:* /bcgov/entity#15863

*Description of changes:*

- The radio buttons in Approval Type and Restoration Type shift when the field is invalid (or left blank). The changes removes that shift by adjusting the margins of the invalid section. 

![image](https://github.com/bcgov/business-create-ui/assets/144158015/5931a7c7-df35-4921-b6d0-f1e16664fcc9)

![image](https://github.com/bcgov/business-create-ui/assets/144158015/6204b25f-205e-4fac-a4ee-f3148fa96cfc)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
