### PR TITLE
Fixed Dissolution Date bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.5.6",
+  "version": "5.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.5.6",
+      "version": "5.5.7",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.5.6",
+  "version": "5.5.7",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/rules/date-rules.ts
+++ b/src/rules/date-rules.ts
@@ -16,18 +16,21 @@ export const DateRuleHelpers = {
     if (!dateStrToValidate) return true
     const date = new Date(dateStrToValidate) // eg, September 5, 2022
     minDate.setHours(0, 0, 0) // Removing the hour to properly compare in case selected date was same as minimum.
+    maxDate.setHours(0, 0, 0)
     return (date >= minDate) && (date <= maxDate)
   },
   /** Whether date string to validate is not before min date. */
   isNotBeforeDate (minDate: Date, dateStrToValidate: string): boolean {
     if (!dateStrToValidate) return true
     const date = new Date(dateStrToValidate) // eg, September 5, 2022
+    minDate.setHours(0, 0, 0)
     return (date >= minDate)
   },
   /** Whether date string to validate is not after max date. */
   isNotAfterDate (maxDate: Date, dateStrToValidate: string): boolean {
     if (!dateStrToValidate) return true
     const date = new Date(dateStrToValidate) // eg, September 5, 2022
+    maxDate.setHours(0, 0, 0)
     return (date <= maxDate)
   }
 }

--- a/src/rules/date-rules.ts
+++ b/src/rules/date-rules.ts
@@ -16,7 +16,7 @@ export const DateRuleHelpers = {
     if (!dateStrToValidate) return true
     const date = new Date(dateStrToValidate) // eg, September 5, 2022
     minDate.setHours(0, 0, 0) // Removing the hour to properly compare in case selected date was same as minimum.
-    maxDate.setHours(0, 0, 0)
+    maxDate.setHours(23, 59, 59)
     return (date >= minDate) && (date <= maxDate)
   },
   /** Whether date string to validate is not before min date. */

--- a/src/rules/date-rules.ts
+++ b/src/rules/date-rules.ts
@@ -30,7 +30,7 @@ export const DateRuleHelpers = {
   isNotAfterDate (maxDate: Date, dateStrToValidate: string): boolean {
     if (!dateStrToValidate) return true
     const date = new Date(dateStrToValidate) // eg, September 5, 2022
-    maxDate.setHours(0, 0, 0)
+    maxDate.setHours(23, 59, 59)
     return (date <= maxDate)
   }
 }

--- a/src/rules/date-rules.ts
+++ b/src/rules/date-rules.ts
@@ -15,6 +15,7 @@ export const DateRuleHelpers = {
   isBetweenDates (minDate: Date, maxDate: Date, dateStrToValidate: string): boolean {
     if (!dateStrToValidate) return true
     const date = new Date(dateStrToValidate) // eg, September 5, 2022
+    minDate.setHours(0, 0, 0) // Removing the hour to properly compare in case selected date was same as minimum.
     return (date >= minDate) && (date <= maxDate)
   },
   /** Whether date string to validate is not before min date. */

--- a/src/views/DissolutionFirm/DissolutionFirm.vue
+++ b/src/views/DissolutionFirm/DissolutionFirm.vue
@@ -58,7 +58,7 @@
         <h2>Business Dissolution Date</h2>
         <p class="mt-4 ">
           Enter the dissolution date of the business.
-          The dissolution date must be after the business start date and registration date.
+          The dissolution date must be on or after the registration date.
           The dissolution date cannot be in the future.
         </p>
       </header>
@@ -469,7 +469,7 @@ export default class DissolutionFirm extends Mixins(DateMixin) {
   /** The minimum start date that can be entered (greater than registration date). */
   get startDateMin (): Date {
     const date = this.apiToDate(this.getBusinessFoundingDate)
-    date.setDate(date.getDate() + 1)
+    date.setDate(date.getDate())
     return date
   }
 

--- a/tests/unit/DissolutionFirm.spec.ts
+++ b/tests/unit/DissolutionFirm.spec.ts
@@ -151,7 +151,8 @@ for (const test of dissolutionFirmTestCases) {
       expect(rules[0]('')).toBe('Dissolution date is required') // no date is selected
       expect(rules[0]('October 16, 2023')).toBe(true) // date is selected
       // A date before the registration date is selected (invalid)
-      expect(rules[1]('June 5, 2022')).toContain('Dissolution Date must be after June 6')
+      expect(rules[1]('June 5, 2022')).toContain('Dissolution Date must be after June 6, 2022 and up to')
+      expect(rules[1]('June 5, 2022')).toContain('June 14, 2022')
       // A valid date is selected (on registration date)
       expect(rules[1]('June 6, 2022')).toBe(true)
       // A valid date is selected (after registration date and not in the future)

--- a/tests/unit/DissolutionFirm.spec.ts
+++ b/tests/unit/DissolutionFirm.spec.ts
@@ -155,6 +155,9 @@ for (const test of dissolutionFirmTestCases) {
       expect(rules[1]('June 6, 2022')).toBe(true)
       // A valid date is selected (after registration date and not in the future)
       expect(rules[1]('June 7, 2022')).toBe(true)
+      // An invalid date is selected (in the future)
+      expect(rules[1]('September 7, 2022')).toContain('Dissolution Date must be after June 6, 2022 and up to')
+      expect(rules[1]('September 7, 2022')).toContain('June 14, 2022')
     })
   })
 }

