### PR TITLE
18102 Show full legal name of the account holder at Certify when filing IA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.5.5",
+  "version": "5.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.5.5",
+      "version": "5.5.6",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.5.5",
+  "version": "5.5.6",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -776,7 +776,7 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
         this.setCertifyState(
           {
             valid: this.getCertifyState.valid,
-            certifiedBy: userInfo.firstName
+            certifiedBy: userInfo.firstname
               ? `${userInfo.firstname} ${userInfo.lastname}`
               : `${userInfo.lastname}`
           }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18102

*Description of changes:*
- fixed typo to show full legal name of account holder at Certify for IAs
- app version = 5.5.6

![image](https://github.com/bcgov/business-create-ui/assets/60866283/d1f5fd78-2cc9-4240-8e7a-9cf708bdd7da)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
