### PR TITLE
18640 More amalgamating fetch / validations work

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "business-create-ui",
-  "version": "5.6.10",
+  "version": "5.6.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.6.10",
+      "version": "5.6.11",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",
         "@bcrs-shared-components/base-address": "2.0.3",
         "@bcrs-shared-components/breadcrumb": "2.1.15",
-        "@bcrs-shared-components/business-lookup": "1.2.4",
+        "@bcrs-shared-components/business-lookup": "1.2.5",
         "@bcrs-shared-components/certify": "2.1.15",
         "@bcrs-shared-components/completing-party": "2.1.30",
         "@bcrs-shared-components/confirm-dialog": "1.2.1",
@@ -271,9 +271,9 @@
       }
     },
     "node_modules/@bcrs-shared-components/business-lookup": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/business-lookup/-/business-lookup-1.2.4.tgz",
-      "integrity": "sha512-YkMgEJH5Ant5zlqfZBZda8U95x0ZJOxxifh4XLADZEdFdznf2NrvwlQI0fOT5mL1Zp9OyrJa/uOgPWuh2KeDKQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/business-lookup/-/business-lookup-1.2.5.tgz",
+      "integrity": "sha512-HEqjK+MxkweJm+YuvRQ0/Z4Nw4Whk7kdx56awvYBijlf0mC6xylbN2Pr2hmqDX/kxiieNZBpjtCtA83/Pm/3uw==",
       "dependencies": {
         "@bcrs-shared-components/interfaces": "^1.1.2",
         "lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.6.10",
+  "version": "5.6.11",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",
@@ -17,7 +17,7 @@
     "@bcrs-shared-components/approval-type": "1.0.19",
     "@bcrs-shared-components/base-address": "2.0.3",
     "@bcrs-shared-components/breadcrumb": "2.1.15",
-    "@bcrs-shared-components/business-lookup": "1.2.4",
+    "@bcrs-shared-components/business-lookup": "1.2.5",
     "@bcrs-shared-components/certify": "2.1.15",
     "@bcrs-shared-components/completing-party": "2.1.30",
     "@bcrs-shared-components/confirm-dialog": "1.2.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -249,7 +249,7 @@ import * as Views from '@/views'
 
 // Mixins, interfaces, etc
 import { CommonMixin, DateMixin, FilingTemplateMixin, NameRequestMixin } from '@/mixins'
-import { AccountInformationIF, AddressIF, BreadcrumbIF, BusinessIF, BusinessWarningIF, CompletingPartyIF,
+import { AccountInformationIF, AddressIF, BreadcrumbIF, BusinessWarningIF, CompletingPartyIF,
   ConfirmDialogType, EmptyFees, FeesIF, FilingDataIF, NameRequestIF, OrgInformationIF, PartyIF, ResourceIF,
   StepIF } from '@/interfaces'
 import { AmalgamationRegResources, DissolutionResources, IncorporationResources, RegistrationResources,
@@ -1158,9 +1158,7 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
 
   /** Fetches and stores business info. */
   private async loadBusinessInfo (businessId: string): Promise<void> {
-    const response = await LegalServices.fetchBusinessInfo(businessId)
-
-    const business = response?.data?.business as BusinessIF
+    const business = await LegalServices.fetchBusinessInfo(businessId).catch(() => {})
 
     if (!business) {
       throw new Error('Invalid business info')

--- a/src/components/Amalgamation/AmalgamatingBusinesses.vue
+++ b/src/components/Amalgamation/AmalgamatingBusinesses.vue
@@ -171,7 +171,7 @@ export default class AmalgamatingBusinesses extends Mixins(CommonMixin) {
   @Getter(useStore) isAmalgamationFilingHorizontal!: boolean
   @Getter(useStore) isRoleStaff!: boolean
 
-  @Action(useStore) setAmalgamatingBusinesses!: (x: Array<AmalgamatingBusinessIF>) => void
+  @Action(useStore) pushAmalgamatingBusiness!: (x: AmalgamatingBusinessIF) => void
   @Action(useStore) setAmalgamatingBusinessesValid!: (x: boolean) => void
 
   // Local properties
@@ -229,11 +229,8 @@ export default class AmalgamatingBusinesses extends Mixins(CommonMixin) {
         (filings[0]?.filingSubType === RestorationTypes.LTD_EXTEND)
     }
 
-    // Add the new business to a new array and store the new array.
-    // *** TODO: create a new action for this instead
-    const amalgamatingBusinesses = this.getAmalgamatingBusinesses
-    amalgamatingBusinesses.push(tingBusiness)
-    this.setAmalgamatingBusinesses(amalgamatingBusinesses)
+    // Add the new business to the amalgamating businesses list.
+    this.pushAmalgamatingBusiness(tingBusiness)
 
     // Close the "Add an Amalgamating Business" panel.
     this.isAddingAmalgamatingBusiness = false

--- a/src/components/Amalgamation/AmalgamatingBusinesses.vue
+++ b/src/components/Amalgamation/AmalgamatingBusinesses.vue
@@ -230,6 +230,7 @@ export default class AmalgamatingBusinesses extends Mixins(CommonMixin) {
     }
 
     // Add the new business to a new array and store the new array.
+    // *** TODO: create a new action for this instead
     const amalgamatingBusinesses = this.getAmalgamatingBusinesses
     amalgamatingBusinesses.push(tingBusiness)
     this.setAmalgamatingBusinesses(amalgamatingBusinesses)

--- a/src/components/Amalgamation/BusinessStatus.vue
+++ b/src/components/Amalgamation/BusinessStatus.vue
@@ -36,12 +36,12 @@ export default class BusinessStatus extends Vue {
       case AmlStatuses.OK:
         return 'mdi-check'
 
-      case AmlStatuses.ERROR_NOT_AFFILIATED:
       case AmlStatuses.ERROR_CCC_MISMATCH:
       case AmlStatuses.ERROR_FOREIGN:
       case AmlStatuses.ERROR_FOREIGN_UNLIMITED:
       case AmlStatuses.ERROR_FUTURE_EFFECTIVE_FILING:
       case AmlStatuses.ERROR_LIMITED_RESTORATION:
+      case AmlStatuses.ERROR_NOT_AFFILIATED:
       case AmlStatuses.ERROR_NOT_IN_GOOD_STANDING:
         return 'mdi-alert'
 
@@ -55,12 +55,12 @@ export default class BusinessStatus extends Vue {
       case AmlStatuses.OK:
         return 'success'
 
-      case AmlStatuses.ERROR_NOT_AFFILIATED:
       case AmlStatuses.ERROR_CCC_MISMATCH:
       case AmlStatuses.ERROR_FOREIGN:
       case AmlStatuses.ERROR_FOREIGN_UNLIMITED:
       case AmlStatuses.ERROR_FUTURE_EFFECTIVE_FILING:
       case AmlStatuses.ERROR_LIMITED_RESTORATION:
+      case AmlStatuses.ERROR_NOT_AFFILIATED:
       case AmlStatuses.ERROR_NOT_IN_GOOD_STANDING:
         return 'warning'
 
@@ -74,12 +74,12 @@ export default class BusinessStatus extends Vue {
       case AmlStatuses.OK:
         return 'Ready'
 
-      case AmlStatuses.ERROR_NOT_AFFILIATED:
       case AmlStatuses.ERROR_CCC_MISMATCH:
       case AmlStatuses.ERROR_FOREIGN:
       case AmlStatuses.ERROR_FOREIGN_UNLIMITED:
       case AmlStatuses.ERROR_FUTURE_EFFECTIVE_FILING:
       case AmlStatuses.ERROR_LIMITED_RESTORATION:
+      case AmlStatuses.ERROR_NOT_AFFILIATED:
       case AmlStatuses.ERROR_NOT_IN_GOOD_STANDING:
         return 'Attention Required'
 
@@ -92,9 +92,6 @@ export default class BusinessStatus extends Vue {
     switch (this.status) {
       case AmlStatuses.OK:
         return ''
-      case AmlStatuses.ERROR_NOT_AFFILIATED:
-        return 'This business is not affiliated with the currently selected BC Registries account. ' +
-         'Affiliate this business with the account on My Business Registry page.'
       case AmlStatuses.ERROR_CCC_MISMATCH:
         return 'A BC Community Contribution Company must amalgamate to form a new BC Community ' +
           'Contribution Company.'
@@ -109,6 +106,9 @@ export default class BusinessStatus extends Vue {
       case AmlStatuses.ERROR_LIMITED_RESTORATION:
         return 'This business is under limited restoration. It cannot be part of an amalgamation ' +
           'unless it is fully restored.'
+      case AmlStatuses.ERROR_NOT_AFFILIATED:
+        return 'This business is not affiliated with the currently selected BC Registries account. ' +
+         'Affiliate this business with the account on My Business Registry page.'
       case AmlStatuses.ERROR_NOT_IN_GOOD_STANDING:
         return 'This business is not in good standing. This filing cannot be submitted until all ' +
           'businesses are in good standing.'

--- a/src/components/Amalgamation/BusinessStatus.vue
+++ b/src/components/Amalgamation/BusinessStatus.vue
@@ -25,24 +25,24 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator'
-import { AmalgamatingStatuses } from '@/enums'
+import { AmlStatuses } from '@/enums'
 
 @Component({})
 export default class BusinessStatus extends Vue {
-  @Prop({ required: true }) readonly status!: AmalgamatingStatuses
+  @Prop({ required: true }) readonly status!: AmlStatuses
 
   get icon (): string {
     switch (this.status) {
-      case AmalgamatingStatuses.OK:
+      case AmlStatuses.OK:
         return 'mdi-check'
 
-      case AmalgamatingStatuses.ERROR_AFFILIATION:
-      case AmalgamatingStatuses.ERROR_CCC_MISMATCH:
-      case AmalgamatingStatuses.ERROR_FOREIGN:
-      case AmalgamatingStatuses.ERROR_FOREIGN_UNLIMITED:
-      case AmalgamatingStatuses.ERROR_FUTURE_EFFECTIVE_FILING:
-      case AmalgamatingStatuses.ERROR_LIMITED_RESTORATION:
-      case AmalgamatingStatuses.ERROR_NIGS:
+      case AmlStatuses.ERROR_NOT_AFFILIATED:
+      case AmlStatuses.ERROR_CCC_MISMATCH:
+      case AmlStatuses.ERROR_FOREIGN:
+      case AmlStatuses.ERROR_FOREIGN_UNLIMITED:
+      case AmlStatuses.ERROR_FUTURE_EFFECTIVE_FILING:
+      case AmlStatuses.ERROR_LIMITED_RESTORATION:
+      case AmlStatuses.ERROR_NOT_IN_GOOD_STANDING:
         return 'mdi-alert'
 
       default:
@@ -52,16 +52,16 @@ export default class BusinessStatus extends Vue {
 
   get color (): string {
     switch (this.status) {
-      case AmalgamatingStatuses.OK:
+      case AmlStatuses.OK:
         return 'success'
 
-      case AmalgamatingStatuses.ERROR_AFFILIATION:
-      case AmalgamatingStatuses.ERROR_CCC_MISMATCH:
-      case AmalgamatingStatuses.ERROR_FOREIGN:
-      case AmalgamatingStatuses.ERROR_FOREIGN_UNLIMITED:
-      case AmalgamatingStatuses.ERROR_FUTURE_EFFECTIVE_FILING:
-      case AmalgamatingStatuses.ERROR_LIMITED_RESTORATION:
-      case AmalgamatingStatuses.ERROR_NIGS:
+      case AmlStatuses.ERROR_NOT_AFFILIATED:
+      case AmlStatuses.ERROR_CCC_MISMATCH:
+      case AmlStatuses.ERROR_FOREIGN:
+      case AmlStatuses.ERROR_FOREIGN_UNLIMITED:
+      case AmlStatuses.ERROR_FUTURE_EFFECTIVE_FILING:
+      case AmlStatuses.ERROR_LIMITED_RESTORATION:
+      case AmlStatuses.ERROR_NOT_IN_GOOD_STANDING:
         return 'warning'
 
       default:
@@ -71,16 +71,16 @@ export default class BusinessStatus extends Vue {
 
   get text (): string {
     switch (this.status) {
-      case AmalgamatingStatuses.OK:
+      case AmlStatuses.OK:
         return 'Ready'
 
-      case AmalgamatingStatuses.ERROR_AFFILIATION:
-      case AmalgamatingStatuses.ERROR_CCC_MISMATCH:
-      case AmalgamatingStatuses.ERROR_FOREIGN:
-      case AmalgamatingStatuses.ERROR_FOREIGN_UNLIMITED:
-      case AmalgamatingStatuses.ERROR_FUTURE_EFFECTIVE_FILING:
-      case AmalgamatingStatuses.ERROR_LIMITED_RESTORATION:
-      case AmalgamatingStatuses.ERROR_NIGS:
+      case AmlStatuses.ERROR_NOT_AFFILIATED:
+      case AmlStatuses.ERROR_CCC_MISMATCH:
+      case AmlStatuses.ERROR_FOREIGN:
+      case AmlStatuses.ERROR_FOREIGN_UNLIMITED:
+      case AmlStatuses.ERROR_FUTURE_EFFECTIVE_FILING:
+      case AmlStatuses.ERROR_LIMITED_RESTORATION:
+      case AmlStatuses.ERROR_NOT_IN_GOOD_STANDING:
         return 'Attention Required'
 
       default:
@@ -90,26 +90,26 @@ export default class BusinessStatus extends Vue {
 
   get tooltip (): string {
     switch (this.status) {
-      case AmalgamatingStatuses.OK:
+      case AmlStatuses.OK:
         return ''
-      case AmalgamatingStatuses.ERROR_AFFILIATION:
+      case AmlStatuses.ERROR_NOT_AFFILIATED:
         return 'This business is not affiliated with the currently selected BC Registries account. ' +
          'Affiliate this business with the account on My Business Registry page.'
-      case AmalgamatingStatuses.ERROR_CCC_MISMATCH:
+      case AmlStatuses.ERROR_CCC_MISMATCH:
         return 'A BC Community Contribution Company must amalgamate to form a new BC Community ' +
           'Contribution Company.'
-      case AmalgamatingStatuses.ERROR_FOREIGN:
+      case AmlStatuses.ERROR_FOREIGN:
         return 'A foreign corporation cannot be amalgamated except by Registries staff.'
-      case AmalgamatingStatuses.ERROR_FOREIGN_UNLIMITED:
+      case AmlStatuses.ERROR_FOREIGN_UNLIMITED:
         return 'A foreign corporation must not amalgamate with a limited company and continue as ' +
           'an unlimited liability company.'
-      case AmalgamatingStatuses.ERROR_FUTURE_EFFECTIVE_FILING:
+      case AmlStatuses.ERROR_FUTURE_EFFECTIVE_FILING:
         return 'This business has a future effective filing. It cannot be part of an amalgamation ' +
           'until all future effective filings have come into effect.'
-      case AmalgamatingStatuses.ERROR_LIMITED_RESTORATION:
+      case AmlStatuses.ERROR_LIMITED_RESTORATION:
         return 'This business is under limited restoration. It cannot be part of an amalgamation ' +
           'unless it is fully restored.'
-      case AmalgamatingStatuses.ERROR_NIGS:
+      case AmlStatuses.ERROR_NOT_IN_GOOD_STANDING:
         return 'This business is not in good standing. This filing cannot be submitted until all ' +
           'businesses are in good standing.'
 

--- a/src/components/Amalgamation/BusinessTable.vue
+++ b/src/components/Amalgamation/BusinessTable.vue
@@ -13,6 +13,14 @@
       </thead>
 
       <tbody>
+        <tr v-if="!businesses.length">
+          <td colspan="6">
+            <p class="text-center">
+              No businesses added
+            </p>
+          </td>
+        </tr>
+
         <tr
           v-for="(item, index) in businesses"
           :key="key(item)"

--- a/src/components/Amalgamation/BusinessTable.vue
+++ b/src/components/Amalgamation/BusinessTable.vue
@@ -99,8 +99,8 @@ export default class BusinessTable extends Mixins(AmalgamationMixin) {
   readonly AmlTypes = AmlTypes
   readonly GetCorpFullDescription = GetCorpFullDescription
 
-  @Action(useStore) setAmalgamatingBusinesses!: (x: AmalgamatingBusinessIF[]) => void
   @Action(useStore) setDefineCompanyStepValidity!: (x: boolean) => void
+  @Action(useStore) spliceAmalgamatingBusiness!: (x: number) => void
 
   /**
    * This is the list of amalgamating businesses with computed statuses.
@@ -166,10 +166,8 @@ export default class BusinessTable extends Mixins(AmalgamationMixin) {
   }
 
   removeBusiness (index: number): void {
-    const temp = this.getAmalgamatingBusinesses
-    temp.splice(index, 1)
-    // set updated list to trigger reactivity
-    this.setAmalgamatingBusinesses(temp)
+    // Delete this item from amalgamating businesses list.
+    this.spliceAmalgamatingBusiness(index)
   }
 
   @Watch('businesses', { deep: true, immediate: true })

--- a/src/components/Amalgamation/BusinessTable.vue
+++ b/src/components/Amalgamation/BusinessTable.vue
@@ -26,7 +26,7 @@
           </td>
 
           <td class="business-address">
-            <template v-if="item.type === 'lear'">
+            <template v-if="item.type === AmlTypes.LEAR">
               <BaseAddress
                 v-if="item.address"
                 :address="item.address"
@@ -34,7 +34,7 @@
               <span v-else>Affiliate to view</span>
             </template>
 
-            <template v-if="item.type === 'foreign'">
+            <template v-if="item.type === AmlTypes.FOREIGN">
               {{ jurisdiction(item) }}
             </template>
           </td>
@@ -73,7 +73,7 @@ import { Component, Emit, Mixins, Watch } from 'vue-property-decorator'
 import { Action } from 'pinia-class'
 import { getName } from 'country-list'
 import { useStore } from '@/store/store'
-import { AmalgamatingStatuses, AmlRoles } from '@/enums'
+import { AmlStatuses, AmlRoles, AmlTypes } from '@/enums'
 import { AmalgamatingBusinessIF } from '@/interfaces'
 import { BaseAddress } from '@bcrs-shared-components/base-address'
 import BusinessStatus from './BusinessStatus.vue'
@@ -88,6 +88,7 @@ import { AmalgamationMixin } from '@/mixins'
 })
 export default class BusinessTable extends Mixins(AmalgamationMixin) {
   readonly AmlRoles = AmlRoles
+  readonly AmlTypes = AmlTypes
   readonly GetCorpFullDescription = GetCorpFullDescription
 
   @Action(useStore) setAmalgamatingBusinesses!: (x: AmalgamatingBusinessIF[]) => void
@@ -102,14 +103,14 @@ export default class BusinessTable extends Mixins(AmalgamationMixin) {
       // evaluate the rules for the current business
       // assign the value of the first failed rule (if any) else OK
       business.status = this.rules.reduce(
-        (status: AmalgamatingStatuses, rule: (business: AmalgamatingBusinessIF) => AmalgamatingStatuses) => {
+        (status: AmlStatuses, rule: (business: AmalgamatingBusinessIF) => AmlStatuses) => {
           // if we already failed a rule, don't check the rest of the rules
           if (status) return status
           // return the value of the current rule (may be null)
           return rule(business)
         },
         null
-      ) || AmalgamatingStatuses.OK
+      ) || AmlStatuses.OK
 
       // return updated business object
       return business
@@ -117,30 +118,30 @@ export default class BusinessTable extends Mixins(AmalgamationMixin) {
   }
 
   key (item: AmalgamatingBusinessIF): string {
-    if (item?.type === 'lear') return item.identifier
-    if (item?.type === 'foreign') return item.corpNumber
+    if (item?.type === AmlTypes.LEAR) return item.identifier
+    if (item?.type === AmlTypes.FOREIGN) return item.corpNumber
     return null // should never happen
   }
 
   name (item: AmalgamatingBusinessIF): string {
-    if (item?.type === 'lear') return item.name
-    if (item?.type === 'foreign') return item.legalName
+    if (item?.type === AmlTypes.LEAR) return item.name
+    if (item?.type === AmlTypes.FOREIGN) return item.legalName
     return '(Unknown)' // should never happen
   }
 
   email (item: AmalgamatingBusinessIF): string {
-    if (item?.type === 'lear') return item.email
+    if (item?.type === AmlTypes.LEAR) return item.email
     return null // should never happen
   }
 
   type (item: AmalgamatingBusinessIF): string {
-    if (item?.type === 'lear') return GetCorpFullDescription(item.legalType)
-    if (item?.type === 'foreign') return 'Foreign'
+    if (item?.type === AmlTypes.LEAR) return GetCorpFullDescription(item.legalType)
+    if (item?.type === AmlTypes.FOREIGN) return 'Foreign'
     return '(Unknown)' // should never happen
   }
 
   jurisdiction (item: AmalgamatingBusinessIF): string {
-    const fj = (item?.type === 'foreign') && item.foreignJurisdiction
+    const fj = (item?.type === AmlTypes.FOREIGN) && item.foreignJurisdiction
     if (fj?.country) {
       const country = getName(fj.country)
       const region = (fj.region === 'FEDERAL' ? 'Federal' : fj.region)
@@ -166,7 +167,7 @@ export default class BusinessTable extends Mixins(AmalgamationMixin) {
   @Watch('businesses', { deep: true, immediate: true })
   @Emit('valid')
   private emitValidity (): boolean {
-    return this.businesses.every(business => business.status === AmalgamatingStatuses.OK)
+    return this.businesses.every(business => business.status === AmlStatuses.OK)
   }
 }
 </script>

--- a/src/components/Amalgamation/BusinessTableSummary.vue
+++ b/src/components/Amalgamation/BusinessTableSummary.vue
@@ -10,6 +10,14 @@
       </thead>
 
       <tbody>
+        <tr v-if="!getAmalgamatingBusinesses.length">
+          <td colspan="6">
+            <p class="text-center mb-0">
+              No businesses added
+            </p>
+          </td>
+        </tr>
+
         <tr
           v-for="item in getAmalgamatingBusinesses"
           :key="key(item)"

--- a/src/components/Amalgamation/BusinessTableSummary.vue
+++ b/src/components/Amalgamation/BusinessTableSummary.vue
@@ -22,7 +22,7 @@
           </td>
 
           <td class="business-address">
-            <template v-if="item.type === 'lear'">
+            <template v-if="item.type === AmlTypes.LEAR">
               <BaseAddress
                 v-if="item.address"
                 :address="item.address"
@@ -30,7 +30,7 @@
               <span v-else>Affiliate to view</span>
             </template>
 
-            <template v-if="item.type === 'foreign'">
+            <template v-if="item.type === AmlTypes.FOREIGN">
               {{ jurisdiction(item) }}
             </template>
           </td>
@@ -49,7 +49,7 @@ import { Component, Vue } from 'vue-property-decorator'
 import { Getter } from 'pinia-class'
 import { getName } from 'country-list'
 import { useStore } from '@/store/store'
-import { AmlRoles } from '@/enums'
+import { AmlRoles, AmlTypes } from '@/enums'
 import { AmalgamatingBusinessIF } from '@/interfaces'
 import { BaseAddress } from '@bcrs-shared-components/base-address'
 
@@ -60,28 +60,29 @@ import { BaseAddress } from '@bcrs-shared-components/base-address'
 })
 export default class BusinessTableSummary extends Vue {
   readonly AmlRoles = AmlRoles
+  readonly AmlTypes = AmlTypes
 
   @Getter(useStore) getAmalgamatingBusinesses!: AmalgamatingBusinessIF[]
 
   key (item: AmalgamatingBusinessIF): string {
-    if (item?.type === 'lear') return item.identifier
-    if (item?.type === 'foreign') return item.corpNumber
+    if (item?.type === AmlTypes.LEAR) return item.identifier
+    if (item?.type === AmlTypes.FOREIGN) return item.corpNumber
     return null // should never happen
   }
 
   name (item: AmalgamatingBusinessIF): string {
-    if (item?.type === 'lear') return item.name
-    if (item?.type === 'foreign') return item.legalName
+    if (item?.type === AmlTypes.LEAR) return item.name
+    if (item?.type === AmlTypes.FOREIGN) return item.legalName
     return '(Unknown)' // should never happen
   }
 
   email (item: AmalgamatingBusinessIF): string {
-    if (item?.type === 'lear') return item.email
+    if (item?.type === AmlTypes.LEAR) return item.email
     return null // should never happen
   }
 
   jurisdiction (item: AmalgamatingBusinessIF): string {
-    const fj = (item?.type === 'foreign') && item.foreignJurisdiction
+    const fj = (item?.type === AmlTypes.FOREIGN) && item.foreignJurisdiction
     if (fj?.country) {
       const country = getName(fj.country)
       const region = (fj.region === 'FEDERAL' ? 'Federal' : fj.region)

--- a/src/enums/amalgamationEnums.ts
+++ b/src/enums/amalgamationEnums.ts
@@ -1,15 +1,20 @@
-export enum AmalgamatingStatuses {
+export enum AmlStatuses {
   OK,
-  ERROR_AFFILIATION,
   ERROR_CCC_MISMATCH,
   ERROR_FOREIGN,
   ERROR_FOREIGN_UNLIMITED,
   ERROR_FUTURE_EFFECTIVE_FILING,
   ERROR_LIMITED_RESTORATION,
-  ERROR_NIGS,
+  ERROR_NOT_AFFILIATED,
+  ERROR_NOT_IN_GOOD_STANDING,
 }
 
 export enum AmlRoles {
   AMALGAMATING = 'amalgamating',
   HOLDING = 'holding'
+}
+
+export enum AmlTypes {
+  LEAR = 'lear',
+  FOREIGN = 'foreign'
 }

--- a/src/interfaces/store-interfaces/state-interfaces/amalgamation-state-interface.ts
+++ b/src/interfaces/store-interfaces/state-interfaces/amalgamation-state-interface.ts
@@ -1,10 +1,10 @@
 import { AddressIF } from '@/interfaces'
-import { AmalgamatingStatuses, AmalgamationTypes, AmlRoles } from '@/enums'
+import { AmlStatuses, AmalgamationTypes, AmlRoles, AmlTypes } from '@/enums'
 import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module'
 
 /** Interface for LEAR amalgamating businesses. */
 interface AmalgamatingLearIF {
-  type: 'lear'
+  type: AmlTypes.LEAR
 
   // properties in schema:
   role: AmlRoles
@@ -15,13 +15,15 @@ interface AmalgamatingLearIF {
   email?: string
   legalType?: CorpTypeCd
   address?: AddressIF
-  goodStanding?: boolean
-  status?: AmalgamatingStatuses
+  status?: AmlStatuses // computed status (base on business rules)
+  isNotInGoodStanding?: boolean // whether business is in good standing
+  isFutureEffective?: boolean // whether business has a FE filing
+  isLimitedRestoration?: boolean // whether business is in limited restoration
 }
 
 /** Interface for foreign amalgamating businesses. */
 interface AmalgamatingForeignIF {
-  type: 'foreign'
+  type: AmlTypes.FOREIGN
 
   // properties in schema:
   role: AmlRoles
@@ -33,7 +35,7 @@ interface AmalgamatingForeignIF {
   corpNumber: string
 
   // properties for UI only:
-  status?: AmalgamatingStatuses
+  status?: AmlStatuses
 }
 
 // type alias (union type)

--- a/src/mixins/amalgamation-mixin.ts
+++ b/src/mixins/amalgamation-mixin.ts
@@ -23,7 +23,8 @@ export default class AmalgamationMixin extends Vue {
     this.rule3,
     this.rule4,
     this.rule5,
-    this.rule6
+    this.rule6,
+    this.rule7
   ]
 
   /** True if there a limited company in the table. */
@@ -61,17 +62,8 @@ export default class AmalgamationMixin extends Vue {
     return null
   }
 
-  // disallow foreign into ULC if there is also a limited
-  // *** TODO: this is a duplicate; reuse this for something else
+  // if we don't have an address, assume business is not affiliated (non-staff only)
   rule3 (business: AmalgamatingBusinessIF): AmlStatuses {
-    if (business.type === AmlTypes.FOREIGN && this.isTypeBcUlcCompany && this.isAnyLimited) {
-      return AmlStatuses.ERROR_FOREIGN
-    }
-    return null
-  }
-
-  // if we don't have address, assume business is not affiliated (non-staff only)
-  rule4 (business: AmalgamatingBusinessIF): AmlStatuses {
     // *** TODO: revert staff check
     if (business.type === AmlTypes.LEAR && !business.address /* && !this.isRoleStaff */) {
       return AmlStatuses.ERROR_NOT_AFFILIATED
@@ -80,9 +72,18 @@ export default class AmalgamationMixin extends Vue {
   }
 
   // identify CCC mismatch
-  rule5 (business: AmalgamatingBusinessIF): AmlStatuses {
+  rule4 (business: AmalgamatingBusinessIF): AmlStatuses {
     if (business.type === AmlTypes.LEAR && business.legalType === CorpTypeCd.BC_CCC && !this.isTypeBcCcc) {
       return AmlStatuses.ERROR_CCC_MISMATCH
+    }
+    return null
+  }
+
+  // disallow limited restoration if not staff
+  rule5 (business: AmalgamatingBusinessIF): AmlStatuses {
+    // *** TODO: revert staff check
+    if (business.type === AmlTypes.LEAR && business.isLimitedRestoration /* && !this.isRoleStaff */) {
+      return AmlStatuses.ERROR_LIMITED_RESTORATION
     }
     return null
   }
@@ -96,19 +97,10 @@ export default class AmalgamationMixin extends Vue {
     return null
   }
 
-  // disallow limited restoration if not staff
+  // check for future effective filing
   rule7 (business: AmalgamatingBusinessIF): AmlStatuses {
     // *** TODO: revert staff check
-    if (business.type === AmlTypes.LEAR && business.isLimitedRestoration /* && !this.isRoleStaff */) {
-      return AmlStatuses.ERROR_LIMITED_RESTORATION
-    }
-    return null
-  }
-
-  // check for future effective filing
-  rule8 (business: AmalgamatingBusinessIF): AmlStatuses {
-    // *** TODO: revert staff check
-    if (business.type === AmlTypes.LEAR && business.isLimitedRestoration /* && !this.isRoleStaff */) {
+    if (business.type === AmlTypes.LEAR && business.isFutureEffective /* && !this.isRoleStaff */) {
       return AmlStatuses.ERROR_FUTURE_EFFECTIVE_FILING
     }
     return null

--- a/src/mixins/amalgamation-mixin.ts
+++ b/src/mixins/amalgamation-mixin.ts
@@ -1,7 +1,7 @@
 import { Component, Vue } from 'vue-property-decorator'
 import { Getter } from 'pinia-class'
 import { useStore } from '@/store/store'
-import { AmalgamatingStatuses } from '@/enums'
+import { AmlStatuses, AmlTypes } from '@/enums'
 import { AmalgamatingBusinessIF } from '@/interfaces'
 import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module'
 
@@ -27,20 +27,20 @@ export default class AmalgamationMixin extends Vue {
   ]
 
   // *** I'M STILL WONDERING IF I WANT TO USE THESE
-  // readonly isLear = (item: AmalgamatingBusinessIF): boolean => (item?.type === 'lear')
-  // readonly isForeign = (item: AmalgamatingBusinessIF): boolean => (item?.type === 'foreign')
+  // readonly isLear = (item: AmalgamatingBusinessIF): boolean => (item?.type === AmlTypes.LEAR)
+  // readonly isForeign = (item: AmalgamatingBusinessIF): boolean => (item?.type === AmlTypes.FOREIGN)
 
   /** True if there a limited company in the table. */
   get isAnyLimited (): boolean {
     return this.getAmalgamatingBusinesses.some(business =>
-      (business.type === 'lear' && business.legalType === CorpTypeCd.BC_COMPANY)
+      (business.type === AmlTypes.LEAR && business.legalType === CorpTypeCd.BC_COMPANY)
     )
   }
 
   /** True if there an unlimited company in the table in Alberta, Nova Scotia or USA. */
   get isAnyUnlimitedAbNsUsa (): boolean {
     return this.getAmalgamatingBusinesses.some(business =>
-      (business.type === 'lear' && business.legalType === CorpTypeCd.BC_COMPANY)
+      (business.type === AmlTypes.LEAR && business.legalType === CorpTypeCd.BC_COMPANY)
     )
   }
 
@@ -48,7 +48,7 @@ export default class AmalgamationMixin extends Vue {
   //   {
   //     id: 0,
   //     rule: (v: any) => !!v || 'Required',
-  //     status: AmalgamatingStatuses.ERROR_FOREIGN
+  //     status: AmlStatuses.ERROR_FOREIGN
   //   }
   // ]
 
@@ -56,61 +56,71 @@ export default class AmalgamationMixin extends Vue {
   // Nova Scotia, or the USA to form a BC Unlimited Liability Company.
 
   // disallow foreign into ULC if there is also a limited
-  rule1 (business: AmalgamatingBusinessIF): AmalgamatingStatuses {
-    if (business.type === 'foreign' && this.isTypeBcUlcCompany && this.isAnyLimited) {
-      return AmalgamatingStatuses.ERROR_FOREIGN
+  rule1 (business: AmalgamatingBusinessIF): AmlStatuses {
+    if (business.type === AmlTypes.FOREIGN && this.isTypeBcUlcCompany && this.isAnyLimited) {
+      return AmlStatuses.ERROR_FOREIGN
     }
     return null
   }
 
   // disallow foreign altogether if not staff
   // (could happen if staff added it and regular user resumes draft)
-  rule2 (business: AmalgamatingBusinessIF): AmalgamatingStatuses {
-    if (business.type === 'foreign' && !this.isRoleStaff) {
-      return AmalgamatingStatuses.ERROR_FOREIGN
+  rule2 (business: AmalgamatingBusinessIF): AmlStatuses {
+    if (business.type === AmlTypes.FOREIGN && !this.isRoleStaff) {
+      return AmlStatuses.ERROR_FOREIGN
     }
     return null
   }
 
   // disallow foreign into ULC if there is also a limited
-  rule3 (business: AmalgamatingBusinessIF): AmalgamatingStatuses {
-    if (business.type === 'foreign' && this.isTypeBcUlcCompany && this.isAnyLimited) {
-      return AmalgamatingStatuses.ERROR_FOREIGN
+  rule3 (business: AmalgamatingBusinessIF): AmlStatuses {
+    if (business.type === AmlTypes.FOREIGN && this.isTypeBcUlcCompany && this.isAnyLimited) {
+      return AmlStatuses.ERROR_FOREIGN
     }
     return null
   }
 
   // assume business is not affiliated if we don't have address (non-staff only)
-  rule4 (business: AmalgamatingBusinessIF): AmalgamatingStatuses {
+  rule4 (business: AmalgamatingBusinessIF): AmlStatuses {
     // *** TODO: revert staff check
-    if (business.type === 'lear' && !business.address /* && !this.isRoleStaff */) {
-      return AmalgamatingStatuses.ERROR_AFFILIATION
+    if (business.type === AmlTypes.LEAR && !business.address /* && !this.isRoleStaff */) {
+      return AmlStatuses.ERROR_NOT_AFFILIATED
     }
     return null
   }
 
   // identify CCC mismatch
-  rule5 (business: AmalgamatingBusinessIF): AmalgamatingStatuses {
-    if (business.type === 'lear' && business.legalType === CorpTypeCd.BC_CCC && !this.isTypeBcCcc) {
-      return AmalgamatingStatuses.ERROR_CCC_MISMATCH
+  rule5 (business: AmalgamatingBusinessIF): AmlStatuses {
+    if (business.type === AmlTypes.LEAR && business.legalType === CorpTypeCd.BC_CCC && !this.isTypeBcCcc) {
+      return AmlStatuses.ERROR_CCC_MISMATCH
     }
     return null
   }
 
   // disallow NIGS if not staff
-  rule6 (business: AmalgamatingBusinessIF): AmalgamatingStatuses {
+  rule6 (business: AmalgamatingBusinessIF): AmlStatuses {
     // *** TODO: revert staff check
-    if (business.type === 'lear' && !business.goodStanding /* && !this.isRoleStaff */) {
-      return AmalgamatingStatuses.ERROR_NIGS
+    if (business.type === AmlTypes.LEAR && business.isNotInGoodStanding /* && !this.isRoleStaff */) {
+      return AmlStatuses.ERROR_NOT_IN_GOOD_STANDING
     }
     return null
   }
 
-  // check if limited restoration
-  // *** TODO
-  // *** need to look at all business' filings
+  // disallow limited restoration if not staff
+  rule7 (business: AmalgamatingBusinessIF): AmlStatuses {
+    // *** TODO: revert staff check
+    if (business.type === AmlTypes.LEAR && business.isLimitedRestoration /* && !this.isRoleStaff */) {
+      return AmlStatuses.ERROR_LIMITED_RESTORATION
+    }
+    return null
+  }
 
   // check for future effective filing
-  // *** TODO
-  // *** need to look at all business' filings
+  rule8 (business: AmalgamatingBusinessIF): AmlStatuses {
+    // *** TODO: revert staff check
+    if (business.type === AmlTypes.LEAR && business.isLimitedRestoration /* && !this.isRoleStaff */) {
+      return AmlStatuses.ERROR_FUTURE_EFFECTIVE_FILING
+    }
+    return null
+  }
 }

--- a/src/mixins/amalgamation-mixin.ts
+++ b/src/mixins/amalgamation-mixin.ts
@@ -26,10 +26,6 @@ export default class AmalgamationMixin extends Vue {
     this.rule6
   ]
 
-  // *** I'M STILL WONDERING IF I WANT TO USE THESE
-  // readonly isLear = (item: AmalgamatingBusinessIF): boolean => (item?.type === AmlTypes.LEAR)
-  // readonly isForeign = (item: AmalgamatingBusinessIF): boolean => (item?.type === AmlTypes.FOREIGN)
-
   /** True if there a limited company in the table. */
   get isAnyLimited (): boolean {
     return this.getAmalgamatingBusinesses.some(business =>
@@ -44,28 +40,13 @@ export default class AmalgamationMixin extends Vue {
     )
   }
 
-  // readonly amalgamationRules = [
-  //   {
-  //     id: 0,
-  //     rule: (v: any) => !!v || 'Required',
-  //     status: AmlStatuses.ERROR_FOREIGN
-  //   }
-  // ]
-
+  // *** TODO
   // A BC Company cannot amalgamate with an existing Unlimited Liability Company from Alberta,
   // Nova Scotia, or the USA to form a BC Unlimited Liability Company.
 
-  // disallow foreign into ULC if there is also a limited
-  rule1 (business: AmalgamatingBusinessIF): AmlStatuses {
-    if (business.type === AmlTypes.FOREIGN && this.isTypeBcUlcCompany && this.isAnyLimited) {
-      return AmlStatuses.ERROR_FOREIGN
-    }
-    return null
-  }
-
   // disallow foreign altogether if not staff
   // (could happen if staff added it and regular user resumes draft)
-  rule2 (business: AmalgamatingBusinessIF): AmlStatuses {
+  rule1 (business: AmalgamatingBusinessIF): AmlStatuses {
     if (business.type === AmlTypes.FOREIGN && !this.isRoleStaff) {
       return AmlStatuses.ERROR_FOREIGN
     }
@@ -73,6 +54,15 @@ export default class AmalgamationMixin extends Vue {
   }
 
   // disallow foreign into ULC if there is also a limited
+  rule2 (business: AmalgamatingBusinessIF): AmlStatuses {
+    if (business.type === AmlTypes.FOREIGN && this.isTypeBcUlcCompany && this.isAnyLimited) {
+      return AmlStatuses.ERROR_FOREIGN
+    }
+    return null
+  }
+
+  // disallow foreign into ULC if there is also a limited
+  // *** TODO: this is a duplicate; reuse this for something else
   rule3 (business: AmalgamatingBusinessIF): AmlStatuses {
     if (business.type === AmlTypes.FOREIGN && this.isTypeBcUlcCompany && this.isAnyLimited) {
       return AmlStatuses.ERROR_FOREIGN
@@ -80,7 +70,7 @@ export default class AmalgamationMixin extends Vue {
     return null
   }
 
-  // assume business is not affiliated if we don't have address (non-staff only)
+  // if we don't have address, assume business is not affiliated (non-staff only)
   rule4 (business: AmalgamatingBusinessIF): AmlStatuses {
     // *** TODO: revert staff check
     if (business.type === AmlTypes.LEAR && !business.address /* && !this.isRoleStaff */) {

--- a/src/services/legal-services.ts
+++ b/src/services/legal-services.ts
@@ -9,6 +9,25 @@ import { FilingTypes } from '@/enums'
  */
 export default class LegalServices {
   /**
+   * Fetches filings list.
+   * @param businessId the business identifier (aka entity inc no)
+   * @returns the filings list
+   */
+  static async fetchFilings (businessId: string): Promise<any[]> {
+    const url = `businesses/${businessId}/filings`
+    return axios.get(url)
+      .then(response => {
+        const filings = response?.data?.filings as any[]
+        if (!filings) {
+          // eslint-disable-next-line no-console
+          console.log('fetchFilings() error - invalid response =', response)
+          throw new Error('Invalid filings list')
+        }
+        return filings
+      })
+  }
+
+  /**
    * Fetches the first or only filing.
    * This is expected to be a draft IA or Registration.
    * @param tempId the temp registration number

--- a/src/services/legal-services.ts
+++ b/src/services/legal-services.ts
@@ -178,7 +178,7 @@ export default class LegalServices {
    * @returns a promise to return the addresses from the response, else exception
    */
   static fetchAddresses (businessId: string): Promise<any> {
-    const url = `businesses/${businessId}/addresses2`
+    const url = `businesses/${businessId}/addresses`
     return axios.get(url).then(response => {
       const data = response?.data
       if (!data) throw new Error('Invalid API response')

--- a/src/services/legal-services.ts
+++ b/src/services/legal-services.ts
@@ -17,7 +17,7 @@ export default class LegalServices {
     const url = `businesses/${businessId}/filings`
     return axios.get(url)
       .then(response => {
-        const filings = response?.data?.filings as any[]
+        const filings = response?.data?.filings
         if (!filings) {
           // eslint-disable-next-line no-console
           console.log('fetchFilings() error - invalid response =', response)
@@ -178,7 +178,7 @@ export default class LegalServices {
    * @returns a promise to return the addresses from the response, else exception
    */
   static fetchAddresses (businessId: string): Promise<any> {
-    const url = `businesses/${businessId}/addresses`
+    const url = `businesses/${businessId}/addresses2`
     return axios.get(url).then(response => {
       const data = response?.data
       if (!data) throw new Error('Invalid API response')

--- a/src/services/legal-services.ts
+++ b/src/services/legal-services.ts
@@ -1,7 +1,7 @@
 import { AxiosInstance as axios } from '@/utils'
 import { StatusCodes } from 'http-status-codes'
-import { AmalgamationFilingIF, DissolutionFilingIF, IncorporationFilingIF, NameRequestIF, RegistrationFilingIF,
-  RestorationFilingIF } from '@/interfaces'
+import { AmalgamationFilingIF, BusinessIF, DissolutionFilingIF, IncorporationFilingIF, NameRequestIF,
+  RegistrationFilingIF, RestorationFilingIF } from '@/interfaces'
 import { FilingTypes } from '@/enums'
 
 /**
@@ -175,10 +175,14 @@ export default class LegalServices {
   /**
    * Fetches business info.
    * @param businessId the business identifier
-   * @returns a promise to return the info from the response, else exception
+   * @returns a promise to return the business info, else exception
    */
-  static async fetchBusinessInfo (businessId: string): Promise<any> {
+  static async fetchBusinessInfo (businessId: string): Promise<BusinessIF> {
     const url = `businesses/${businessId}`
-    return axios.get(url)
+    return axios.get(url).then(response => {
+      const data = response?.data
+      if (!data) throw new Error('Invalid API response')
+      return data.business
+    })
   }
 }

--- a/src/store/state/state-model.ts
+++ b/src/store/state/state-model.ts
@@ -13,118 +13,118 @@ import { EmptyAddress } from '@bcrs-shared-components/interfaces'
 import { cloneDeep } from 'lodash'
 import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module'
 
-const AMALGAMATING_BUSINESSES: AmalgamatingBusinessIF[] = [
-  {
-    type: AmlTypes.LEAR,
-    identifier: 'BC1111111',
-    name: 'Frozen Yogurt',
-    email: 'froyo@example.com',
-    legalType: CorpTypeCd.BC_COMPANY,
-    address: {
-      streetAddress: '1234 Main St',
-      addressCity: 'Vancouver',
-      addressRegion: 'BC',
-      postalCode: 'V6A 1A1',
-      addressCountry: 'CA'
-    },
-    role: AmlRoles.HOLDING,
-    isNotInGoodStanding: true
-  },
-  {
-    // this business is an xpro and should only be valid if staff
-    type: AmlTypes.LEAR,
-    identifier: 'A5555555',
-    name: 'Lollipop Canada',
-    email: 'sucker@example.com',
-    legalType: CorpTypeCd.EXTRA_PRO_A,
-    address: {
-      streetAddress: '4321 Principal Ave',
-      addressCity: 'Halifax',
-      addressRegion: 'NS',
-      postalCode: 'B3H 1A1',
-      addressCountry: 'CA'
-    },
-    role: AmlRoles.AMALGAMATING,
-    isNotInGoodStanding: true
-  },
-  {
-    // this business is NIGS and should only be valid if staff
-    type: AmlTypes.LEAR,
-    identifier: 'BC2222222',
-    name: 'Jelly Bean',
-    email: 'oval.treat@example.com',
-    legalType: CorpTypeCd.BC_COMPANY,
-    address: {
-      streetAddress: '1234 Main St',
-      addressCity: 'Vancouver',
-      addressRegion: 'BC',
-      postalCode: 'V6A 1A1',
-      addressCountry: 'CA'
-    },
-    role: AmlRoles.AMALGAMATING,
-    isNotInGoodStanding: false
-  },
-  {
-    // this business has 2 issues:
-    // 1. not affiliated
-    // 2. not in good standing
-    type: AmlTypes.LEAR,
-    identifier: 'BC4444444', // we know this from the business lookup
-    name: 'Eclair', // we know this from the business lookup
-    email: undefined, // we don't know this yet (not affiliated)
-    legalType: CorpTypeCd.BC_COMPANY, // we know this from the business lookup
-    address: undefined, // we don't know this yet (not affiliated)
-    role: AmlRoles.AMALGAMATING,
-    isNotInGoodStanding: false // we know this from the business lookup
-  },
-  {
-    type: AmlTypes.FOREIGN,
-    corpNumber: 'XYZ789',
-    legalName: 'Ice Cream Sandwich Canada',
-    foreignJurisdiction: { region: 'FEDERAL', country: 'CA' },
-    role: AmlRoles.AMALGAMATING
-  },
-  {
-    type: AmlTypes.FOREIGN,
-    corpNumber: 'ABC123',
-    legalName: 'Gingerbread USA',
-    foreignJurisdiction: { country: 'US' },
-    role: AmlRoles.AMALGAMATING
-  },
-  {
-    // this business is CCC and should only be valid if amalg type is CCC
-    type: AmlTypes.LEAR,
-    identifier: 'BC7777777',
-    name: 'Donut',
-    email: 'holey.goodness@example.com',
-    legalType: CorpTypeCd.BC_CCC,
-    address: {
-      streetAddress: '1234 Main St',
-      addressCity: 'Vancouver',
-      addressRegion: 'BC',
-      postalCode: 'V6A 1A1',
-      addressCountry: 'CA'
-    },
-    role: AmlRoles.AMALGAMATING,
-    isNotInGoodStanding: true
-  },
-  {
-    type: AmlTypes.LEAR,
-    identifier: 'BC3333333',
-    name: 'Cupcake',
-    email: 'cute.sugarbomb@example.com',
-    legalType: CorpTypeCd.BC_COMPANY,
-    address: {
-      streetAddress: '1234 Main St',
-      addressCity: 'Vancouver',
-      addressRegion: 'BC',
-      postalCode: 'V6A 1A1',
-      addressCountry: 'CA'
-    },
-    role: AmlRoles.AMALGAMATING,
-    isNotInGoodStanding: true
-  }
-]
+// const AMALGAMATING_BUSINESSES: AmalgamatingBusinessIF[] = [
+//   {
+//     type: AmlTypes.LEAR,
+//     identifier: 'BC1111111',
+//     name: 'Frozen Yogurt',
+//     email: 'froyo@example.com',
+//     legalType: CorpTypeCd.BC_COMPANY,
+//     address: {
+//       streetAddress: '1234 Main St',
+//       addressCity: 'Vancouver',
+//       addressRegion: 'BC',
+//       postalCode: 'V6A 1A1',
+//       addressCountry: 'CA'
+//     },
+//     role: AmlRoles.HOLDING,
+//     isNotInGoodStanding: true
+//   },
+//   {
+//     // this business is an xpro and should only be valid if staff
+//     type: AmlTypes.LEAR,
+//     identifier: 'A5555555',
+//     name: 'Lollipop Canada',
+//     email: 'sucker@example.com',
+//     legalType: CorpTypeCd.EXTRA_PRO_A,
+//     address: {
+//       streetAddress: '4321 Principal Ave',
+//       addressCity: 'Halifax',
+//       addressRegion: 'NS',
+//       postalCode: 'B3H 1A1',
+//       addressCountry: 'CA'
+//     },
+//     role: AmlRoles.AMALGAMATING,
+//     isNotInGoodStanding: true
+//   },
+//   {
+//     // this business is NIGS and should only be valid if staff
+//     type: AmlTypes.LEAR,
+//     identifier: 'BC2222222',
+//     name: 'Jelly Bean',
+//     email: 'oval.treat@example.com',
+//     legalType: CorpTypeCd.BC_COMPANY,
+//     address: {
+//       streetAddress: '1234 Main St',
+//       addressCity: 'Vancouver',
+//       addressRegion: 'BC',
+//       postalCode: 'V6A 1A1',
+//       addressCountry: 'CA'
+//     },
+//     role: AmlRoles.AMALGAMATING,
+//     isNotInGoodStanding: false
+//   },
+//   {
+//     // this business has 2 issues:
+//     // 1. not affiliated
+//     // 2. not in good standing
+//     type: AmlTypes.LEAR,
+//     identifier: 'BC4444444', // we know this from the business lookup
+//     name: 'Eclair', // we know this from the business lookup
+//     email: undefined, // we don't know this yet (not affiliated)
+//     legalType: CorpTypeCd.BC_COMPANY, // we know this from the business lookup
+//     address: undefined, // we don't know this yet (not affiliated)
+//     role: AmlRoles.AMALGAMATING,
+//     isNotInGoodStanding: false // we know this from the business lookup
+//   },
+//   {
+//     type: AmlTypes.FOREIGN,
+//     corpNumber: 'XYZ789',
+//     legalName: 'Ice Cream Sandwich Canada',
+//     foreignJurisdiction: { region: 'FEDERAL', country: 'CA' },
+//     role: AmlRoles.AMALGAMATING
+//   },
+//   {
+//     type: AmlTypes.FOREIGN,
+//     corpNumber: 'ABC123',
+//     legalName: 'Gingerbread USA',
+//     foreignJurisdiction: { country: 'US' },
+//     role: AmlRoles.AMALGAMATING
+//   },
+//   {
+//     // this business is CCC and should only be valid if amalg type is CCC
+//     type: AmlTypes.LEAR,
+//     identifier: 'BC7777777',
+//     name: 'Donut',
+//     email: 'holey.goodness@example.com',
+//     legalType: CorpTypeCd.BC_CCC,
+//     address: {
+//       streetAddress: '1234 Main St',
+//       addressCity: 'Vancouver',
+//       addressRegion: 'BC',
+//       postalCode: 'V6A 1A1',
+//       addressCountry: 'CA'
+//     },
+//     role: AmlRoles.AMALGAMATING,
+//     isNotInGoodStanding: true
+//   },
+//   {
+//     type: AmlTypes.LEAR,
+//     identifier: 'BC3333333',
+//     name: 'Cupcake',
+//     email: 'cute.sugarbomb@example.com',
+//     legalType: CorpTypeCd.BC_COMPANY,
+//     address: {
+//       streetAddress: '1234 Main St',
+//       addressCity: 'Vancouver',
+//       addressRegion: 'BC',
+//       postalCode: 'V6A 1A1',
+//       addressCountry: 'CA'
+//     },
+//     role: AmlRoles.AMALGAMATING,
+//     isNotInGoodStanding: true
+//   }
+// ]
 
 export const stateModel: StateModelIF = {
   currentJsDate: null,
@@ -322,7 +322,7 @@ export const stateModel: StateModelIF = {
     isAutoPopulatedBusinessNumber: false
   },
   amalgamation: {
-    amalgamatingBusinesses: cloneDeep(AMALGAMATING_BUSINESSES),
+    amalgamatingBusinesses: [], // cloneDeep(AMALGAMATING_BUSINESSES),
     amalgamatingBusinessesValid: false,
     courtApproval: null,
     type: null

--- a/src/store/state/state-model.ts
+++ b/src/store/state/state-model.ts
@@ -8,14 +8,14 @@ import {
   EmptyNaics,
   StateModelIF
 } from '@/interfaces'
-import { AmlRoles } from '@/enums'
+import { AmlRoles, AmlTypes } from '@/enums'
 import { EmptyAddress } from '@bcrs-shared-components/interfaces'
 import { cloneDeep } from 'lodash'
 import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module'
 
 const AMALGAMATING_BUSINESSES: AmalgamatingBusinessIF[] = [
   {
-    type: 'lear',
+    type: AmlTypes.LEAR,
     identifier: 'BC1111111',
     name: 'Frozen Yogurt',
     email: 'froyo@example.com',
@@ -28,11 +28,11 @@ const AMALGAMATING_BUSINESSES: AmalgamatingBusinessIF[] = [
       addressCountry: 'CA'
     },
     role: AmlRoles.HOLDING,
-    goodStanding: true
+    isNotInGoodStanding: true
   },
   {
     // this business is an xpro and should only be valid if staff
-    type: 'lear',
+    type: AmlTypes.LEAR,
     identifier: 'A5555555',
     name: 'Lollipop Canada',
     email: 'sucker@example.com',
@@ -45,11 +45,11 @@ const AMALGAMATING_BUSINESSES: AmalgamatingBusinessIF[] = [
       addressCountry: 'CA'
     },
     role: AmlRoles.AMALGAMATING,
-    goodStanding: true
+    isNotInGoodStanding: true
   },
   {
     // this business is NIGS and should only be valid if staff
-    type: 'lear',
+    type: AmlTypes.LEAR,
     identifier: 'BC2222222',
     name: 'Jelly Bean',
     email: 'oval.treat@example.com',
@@ -62,30 +62,30 @@ const AMALGAMATING_BUSINESSES: AmalgamatingBusinessIF[] = [
       addressCountry: 'CA'
     },
     role: AmlRoles.AMALGAMATING,
-    goodStanding: false
+    isNotInGoodStanding: false
   },
   {
     // this business has 2 issues:
     // 1. not affiliated
     // 2. not in good standing
-    type: 'lear',
+    type: AmlTypes.LEAR,
     identifier: 'BC4444444', // we know this from the business lookup
     name: 'Eclair', // we know this from the business lookup
     email: undefined, // we don't know this yet (not affiliated)
     legalType: CorpTypeCd.BC_COMPANY, // we know this from the business lookup
     address: undefined, // we don't know this yet (not affiliated)
     role: AmlRoles.AMALGAMATING,
-    goodStanding: false // we know this from the business lookup
+    isNotInGoodStanding: false // we know this from the business lookup
   },
   {
-    type: 'foreign',
+    type: AmlTypes.FOREIGN,
     corpNumber: 'XYZ789',
     legalName: 'Ice Cream Sandwich Canada',
     foreignJurisdiction: { region: 'FEDERAL', country: 'CA' },
     role: AmlRoles.AMALGAMATING
   },
   {
-    type: 'foreign',
+    type: AmlTypes.FOREIGN,
     corpNumber: 'ABC123',
     legalName: 'Gingerbread USA',
     foreignJurisdiction: { country: 'US' },
@@ -93,7 +93,7 @@ const AMALGAMATING_BUSINESSES: AmalgamatingBusinessIF[] = [
   },
   {
     // this business is CCC and should only be valid if amalg type is CCC
-    type: 'lear',
+    type: AmlTypes.LEAR,
     identifier: 'BC7777777',
     name: 'Donut',
     email: 'holey.goodness@example.com',
@@ -106,10 +106,10 @@ const AMALGAMATING_BUSINESSES: AmalgamatingBusinessIF[] = [
       addressCountry: 'CA'
     },
     role: AmlRoles.AMALGAMATING,
-    goodStanding: true
+    isNotInGoodStanding: true
   },
   {
-    type: 'lear',
+    type: AmlTypes.LEAR,
     identifier: 'BC3333333',
     name: 'Cupcake',
     email: 'cute.sugarbomb@example.com',
@@ -122,7 +122,7 @@ const AMALGAMATING_BUSINESSES: AmalgamatingBusinessIF[] = [
       addressCountry: 'CA'
     },
     role: AmlRoles.AMALGAMATING,
-    goodStanding: true
+    isNotInGoodStanding: true
   }
 ]
 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1239,6 +1239,14 @@ export const useStore = defineStore('store', {
     setAmalgamatingBusinesses (amalgamatingBusinesses: Array<AmalgamatingBusinessIF>) {
       this.stateModel.amalgamation.amalgamatingBusinesses = amalgamatingBusinesses
     },
+    /** Adds specified item to end of amalgamating businesses list. */
+    pushAmalgamatingBusiness (item: AmalgamatingBusinessIF) {
+      this.stateModel.amalgamation.amalgamatingBusinesses.push(item)
+    },
+    /** Deletes item at specified index from amalgamating businesses list. */
+    spliceAmalgamatingBusiness (index: number) {
+      this.stateModel.amalgamation.amalgamatingBusinesses.splice(index, 1)
+    },
     setAmalgamatingBusinessesValid (valid: boolean) {
       this.stateModel.amalgamation.amalgamatingBusinessesValid = valid
     },

--- a/tests/unit/legal-services.spec.ts
+++ b/tests/unit/legal-services.spec.ts
@@ -2,25 +2,24 @@ import sinon from 'sinon'
 import { AxiosInstance as axios } from '@/utils'
 import LegalServices from '@/services/legal-services'
 
-// draft registration filing
-const draftRegistration = {
-  header: {
-    name: 'registration',
-    filingId: 123
-  },
-  registration: {
-    offices: [],
-    contactPoint: {},
-    parties: []
-  }
-}
-
 describe('Legal Services', () => {
   it('fetches a draft application as a single item', async () => {
     // mock single item response
     sinon.stub(axios, 'get').withArgs('businesses/123/filings')
       .returns(new Promise(resolve => resolve({
-        data: { filing: draftRegistration }
+        data: {
+          filing: {
+            header: {
+              name: 'registration',
+              filingId: 123
+            },
+            registration: {
+              offices: [],
+              contactPoint: {},
+              parties: []
+            }
+          }
+        }
       })))
 
     // fetch draft and check it
@@ -39,17 +38,21 @@ describe('Legal Services', () => {
     // mock list response
     sinon.stub(axios, 'get').withArgs('businesses/123/filings')
       .returns(new Promise(resolve => resolve({
-        data: { filings: [{ filing: draftRegistration }] }
+        data: {
+          filings: [
+            {
+              name: 'registration',
+              filingId: 123
+            }
+          ]
+        }
       })))
 
     // fetch draft and check it
     const draft: any = await LegalServices.fetchFirstOrOnlyFiling('123')
     expect(draft).not.toBeFalsy()
-    expect(draft).toHaveProperty('header')
-    expect(draft).toHaveProperty('registration')
-    expect(draft.registration).toHaveProperty('offices')
-    expect(draft.registration).toHaveProperty('contactPoint')
-    expect(draft.registration).toHaveProperty('parties')
+    expect(draft).toHaveProperty('name')
+    expect(draft).toHaveProperty('filingId')
 
     sinon.restore()
   })


### PR DESCRIPTION
*Issue #:* bcgov/entity#18640

*Description of changes:*

Commit 1:
    - app version = 5.6.11
    - imported latest BusinessLookup shared component
    - updated fetchBusinessInfo return object
    - simplified Amalg Businesses button and panel logic
    - added Cancel button to Foreign panel
    - added snackbar for save business errors
    - deleted debugging template code
Commit 2:
    - added fetch for business filings (for more validations)
    - renamed AmalgamatingStatuses -> AmlStatuses
    - added AmlTypes enum and replaced strings
    - added some properties to TING business object (for more validations)
    - added LegalServices.fetchFilings()
    - misc updates
Commit 3:
    - changed all to allSettled so I can get partial fetches
    - fall back to lookup properties if some fetches fail (eg, not amalgamated)
    - added empty table message
    - temporarily start with empty (instead of pre-populated) table

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).