### PR TITLE
Amalgamation stepper fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.6.37",
+  "version": "5.6.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.6.37",
+      "version": "5.6.38",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.6.37",
+  "version": "5.6.38",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/Stepper.vue
+++ b/src/components/common/Stepper.vue
@@ -223,7 +223,7 @@ export default class Stepper extends Vue {
 
 .step__btn2 {
   position: absolute;
-  margin-top: -19px;
+  margin-top: -30px;
   margin-left: -16px;
   background-color: $BCgovInputBG;
   border-radius: 50%;

--- a/src/components/common/Stepper.vue
+++ b/src/components/common/Stepper.vue
@@ -223,7 +223,7 @@ export default class Stepper extends Vue {
 
 .step__btn2 {
   position: absolute;
-  margin-top: -5px;
+  margin-top: -19px;
   margin-left: -16px;
   background-color: $BCgovInputBG;
   border-radius: 50%;

--- a/src/components/common/Stepper.vue
+++ b/src/components/common/Stepper.vue
@@ -31,7 +31,7 @@
         <v-icon
           v-show="isValid(step.to)"
           class="step__btn2"
-          size="30"
+          size="24"
           color="success darken-1"
         >
           mdi-check-circle
@@ -39,7 +39,7 @@
         <v-icon
           v-show="!isValid(step.to) && getShowErrors && getValidateSteps"
           class="step__btn2"
-          size="30"
+          size="24"
           color="error darken-1"
         >
           mdi-close-circle


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19224

*Description of changes:*
This PR should be in the Guinness World Records for smallest PR ever 😆 

For points 1 and 3 in the ticket, I've tested and they seem to be working. They might've been fixed collaterally maybe?

- For point 1: The state icons on the first step is missing when validation is triggered.

https://github.com/bcgov/business-create-ui/assets/122301442/66c3fb75-5d96-42e2-8b32-c17bdacd2c32

- For point 3: The valid step states do not persist their green checkmark state when draft is closed and reopened. This works on IA filing. I.e. in IA, if share structure is added and has green checkmark, when the user saves the draft and comes back to it, the green checkmark on the valid step displays on load.

https://github.com/bcgov/business-create-ui/assets/122301442/38caaebe-0cde-4a27-a6dc-9f1f4e14a413



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
