### PR TITLE
18848 - add court order / POA component on review page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.6.17",
+  "version": "5.6.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.6.17",
+      "version": "5.6.18",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.6.17",
+  "version": "5.6.18",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -581,12 +581,15 @@ export const useStore = defineStore('store', {
     isAmalgamationRegularValid (): boolean {
       // *** TODO: add checks for review page components
       const isFolioNumberValid = !this.isPremiumAccount || this.getFolioNumberValid
+      const isCourtOrderValid = this.isRoleStaff ? this.getCourtOrderStep.valid : true
+
       return (
         this.getAmalgamatingBusinessesValid &&
         this.isDefineCompanyValid &&
         this.isAddPeopleAndRolesValid &&
         this.isCreateShareStructureValid &&
-        isFolioNumberValid
+        isFolioNumberValid &&
+        isCourtOrderValid
       )
     },
 

--- a/src/views/AmalgamationRegular/ReviewConfirm.vue
+++ b/src/views/AmalgamationRegular/ReviewConfirm.vue
@@ -179,34 +179,9 @@
       </v-card>
     </section>
 
-    <!-- Certify -->
-    <section
-      id="certify-section"
-      class="mt-10"
-    >
-      <header>
-        <h2>Certify</h2>
-        <p class="mt-4">
-          Confirm the legal name of the person authorized to complete and submit this application.
-        </p>
-      </header>
-
-      <v-card
-        flat
-        class="mt-6"
-      >
-        <Certify
-          class="py-8 px-6"
-          :class="{ 'invalid-section': isCertifyInvalid }"
-          :disableEdit="!isRoleStaff"
-          :invalidSection="isCertifyInvalid"
-          :isStaff="isRoleStaff"
-        />
-      </v-card>
-    </section>
-
     <!-- Court Order and Plan of Arrangement -->
-    <!-- <section
+    <section
+      v-if="isRoleStaff"
       id="court-order-poa-section"
       class="mt-10"
     >
@@ -235,7 +210,33 @@
           @emitValid="setCourtOrderValidity($event)"
         />
       </v-card>
-    </section> -->
+    </section>
+
+    <!-- Certify -->
+    <section
+      id="certify-section"
+      class="mt-10"
+    >
+      <header>
+        <h2>Certify</h2>
+        <p class="mt-4">
+          Confirm the legal name of the person authorized to complete and submit this application.
+        </p>
+      </header>
+
+      <v-card
+        flat
+        class="mt-6"
+      >
+        <Certify
+          class="py-8 px-6"
+          :class="{ 'invalid-section': isCertifyInvalid }"
+          :disableEdit="!isRoleStaff"
+          :invalidSection="isCertifyInvalid"
+          :isStaff="isRoleStaff"
+        />
+      </v-card>
+    </section>
 
     <!-- Staff Payment -->
     <section


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18848

*Description of changes:*

Add court order / POA component (only for staff)

Invalid Court order:

![image](https://github.com/bcgov/business-create-ui/assets/116035339/230a6bd7-7db8-40e8-8c04-2474d26e1ac3)

![image](https://github.com/bcgov/business-create-ui/assets/116035339/7deea47b-34b0-4121-a9f8-1fcb484661c5)

On clicking File and Pay/ step validity
![image](https://github.com/bcgov/business-create-ui/assets/116035339/1ee2e751-0f55-4cfb-a984-d88aa1ebc58b)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
