### PR TITLE
18960 - Re-fetch businesses information when loading draft

### DIFF
--- a/src/components/Amalgamation/AmalgamatingBusinesses.vue
+++ b/src/components/Amalgamation/AmalgamatingBusinesses.vue
@@ -187,21 +187,8 @@ export default class AmalgamatingBusinesses extends Mixins(AmalgamationMixin, Co
     // Show spinner since the network calls below can take a few seconds.
     this.$root.$emit('showSpinner', true)
 
-    // Get the auth info, business info, addresses and latest filing concurrently.
-    // Return data array; if any call failed, that item will be null.
-    const data = await Promise.allSettled([
-      AuthServices.fetchAuthInfo(businessLookup.identifier),
-      LegalServices.fetchBusinessInfo(businessLookup.identifier),
-      LegalServices.fetchAddresses(businessLookup.identifier),
-      LegalServices.fetchFirstOrOnlyFiling(businessLookup.identifier)
-    ]).then(results => results.map((result: any) => result.value || null))
-
-    const authInfo = data[0]
-    const businessInfo = data[1]
-    const addresses = data[2]
-    const firstFiling = data[3]
     // Get the business information
-    const business = await this.fetchBusinessInfoForTing(businessLookup)
+    const business = await this.fetchAmalgamatingBusinessInfo(businessLookup)
 
     // Check for unaffiliated business.
     if (!business.authInfo) {
@@ -254,21 +241,6 @@ export default class AmalgamatingBusinesses extends Mixins(AmalgamationMixin, Co
       this.$root.$emit('showSpinner', false)
 
       return
-    }
-
-    // This business is in limited restoration if there is a state filing and restoration expiry date isn't
-    // in the past and the state filing is a limited restoration or a limited restoration extension.
-    const isLimitedRestoration = async (): Promise<boolean> => {
-      // check for no state filing
-      if (!businessInfo.stateFiling) return false
-      // check for expired restoration
-      if (this.getCurrentDate > businessInfo.restorationExpiryDate) return false
-      // fetch state filing
-      const stateFiling = await LegalServices.fetchFiling(businessInfo.stateFiling)
-      return (
-        stateFiling.restoration.type === RestorationTypes.LIMITED ||
-        stateFiling.restoration.type === RestorationTypes.LTD_EXTEND
-      )
     }
 
     // Create amalgamating business object.

--- a/src/components/Amalgamation/AmalgamatingBusinesses.vue
+++ b/src/components/Amalgamation/AmalgamatingBusinesses.vue
@@ -149,11 +149,11 @@
 import { Component, Mixins, Watch } from 'vue-property-decorator'
 import { Action, Getter } from 'pinia-class'
 import { useStore } from '@/store/store'
-import { CommonMixin } from '@/mixins'
-import { AuthServices, BusinessLookupServices, LegalServices } from '@/services'
+import { AmalgamationMixin, CommonMixin } from '@/mixins'
+import { BusinessLookupServices } from '@/services'
 import { BusinessLookup } from '@bcrs-shared-components/business-lookup'
 import { AmalgamatingBusinessIF, BusinessLookupResultIF, EmptyBusinessLookup } from '@/interfaces'
-import { AmlRoles, AmlTypes, RestorationTypes } from '@/enums'
+import { AmlRoles, AmlTypes } from '@/enums'
 import BusinessTable from '@/components/Amalgamation/BusinessTable.vue'
 import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module'
 
@@ -163,15 +163,12 @@ import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module'
     BusinessTable
   }
 })