--- a/tests/unit/DissolutionFirm.spec.ts
+++ b/tests/unit/DissolutionFirm.spec.ts
@@ -145,6 +145,7 @@ for (const test of dissolutionFirmTestCases) {
         { vuetify }
       )
       const rules = wrapper.vm.startDateRules
+      store.stateModel.business.foundingDate = '2022-06-06T23:59:59.000+00:00'
       store.setCurrentJsDate(new Date('2022-06-14T00:00:00.000'))
 
       expect(rules[0]('')).toBe('Dissolution date is required') // no date is selected

--- a/tests/unit/DissolutionFirm.spec.ts
+++ b/tests/unit/DissolutionFirm.spec.ts
@@ -145,12 +145,13 @@ for (const test of dissolutionFirmTestCases) {
         { vuetify }
       )
       const rules = wrapper.vm.startDateRules
-      store.setCurrentJsDate(new Date('2022-06-14T12:00:00.000Z'))
+      store.setCurrentJsDate(new Date('2022-06-14T00:00:00.000'))
 
       expect(rules[0]('')).toBe('Dissolution date is required') // no date is selected
       expect(rules[0]('October 16, 2023')).toBe(true) // date is selected
       // A date before the registration date is selected (invalid)
-      expect(rules[1]('June 5, 2022')).toBe('Dissolution Date must be after June 6, 2022 and up to\n        June 14, 2022')
+      expect(rules[1]('June 5, 2022')).toContain('Dissolution Date must be after June 6, 2022 and up to')
+      expect(rules[1]('June 5, 2022')).toContain('June 14, 2022')
       // A valid date is selected (after registration date and not in the future)
       expect(rules[1]('June 7, 2022')).toBe(true)
     })

--- a/tests/unit/DissolutionFirm.spec.ts
+++ b/tests/unit/DissolutionFirm.spec.ts
@@ -138,5 +138,22 @@ for (const test of dissolutionFirmTestCases) {
       expect(errorMessages.at(0).text()).toBe('Cannot exceed 20 characters')
       expect(errorMessages.at(1).text()).toBe('Cannot exceed 20 characters')
     })
+
+    it('display correct date rules', async () => {
+      wrapper = mount(
+        DissolutionFirm,
+        { vuetify }
+      )
+      const rules = wrapper.vm.startDateRules
+      store.setCurrentJsDate(new Date('2022-06-14T12:00:00.000Z'))
+
+      expect(rules[0]('')).toBe('Dissolution date is required') // no date is selected
+      expect(rules[0]('October 16, 2023')).toBe(true) // date is selected
+      // A date before the registration date is selected (invalid)
+      expect(rules[1]('June 5, 2022')).toContain('Dissolution Date must be after June 6, 2022 and up to')
+      expect(rules[1]('June 5, 2022')).toContain('June 14, 2022')
+      // A valid date is selected (after registration date and not in the future)
+      expect(rules[1]('June 7, 2022')).toBe(true)
+    })
   })
 }

--- a/tests/unit/DissolutionFirm.spec.ts
+++ b/tests/unit/DissolutionFirm.spec.ts
@@ -150,8 +150,7 @@ for (const test of dissolutionFirmTestCases) {
       expect(rules[0]('')).toBe('Dissolution date is required') // no date is selected
       expect(rules[0]('October 16, 2023')).toBe(true) // date is selected
       // A date before the registration date is selected (invalid)
-      expect(rules[1]('June 5, 2022')).toContain('Dissolution Date must be after June 6, 2022 and up to')
-      expect(rules[1]('June 5, 2022')).toContain('June 14, 2022')
+      expect(rules[1]('June 5, 2022')).toBe('Dissolution Date must be after June 6, 2022 and up to\n        June 14, 2022')
       // A valid date is selected (after registration date and not in the future)
       expect(rules[1]('June 7, 2022')).toBe(true)
     })

--- a/tests/unit/DissolutionFirm.spec.ts
+++ b/tests/unit/DissolutionFirm.spec.ts
@@ -150,8 +150,9 @@ for (const test of dissolutionFirmTestCases) {
       expect(rules[0]('')).toBe('Dissolution date is required') // no date is selected
       expect(rules[0]('October 16, 2023')).toBe(true) // date is selected
       // A date before the registration date is selected (invalid)
-      expect(rules[1]('June 5, 2022')).toContain('Dissolution Date must be after June 6, 2022 and up to')
-      expect(rules[1]('June 5, 2022')).toContain('June 14, 2022')
+      expect(rules[1]('June 5, 2022')).toContain('Dissolution Date must be after June 6')
+      // A valid date is selected (on registration date)
+      expect(rules[1]('June 6, 2022')).toBe(true)
       // A valid date is selected (after registration date and not in the future)
       expect(rules[1]('June 7, 2022')).toBe(true)
     })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18008

*Description of changes:*
- Fixed the bug in which the UI doesn't let the user select a dissolution date that is the same as the registration date.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
