### PR TITLE
18535 Amalgamating Businesses Part 1 Continuation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.6.7",
+  "version": "5.6.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.6.7",
+      "version": "5.6.8",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@bcrs-shared-components/approval-type": "1.0.19",
         "@bcrs-shared-components/base-address": "2.0.3",
         "@bcrs-shared-components/breadcrumb": "2.1.15",
-        "@bcrs-shared-components/business-lookup": "1.2.3",
+        "@bcrs-shared-components/business-lookup": "1.2.4",
         "@bcrs-shared-components/certify": "2.1.15",
         "@bcrs-shared-components/completing-party": "2.1.30",
         "@bcrs-shared-components/confirm-dialog": "1.2.1",
@@ -271,9 +271,9 @@
       }
     },
     "node_modules/@bcrs-shared-components/business-lookup": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/business-lookup/-/business-lookup-1.2.3.tgz",
-      "integrity": "sha512-oC4PuqiNLDXo7cd/YxGm5MqpyAi8vmXiHYdlALhCVpbGjXOuPBWA7DIHVZz0twtP/hg2J8y/01QTiUA5gD/s/w==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/business-lookup/-/business-lookup-1.2.4.tgz",
+      "integrity": "sha512-YkMgEJH5Ant5zlqfZBZda8U95x0ZJOxxifh4XLADZEdFdznf2NrvwlQI0fOT5mL1Zp9OyrJa/uOgPWuh2KeDKQ==",
       "dependencies": {
         "@bcrs-shared-components/interfaces": "^1.1.2",
         "lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.6.7",
+  "version": "5.6.8",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@bcrs-shared-components/approval-type": "1.0.19",
     "@bcrs-shared-components/base-address": "2.0.3",
     "@bcrs-shared-components/breadcrumb": "2.1.15",
-    "@bcrs-shared-components/business-lookup": "1.2.3",
+    "@bcrs-shared-components/business-lookup": "1.2.4",
     "@bcrs-shared-components/certify": "2.1.15",
     "@bcrs-shared-components/completing-party": "2.1.30",
     "@bcrs-shared-components/confirm-dialog": "1.2.1",

--- a/src/components/Amalgamation/AmalgamatingBusinesses.vue
+++ b/src/components/Amalgamation/AmalgamatingBusinesses.vue
@@ -212,19 +212,20 @@ export default class AmalgamatingBusinesses extends Mixins(CommonMixin) {
       business = data[0].data?.business
       business.businessContact = data[1].contacts[0]
       business.officeAddress = data[2]
-    } else {
-      business = businessLookup
     }
 
+    // If the business is not null (LEAR Entity)
     // If the amalgamating businesses array is not empty, check if identifier already exists.
     // If identifier already exists, don't add the business to the array.
-    if (this.amalgamatingBusinesses.length > 0) {
-      const businessExists = this.amalgamatingBusinesses.find(function (id) {
-        return id.identifier === business.identifier
-      })
-      if (!businessExists) this.amalgamatingBusinesses.push(business)
-    } else {
-      this.amalgamatingBusinesses.push(business)
+    if (business) {
+      if (this.amalgamatingBusinesses) {
+        const businessExists = this.amalgamatingBusinesses.find(
+          (id) => id.identifier === business.identifier
+        )
+        if (!businessExists) this.amalgamatingBusinesses.push(business)
+      } else {
+        this.amalgamatingBusinesses.push(business)
+      }
     }
 
     // Set the amalgamated businesses array in the store.

--- a/src/components/Amalgamation/AmalgamatingBusinesses.vue
+++ b/src/components/Amalgamation/AmalgamatingBusinesses.vue
@@ -215,26 +215,25 @@ export default class AmalgamatingBusinesses extends Mixins(CommonMixin) {
       business.officeAddress = data[2]
     }
 
-    const tingBusiness = {
-      type: 'lear',
-      role: AmlRoles.AMALGAMATING,
-      identifier: business.identifier,
-      name: business.legalName,
-      email: business.businessContact.email,
-      legalType: business.legalType,
-      address: business.officeAddress.registeredOffice.mailingAddress,
-      goodStanding: business.goodStanding
-    } as AmalgamatingBusinessIF
-
-    // If the business is not null (LEAR Entity)
+    // If the business is not null (LEAR Entity), create from it a TING business following the interface.
     // If the amalgamating businesses array is not empty, check if identifier already exists.
     // If identifier already exists, don't add the business to the array.
     if (business) {
+      const tingBusiness = {
+        type: 'lear',
+        role: AmlRoles.AMALGAMATING,
+        identifier: business.identifier,
+        name: business.legalName,
+        email: business.businessContact.email,
+        legalType: business.legalType,
+        address: business.officeAddress.registeredOffice.mailingAddress,
+        goodStanding: business.goodStanding
+      } as AmalgamatingBusinessIF
+
       if (this.amalgamatingBusinesses) {
-        const businessExists = this.amalgamatingBusinesses.find(
-          (id) => id.identifier === business.identifier
-        )
-        if (!businessExists) this.amalgamatingBusinesses.push(tingBusiness)
+        if (!this.amalgamatingBusinesses.find(b => b.identifier === business.identifier)) {
+          this.amalgamatingBusinesses.push(tingBusiness)
+        }
       } else {
         this.amalgamatingBusinesses.push(tingBusiness)
       }

--- a/src/components/Amalgamation/AmalgamatingBusinesses.vue
+++ b/src/components/Amalgamation/AmalgamatingBusinesses.vue
@@ -145,6 +145,7 @@ import { CommonMixin } from '@/mixins'
 import { AuthServices, BusinessLookupServices, LegalServices } from '@/services'
 import { BusinessLookup } from '@bcrs-shared-components/business-lookup'
 import { AmalgamatingBusinessIF, BusinessLookupIF, EmptyBusinessLookup } from '@/interfaces'
+import { AmlRoles } from '@/enums'
 import BusinessTable from '@/components/Amalgamation/BusinessTable.vue'
 
 @Component({
@@ -214,6 +215,17 @@ export default class AmalgamatingBusinesses extends Mixins(CommonMixin) {
       business.officeAddress = data[2]
     }
 
+    const tingBusiness = {
+      type: 'lear',
+      role: AmlRoles.AMALGAMATING,
+      identifier: business.identifier,
+      name: business.legalName,
+      email: business.businessContact.email,
+      legalType: business.legalType,
+      address: business.officeAddress.registeredOffice.mailingAddress,
+      goodStanding: business.goodStanding
+    } as AmalgamatingBusinessIF
+
     // If the business is not null (LEAR Entity)
     // If the amalgamating businesses array is not empty, check if identifier already exists.
     // If identifier already exists, don't add the business to the array.
@@ -222,9 +234,9 @@ export default class AmalgamatingBusinesses extends Mixins(CommonMixin) {
         const businessExists = this.amalgamatingBusinesses.find(
           (id) => id.identifier === business.identifier
         )
-        if (!businessExists) this.amalgamatingBusinesses.push(business)
+        if (!businessExists) this.amalgamatingBusinesses.push(tingBusiness)
       } else {
-        this.amalgamatingBusinesses.push(business)
+        this.amalgamatingBusinesses.push(tingBusiness)
       }
     }
 

--- a/src/components/Amalgamation/AmalgamatingBusinesses.vue
+++ b/src/components/Amalgamation/AmalgamatingBusinesses.vue
@@ -155,11 +155,13 @@ import BusinessTable from '@/components/Amalgamation/BusinessTable.vue'
 })
 export default class AmalgamatingBusinesses extends Mixins(CommonMixin) {
   @Getter(useStore) getAmalgamatingBusinesses!: AmalgamatingBusinessIF[]
+  @Getter(useStore) getAmalgamatingBusinessesValid!: boolean
   @Getter(useStore) getShowErrors!: boolean
   @Getter(useStore) isAmalgamationFilingHorizontal!: boolean
   @Getter(useStore) isRoleStaff!: boolean
 
   @Action(useStore) setAmalgamatingBusinesses!: (x: Array<any>) => void
+  @Action(useStore) setAmalgamatingBusinessesValid!: (x: boolean) => void
 
   // Local properties
   amalgamatingBusinessesValid = false
@@ -176,18 +178,21 @@ export default class AmalgamatingBusinesses extends Mixins(CommonMixin) {
   // Cancel button in "Add an Amalgamating Business" is pressed.
   addAmalgamatingBusinessCancel (): void {
     this.isAddingAmalgamatingBusiness = false
+    this.setAmalgamatingBusinessesValid(true)
   }
 
   // "Add an Amalgamating Business" button is pressed.
   onAddBusinessClick (): void {
     this.isAddingAmalgamatingBusiness = true
     this.isAddingAmalgamatingForeignBusiness = false
+    this.setAmalgamatingBusinessesValid(false)
   }
 
   // "Add an Amalgamating Foreign Business" button is pressed.
   onAddForeignBusinessClick (): void {
     this.isAddingAmalgamatingBusiness = false
     this.isAddingAmalgamatingForeignBusiness = true
+    this.setAmalgamatingBusinessesValid(false)
   }
 
   async saveAmalgamatingBusiness (businessLookup: BusinessLookupIF): Promise<void> {
@@ -227,6 +232,7 @@ export default class AmalgamatingBusinesses extends Mixins(CommonMixin) {
 
     // Close the "Add an Amalgamating Business" Panel.
     this.isAddingAmalgamatingBusiness = false
+    this.setAmalgamatingBusinessesValid(true)
   }
 }
 </script>

--- a/src/components/Amalgamation/AmalgamatingBusinesses.vue
+++ b/src/components/Amalgamation/AmalgamatingBusinesses.vue
@@ -52,6 +52,7 @@
               :showErrors="false"
               :businessLookup="initialBusinessLookupObject"
               :BusinessLookupServices="BusinessLookupServices"
+              legalTypes="BC,BEN,CC,ULC,A"
               label="Business Name or Incorporation Number"
               @setBusiness="saveAmalgamatingBusiness($event)"
             />
@@ -111,7 +112,8 @@
           <template v-if="business.foundingDate">
             Legal Name: {{ business.legalName }} <br>
             Legal Type: {{ business.legalType }} <br>
-            Mailing Address: {{ business.officeAddress.mailingAddress }} <br>
+            Mailing Address: {{ business.officeAddress.registeredOffice.mailingAddress }} <br>
+            Email Address: {{ business.businessContact.email }} <br>
             State: {{ business.state }} <br>
             Good Standing: {{ business.goodStanding }} <br>
         </template>
@@ -140,7 +142,7 @@ import { Component, Mixins } from 'vue-property-decorator'
 import { Action, Getter } from 'pinia-class'
 import { useStore } from '@/store/store'
 import { CommonMixin } from '@/mixins'
-import { BusinessLookupServices, LegalServices } from '@/services'
+import { AuthServices, BusinessLookupServices, LegalServices } from '@/services'
 import { BusinessLookup } from '@bcrs-shared-components/business-lookup'
 import { AmalgamatingBusinessIF, BusinessLookupIF, EmptyBusinessLookup } from '@/interfaces'
 import BusinessTable from '@/components/Amalgamation/BusinessTable.vue'
@@ -189,27 +191,24 @@ export default class AmalgamatingBusinesses extends Mixins(CommonMixin) {
   }
 
   async saveAmalgamatingBusiness (businessLookup: BusinessLookupIF): Promise<void> {
-    // Get the amalgamating business information
-    // Will have a different format depending on the business
-    let business = await LegalServices.fetchBusinessInfo(businessLookup.identifier)
-      .then((response) => {
-        return response?.data?.business
-      }).catch(() => {
-        return businessLookup
-      })
+    let business = null
 
-    // Get the address of the amalgamating business
-    if (businessLookup.identifier && business.foundingDate) {
-      const addresses = await LegalServices.fetchAddresses(businessLookup.identifier)
-        .then((data) => {
-          // SP and GP have businessOffice instead of registeredOffice
-          return data?.registeredOffice || data?.businessOffice
-        }).catch(() => {
-          return undefined
-        })
-      if (addresses) {
-        business.officeAddress = addresses
-      }
+    // Get the amalgamating business information, mailing address, and email if in LEAR.
+    // Otherwise, return the businesslookup object.
+    const data = await Promise.all([
+      LegalServices.fetchBusinessInfo(businessLookup.identifier),
+      AuthServices.fetchAuthInfo(businessLookup.identifier),
+      LegalServices.fetchAddresses(businessLookup.identifier)
+    ]).catch((error) => {
+      return error
+    })
+
+    if (data.length === 3) {
+      business = data[0].data?.business
+      business.businessContact = data[1].contacts[0]
+      business.officeAddress = data[2]
+    } else {
+      business = businessLookup
     }
 
     // If the amalgamating businesses array is not empty, check if identifier already exists.

--- a/src/components/Amalgamation/AmalgamatingBusinesses.vue
+++ b/src/components/Amalgamation/AmalgamatingBusinesses.vue
@@ -230,11 +230,7 @@ export default class AmalgamatingBusinesses extends Mixins(CommonMixin) {
         goodStanding: business.goodStanding
       } as AmalgamatingBusinessIF
 
-      if (this.amalgamatingBusinesses) {
-        if (!this.amalgamatingBusinesses.find(b => b.identifier === business.identifier)) {
-          this.amalgamatingBusinesses.push(tingBusiness)
-        }
-      } else {
+      if (!this.amalgamatingBusinesses.find(b => b.identifier === business.identifier)) {
         this.amalgamatingBusinesses.push(tingBusiness)
       }
     }

--- a/src/interfaces/store-interfaces/state-interfaces/amalgamation-state-interface.ts
+++ b/src/interfaces/store-interfaces/state-interfaces/amalgamation-state-interface.ts
@@ -43,5 +43,6 @@ export type AmalgamatingBusinessIF = AmalgamatingLearIF | AmalgamatingForeignIF
 export interface AmalgamationStateIF {
   amalgamatingBusinesses: Array<AmalgamatingBusinessIF>
   courtApproval: boolean
+  amalgamatingBusinessesValid: boolean
   type: AmalgamationTypes
 }

--- a/src/services/business-lookup-services.ts
+++ b/src/services/business-lookup-services.ts
@@ -30,6 +30,8 @@ export default class BusinessLookupServices {
   /**
    * Searches for business by code or words.
    * @param query code or words to search
+   * @param searchStatus not used here but needed as it's a parameter needed for other UIs
+   * @param legalTypes the legal types we're searching for
    * @returns a promise to return the search results
    */
   static async search (query: string, searchStatus: string, legalTypes: string): Promise<BusinessLookupResultIF[]> {

--- a/src/services/business-lookup-services.ts
+++ b/src/services/business-lookup-services.ts
@@ -32,10 +32,9 @@ export default class BusinessLookupServices {
    * @param query code or words to search
    * @returns a promise to return the search results
    */
-  static async search (query: string): Promise<BusinessLookupResultIF[]> {
-    const legalType = 'BC,A,ULC,C,S,XP,GP,LP,CUL,XS,LLC,LL,BEN,CP,CC,XL,FI,XCP,PA'
+  static async search (query: string, searchStatus: string, legalTypes: string): Promise<BusinessLookupResultIF[]> {
     const url = this.businessApiUrl +
-      `businesses/search/facets?start=0&rows=20&categories=legalType:${legalType}::status:ACTIVE` +
+      `businesses/search/facets?start=0&rows=20&categories=legalType:${legalTypes}::status:ACTIVE` +
       `&query=value:${encodeURIComponent(query)}`
 
     return axios.get(url, {

--- a/src/store/state/state-model.ts
+++ b/src/store/state/state-model.ts
@@ -323,6 +323,7 @@ export const stateModel: StateModelIF = {
   },
   amalgamation: {
     amalgamatingBusinesses: cloneDeep(AMALGAMATING_BUSINESSES),
+    amalgamatingBusinessesValid: false,
     courtApproval: null,
     type: null
   },

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -746,6 +746,11 @@ export const useStore = defineStore('store', {
       return this.stateModel.amalgamation.amalgamatingBusinesses
     },
 
+    /** The amalgamating businesses validity. */
+    getAmalgamatingBusinessesValid (): boolean {
+      return this.stateModel.amalgamation.amalgamatingBusinessesValid
+    },
+
     //
     // Dissolution getters
     //
@@ -1223,6 +1228,9 @@ export const useStore = defineStore('store', {
     },
     setAmalgamatingBusinesses (amalgamatingBusinesses: Array<AmalgamatingBusinessIF>) {
       this.stateModel.amalgamation.amalgamatingBusinesses = amalgamatingBusinesses
+    },
+    setAmalgamatingBusinessesValid (valid: boolean) {
+      this.stateModel.amalgamation.amalgamatingBusinessesValid = valid
     },
     setAmalgamationType (type: AmalgamationTypes) {
       this.stateModel.amalgamation.type = type

--- a/tests/unit/business-lookup-services.spec.ts
+++ b/tests/unit/business-lookup-services.spec.ts
@@ -24,7 +24,9 @@ describe('Business Lookup Services', () => {
       .returns(new Promise(resolve => resolve({ data: { searchResults: { results: [result] } } })))
 
     // search and look at results
-    const results = await BusinessLookupServices.search('FM1000002')
+    const results = await BusinessLookupServices.search(
+      'FM1000002', 'ACTIVE', 'BC,A,ULC,C,S,XP,GP,LP,CUL,XS,LLC,LL,BEN,CP,CC,XL,FI,XCP,PA'
+    )
     expect(results.length).toBe(1)
     expect(results[0]).toEqual(result)
 
@@ -39,7 +41,9 @@ describe('Business Lookup Services', () => {
       .returns(new Promise(resolve => resolve({ data: { searchResults: { results: [] } } })))
 
     // search and look at results
-    const results = await BusinessLookupServices.search('FM1000003')
+    const results = await BusinessLookupServices.search(
+      'FM1000003', 'ACTIVE', 'BC,A,ULC,C,S,XP,GP,LP,CUL,XS,LLC,LL,BEN,CP,CC,XL,FI,XCP,PA'
+    )
     expect(results.length).toBe(0)
 
     sinon.restore()


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18535

*Description of changes:*
- Continuation of Amalgamating Businesses part 1
- Updated business lookup to search only for: A, BEN, CC, BC, and ULC
- Refactored the saveAmalgamatingBusiness to make parallel calls + added email fetching
- Setting the AmalgamatingBusiness component validation (store getter and setter)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