-export default class AmalgamatingBusinesses extends Mixins(CommonMixin) {
+export default class AmalgamatingBusinesses extends Mixins(AmalgamationMixin, CommonMixin) {
   readonly BusinessLookupServices = BusinessLookupServices
 
-  @Getter(useStore) getAmalgamatingBusinesses!: AmalgamatingBusinessIF[]
   @Getter(useStore) getAmalgamatingBusinessesValid!: boolean
-  @Getter(useStore) getCurrentDate!: string
   @Getter(useStore) getShowErrors!: boolean
   @Getter(useStore) isAmalgamationFilingHorizontal!: boolean
-  @Getter(useStore) isRoleStaff!: boolean
 
   @Action(useStore) pushAmalgamatingBusiness!: (x: AmalgamatingBusinessIF) => void
   @Action(useStore) setAmalgamatingBusinessesValid!: (x: boolean) => void
@@ -203,9 +200,11 @@ export default class AmalgamatingBusinesses extends Mixins(CommonMixin) {
     const businessInfo = data[1]
     const addresses = data[2]
     const firstFiling = data[3]
+    // Get the business information
+    const business = await this.fetchBusinessInfoForTing(businessLookup)
 
     // Check for unaffiliated business.
-    if (!authInfo) {
+    if (!business.authInfo) {
       // If a staff account couldn't fetch the auth info then the business doesn't exist.
       if (this.isRoleStaff) {
         this.snackbarText = 'Business doesn\'t exist in LEAR.'
@@ -236,7 +235,7 @@ export default class AmalgamatingBusinesses extends Mixins(CommonMixin) {
     }
 
     // Check for Legal API fetch issues.
-    if (!businessInfo || !addresses || !firstFiling) {
+    if (!business.businessInfo || !business.addresses || !business.firstFiling) {
       this.snackbarText = 'Unable to add that business.'
       this.snackbar = true
 
@@ -247,7 +246,7 @@ export default class AmalgamatingBusinesses extends Mixins(CommonMixin) {
     }
 
     // Check for duplicate.
-    if (this.getAmalgamatingBusinesses.find((b: any) => b.identifier === businessInfo.identifier)) {
+    if (this.getAmalgamatingBusinesses.find((b: any) => b.identifier === business.businessInfo.identifier)) {
       this.snackbarText = 'Business is already in table.'
       this.snackbar = true
 
@@ -276,14 +275,14 @@ export default class AmalgamatingBusinesses extends Mixins(CommonMixin) {
     const tingBusiness: AmalgamatingBusinessIF = {
       type: AmlTypes.LEAR,
       role: AmlRoles.AMALGAMATING,
-      identifier: businessInfo.identifier,
-      name: businessInfo.legalName,
-      email: authInfo.contacts[0].email,
-      legalType: businessInfo.legalType,
-      address: addresses.registeredOffice.mailingAddress,
-      isNotInGoodStanding: (businessInfo.goodStanding === false),
-      isFutureEffective: (firstFiling.isFutureEffective === true),
-      isLimitedRestoration: await isLimitedRestoration()
+      identifier: business.businessInfo.identifier,
+      name: business.businessInfo.legalName,
+      email: business.authInfo.contacts[0].email,
+      legalType: business.businessInfo.legalType,
+      address: business.addresses.registeredOffice.mailingAddress,
+      isNotInGoodStanding: (business.businessInfo.goodStanding === false),
+      isFutureEffective: (business.firstFiling.isFutureEffective === true),
+      isLimitedRestoration: await this.isLimitedRestoration(business)
     }
 
     // Add the new business to the amalgamating businesses list.

--- a/src/mixins/amalgamation-mixin.ts
+++ b/src/mixins/amalgamation-mixin.ts
@@ -59,7 +59,7 @@ export default class AmalgamationMixin extends Vue {
    * Get the business information, mailing address, email, and first filing if in LEAR.
    * Otherwise, return error.
    */
-  async fetchBusinessInfoForTing (item: any): Promise<any> {
+  async fetchAmalgamatingBusinessInfo (item: any): Promise<any> {
     // Get the auth info, business info, addresses and filings in parallel.
     // Return data array; if any call failed, that item will be undefined.
     const data = await Promise.allSettled([
@@ -83,11 +83,11 @@ export default class AmalgamationMixin extends Vue {
   }
 
   /**
-   * If there is a state filing and restoration expiry date isn't in the past and the state filing is a
-   * limited restoration or limited restoration extension, then this business is in limited restoration.
+   * This business is in limited restoration if there is a state filing and restoration expiry date isn't
+   * in the past and the state filing is a limited restoration or a limited restoration extension.
    * @param business The business to check if is in Limited Restoration or not.
    */
-  isLimitedRestoration = async (business: any): Promise<boolean> => {
+  async isLimitedRestoration (business: any): Promise<boolean> {
     // check for no state filing
     if (!business.businessInfo.stateFiling) return false
     // check for expired restoration
@@ -106,7 +106,7 @@ export default class AmalgamationMixin extends Vue {
    */
   async refetchAmalgamatingBusinessesInfo (): Promise<void> {
     const fetchTingInfo = async (item: any): Promise<AmalgamatingBusinessIF> => {
-      const tingBusiness = await this.fetchBusinessInfoForTing(item)
+      const tingBusiness = await this.fetchAmalgamatingBusinessInfo(item)
       if (!tingBusiness.authInfo) {
         return {
           type: AmlTypes.LEAR,

--- a/src/mixins/amalgamation-mixin.ts
+++ b/src/mixins/amalgamation-mixin.ts
@@ -106,7 +106,7 @@ export default class AmalgamationMixin extends Vue {
    */
   async refetchAmalgamatingBusinessesInfo (): Promise<void> {
     const fetchTingInfo = async (item: any): Promise<AmalgamatingBusinessIF> => {
-      let tingBusiness = await this.fetchBusinessInfoForTing(item)
+      const tingBusiness = await this.fetchBusinessInfoForTing(item)
       if (!tingBusiness.authInfo) {
         return {
           type: AmlTypes.LEAR,
@@ -129,7 +129,7 @@ export default class AmalgamationMixin extends Vue {
           isLimitedRestoration: await this.isLimitedRestoration(tingBusiness)
         }
       }
-    } 
+    }
 
     this.setAmalgamatingBusinesses(
       await Promise.all(this.getAmalgamatingBusinesses.map(fetchTingInfo))

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -1,9 +1,9 @@
 import { Component, Mixins } from 'vue-property-decorator'
 import { Getter, Action } from 'pinia-class'
 import { useStore } from '@/store/store'
-import { DateMixin } from '@/mixins'
+import { AmalgamationMixin, DateMixin } from '@/mixins'
 import {
-  AmalgamatingBusinessIF, AmalgamationFilingIF, BusinessAddressIF, ContactPointIF, CertifyIF, CompletingPartyIF,
+  AmalgamationFilingIF, BusinessAddressIF, ContactPointIF, CertifyIF, CompletingPartyIF,
   CourtOrderIF, CourtOrderStepIF, CreateMemorandumIF, CreateResolutionIF, CreateRulesIF, DefineCompanyIF,
   DissolutionFilingIF, DissolutionStatementIF, DocumentDeliveryIF, EffectiveDateTimeIF, EmptyContactPoint,
   EmptyNaics, IncorporationAgreementIF, IncorporationFilingIF, NaicsIF, NameRequestFilingIF,
@@ -21,10 +21,9 @@ import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module/'
  * Mixin that provides the integration with the Legal API.
  */
 @Component({})
-export default class FilingTemplateMixin extends Mixins(DateMixin) {
+export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateMixin) {
   @Getter(useStore) getAddPeopleAndRoleStep!: PeopleAndRoleIF
   @Getter(useStore) getAffidavitStep!: UploadAffidavitIF
-  @Getter(useStore) getAmalgamatingBusinesses!: AmalgamatingBusinessIF[]
   @Getter(useStore) getAmalgamationCourtApproval!: boolean
   @Getter(useStore) getAmalgamationType!: AmalgamationTypes
   @Getter(useStore) getBusinessContact!: ContactPointIF
@@ -65,7 +64,6 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
   @Getter(useStore) getTempId!: string
   @Getter(useStore) getTransactionalFolioNumber!: string
   @Getter(useStore) isPremiumAccount!: boolean
-  @Getter(useStore) isRoleStaff!: boolean
   @Getter(useStore) isTypeCoop!: boolean
   @Getter(useStore) isTypeFirm!: boolean
   @Getter(useStore) isTypeSoleProp!: boolean
@@ -226,6 +224,7 @@ export default class FilingTemplateMixin extends Mixins(DateMixin) {
     // restore the amalgamating businesses array
     if (draftFiling.amalgamation.amalgamatingBusinesses) {
       this.setAmalgamatingBusinesses(draftFiling.amalgamation.amalgamatingBusinesses)
+      this.refetchAmalgamatingBusinessesInfo()
     }
 
     // restore the amalgamation court approval


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18960

*Description of changes:*
Re-fetch the amalgamating businesses information when loading draft.

https://github.com/bcgov/business-create-ui/assets/122301442/c3e28dfc-23cc-4875-a572-00bb34e84eb2




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
