### PR TITLE
Fixed bug with certify if submitting the amalgamation failed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.6.30",
+  "version": "5.6.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.6.30",
+      "version": "5.6.31",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.6.30",
+  "version": "5.6.31",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/views/AmalgamationRegular/ReviewConfirm.vue
+++ b/src/views/AmalgamationRegular/ReviewConfirm.vue
@@ -331,6 +331,17 @@ export default class AmalgamationRegularReviewConfirm extends Vue {
   @Action(useStore) setHasPlanOfArrangement!: (x: boolean) => void
   @Action(useStore) setIsFutureEffective!: (x: boolean) => void
 
+  /**
+   * In case submitting the amalgamation failed, we want to reset the validity of Certify.
+   * This is since the checkbox has to be ticked again after the save dialog has been closed.
+   */
+  mounted (): void {
+    this.setCertifyState({
+      certifiedBy: this.getCertifyState.certifiedBy,
+      valid: false
+    })
+  }
+
   /** The entity description,  */
   get getEntityDescription (): string {
     return GetCorpFullDescription(this.getEntityType)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18689

*Description of changes:*
- Fix Certify blocked being valid even if the box hasn't been ticked

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
