### PR TITLE
19037 Added processing for new holding/primary company

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     'max-len': ['warn', { code: 120, ignoreRegExpLiterals: true }],
     'vue/attribute-hyphenation': 'off',
+    'vue/component-name-in-template-casing': ['error', 'PascalCase'],
     'vue/multi-word-component-names': 'off',
     'vue/no-deprecated-filter': 'warn',
     'vue/no-deprecated-slot-scope-attribute': 'warn',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.8.3",
+  "version": "5.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.8.3",
+      "version": "5.8.4",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.8.3",
+  "version": "5.8.4",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -916,7 +916,7 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
           ...this.buildAmalgamationFiling(),
           ...draftFiling
         }
-        this.parseAmalgamationDraft(draftFiling)
+        await this.parseAmalgamationDraft(draftFiling)
         if (this.isAmalgamationFilingRegular) {
           resources = AmalgamationRegResources.find(x => x.entityType === this.getEntityType) as ResourceIF
         } else if (this.isAmalgamationFilingHorizontal || this.isAmalgamationFilingVertical) {

--- a/src/components/Amalgamation/AmalgamatingBusinesses.vue
+++ b/src/components/Amalgamation/AmalgamatingBusinesses.vue
@@ -235,6 +235,7 @@
     <BusinessTable
       class="mt-8"
       :class="{ 'invalid-section': getShowErrors && !businessTableValid }"
+      @newHoldingPrimaryBusiness="newHoldingPrimaryBusiness($event)"
       @allOk="allOk=$event"
     />
 
@@ -492,7 +493,7 @@ export default class AmalgamatingBusinesses extends Mixins(AmalgamationMixin, Co
       name: business.businessInfo.legalName,
       email: business.authInfo.contacts[0].email,
       legalType: business.businessInfo.legalType,
-      address: business.addresses.registeredOffice.mailingAddress,
+      addresses: business.addresses,
       isNotInGoodStanding: (business.businessInfo.goodStanding === false),
       isFrozen: (business.businessInfo.adminFreeze === true),
       isFutureEffective: this.isFutureEffective(business),
@@ -556,6 +557,26 @@ export default class AmalgamatingBusinesses extends Mixins(AmalgamationMixin, Co
 
     // Close the "Add an Amalgamating Foreign Business" panel.
     this.isAddingAmalgamatingForeignBusiness = false
+  }
+
+  /** Sets the specified business as the new holding/primary business. */
+  async newHoldingPrimaryBusiness (business: AmalgamatingBusinessIF): Promise<void> {
+    try {
+      // show spinner since the network calls below can take a few seconds
+      this.$root.$emit('showSpinner', true)
+
+      // fetch the new holding/primary business' data and update the prepopulated data
+      // this will overwrite office addresses, directors, share structure and contact info
+      this.updatePrepopulatedData(business, true)
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log('Error setting new holding/primary business =', error)
+      this.snackbarText = 'Error marking new business.'
+      this.snackbar = true
+    } finally {
+      // hide spinner
+      this.$root.$emit('showSpinner', false)
+    }
   }
 
   /**

--- a/src/components/Amalgamation/BusinessTableSummary.vue
+++ b/src/components/Amalgamation/BusinessTableSummary.vue
@@ -32,8 +32,8 @@
           <td class="business-address">
             <template v-if="item.type === AmlTypes.LEAR">
               <BaseAddress
-                v-if="item.address"
-                :address="item.address"
+                v-if="item.addresses"
+                :address="registeredOfficeMailingAddress(item)"
               />
               <span v-else>Affiliate to view</span>
             </template>
@@ -58,7 +58,7 @@ import { Getter } from 'pinia-class'
 import { getName } from 'country-list'
 import { useStore } from '@/store/store'
 import { AmlRoles, AmlTypes } from '@/enums'
-import { AmalgamatingBusinessIF } from '@/interfaces'
+import { AddressIF, AmalgamatingBusinessIF } from '@/interfaces'
 import { BaseAddress } from '@bcrs-shared-components/base-address'
 
 @Component({
@@ -86,6 +86,11 @@ export default class BusinessTableSummary extends Vue {
 
   email (item: AmalgamatingBusinessIF): string {
     if (item?.type === AmlTypes.LEAR) return item.email
+    return null // should never happen
+  }
+
+  registeredOfficeMailingAddress (item: AmalgamatingBusinessIF): AddressIF {
+    if (item?.type === AmlTypes.LEAR) return item.addresses?.registeredOffice?.mailingAddress
     return null // should never happen
   }
 

--- a/src/components/Amalgamation/ResultingBusinessName.vue
+++ b/src/components/Amalgamation/ResultingBusinessName.vue
@@ -94,6 +94,8 @@ export default class ResultingBusinessName extends Mixins(AmalgamationMixin, Nam
   @Getter(useStore) getNameRequestNumber!: string
   @Getter(useStore) getShowErrors!: boolean
 
+  // @Action(useStore) setCorrectNameOption!: (x: CorrectNameOptions) => void
+
   // Local properties
   formType = null as CorrectNameOptions
 

--- a/src/components/common/Actions.vue
+++ b/src/components/common/Actions.vue
@@ -217,11 +217,14 @@ export default class Actions extends Mixins(AmalgamationMixin, CommonMixin,
     // Prompt Step validations
     this.setValidateSteps(true)
 
-    // If we're filing an amalgamation, we need to re-fetch the business table data on file and pay.
-    // We do that in case one of the businesses became invalid (e.g. historical) while the draft is open.
     if (this.getFilingType === FilingTypes.AMALGAMATION_APPLICATION) {
       try {
-        await this.refetchAmalgamatingBusinessesInfo()
+        // Re-fetch the business table data. We do this in case one of the businesses has changed (eg,
+        // became historical) while the draft was open.
+        const holdingPrimary = await this.refetchAmalgamatingBusinessesInfo()
+        // If there's a holding or primary business, re-fetch its data and update the prepopulated data.
+        // This will overwrite office addresses, directors and share structure.
+        if (holdingPrimary) await this.updatePrepopulatedData(holdingPrimary)
       } catch (error) {
         console.log('Error validating table in onClickFilePay(): ', error) // eslint-disable-line no-console
         this.setIsFilingPaying(false)

--- a/src/components/common/BusinessContactInfo.vue
+++ b/src/components/common/BusinessContactInfo.vue
@@ -58,7 +58,7 @@
             />
           </v-col>
 
-          <!-- Phone Number -->
+          <!-- Phone Number + Extension -->
           <v-col
             cols="12"
             sm="3"
@@ -176,7 +176,7 @@ export default class BusinessContactInfo extends Mixins(CommonMixin) {
   // Rules for template
   readonly Rules = Rules
 
-  contact = this.initialValue
+  contact = { ...EmptyContactPoint } as ContactPointIF
   formValid = false
 
   // Rules
@@ -205,8 +205,8 @@ export default class BusinessContactInfo extends Mixins(CommonMixin) {
   }
 
   @Watch('formValid')
-  private onFormValidityChange (val: boolean): void {
-    this.emitValid(val)
+  private onFormValidityChange (valid: boolean): void {
+    this.emitValid(valid)
   }
 
   // Events

--- a/src/components/common/ListNameTranslations.vue
+++ b/src/components/common/ListNameTranslations.vue
@@ -41,7 +41,10 @@
           </span>
 
           <!-- more actions menu -->
-          <v-menu offset-y>
+          <v-menu
+            offset-y
+            left
+          >
             <template #activator="{ on }">
               <v-btn
                 text
@@ -149,7 +152,7 @@ export default class ListNameTranslations extends Vue {
   }
 }
 
-// move icon up a bit to line up with text
+// nudge icon up a bit to line up with text
 .v-icon.mdi-delete {
   margin-top: -2px;
 }

--- a/src/interfaces/store-interfaces/state-interfaces/amalgamation-state-interface.ts
+++ b/src/interfaces/store-interfaces/state-interfaces/amalgamation-state-interface.ts
@@ -1,4 +1,4 @@
-import { AddressIF } from '@/interfaces'
+import { RegisteredRecordsAddressesIF } from '@/interfaces'
 import { AmlStatuses, AmalgamationTypes, AmlRoles, AmlTypes } from '@/enums'
 import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module'
 
@@ -14,7 +14,7 @@ interface AmalgamatingLearIF {
   name?: string
   email?: string
   legalType?: CorpTypeCd
-  address?: AddressIF
+  addresses?: RegisteredRecordsAddressesIF
   status?: AmlStatuses // computed status (base on business rules)
   isNotInGoodStanding?: boolean // whether business is in good standing
   isFrozen?: boolean // whether business is frozen

--- a/src/mixins/amalgamation-mixin.ts
+++ b/src/mixins/amalgamation-mixin.ts
@@ -1,8 +1,13 @@
 import { Component, Vue } from 'vue-property-decorator'
 import { Action, Getter } from 'pinia-class'
 import { useStore } from '@/store/store'
-import { AmlRoles, AmlStatuses, AmlTypes, EntityStates, FilingStatus, RestorationTypes } from '@/enums'
-import { AmalgamatingBusinessIF, EmptyNameRequest, NameRequestIF, NameTranslationIF } from '@/interfaces'
+import {
+  AmlRoles, AmlStatuses, AmlTypes, EntityStates, FilingStatus, RestorationTypes, RoleTypes
+} from '@/enums'
+import {
+  AmalgamatingBusinessIF, ContactPointIF, EmptyNameRequest, NameRequestIF, NameTranslationIF,
+  OrgPersonIF, PeopleAndRoleIF, RegisteredRecordsAddressesIF, ShareClassIF
+} from '@/interfaces'
 import { CorrectNameOptions } from '@bcrs-shared-components/enums/'
 import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module'
 import { AuthServices, LegalServices } from '@/services'
@@ -13,6 +18,7 @@ import { AuthServices, LegalServices } from '@/services'
  */
 @Component({})
 export default class AmalgamationMixin extends Vue {
+  @Getter(useStore) getAddPeopleAndRoleStep!: PeopleAndRoleIF
   @Getter(useStore) getAmalgamatingBusinesses!: AmalgamatingBusinessIF[]
   @Getter(useStore) getCurrentDate!: string
   @Getter(useStore) isAmalgamationFilingHorizontal!: boolean
@@ -23,10 +29,15 @@ export default class AmalgamationMixin extends Vue {
   @Getter(useStore) isTypeBcUlcCompany!: boolean
 
   @Action(useStore) setAmalgamatingBusinesses!: (x: Array<any>) => void
+  @Action(useStore) setBusinessContact!: (x: ContactPointIF) => void
   @Action(useStore) setCorrectNameOption!: (x: CorrectNameOptions) => void
+  @Action(useStore) setEntityType!: (x: CorpTypeCd) => void
   @Action(useStore) setNameRequest!: (x: NameRequestIF) => void
   @Action(useStore) setNameRequestApprovedName!: (x: string) => void
   @Action(useStore) setNameTranslations!: (x: NameTranslationIF[]) => void
+  @Action(useStore) setOfficeAddresses!: (x: RegisteredRecordsAddressesIF) => void
+  @Action(useStore) setOrgPersonList!: (x: OrgPersonIF[]) => void
+  @Action(useStore) setShareClasses!: (x: ShareClassIF[]) => void
 
   /** Iterable array of rule functions, in order of processing. */
   readonly rules = [
@@ -48,9 +59,9 @@ export default class AmalgamationMixin extends Vue {
     this.foreignHorizontal
   ]
 
-  /** If we don't have an address, assume business is not affiliated (except for staff). */
+  /** If we don't have addresses, assume business is not affiliated (except for staff). */
   notAffiliated (business: AmalgamatingBusinessIF): AmlStatuses {
-    if (!this.isRoleStaff && business.type === AmlTypes.LEAR && !business.address) {
+    if (!this.isRoleStaff && business.type === AmlTypes.LEAR && !business.addresses) {
       return AmlStatuses.ERROR_NOT_AFFILIATED
     }
     return null
@@ -277,10 +288,10 @@ export default class AmalgamationMixin extends Vue {
   }
 
   /**
-   * Re-fetch the draft amalgamating businesses information and set in the store.
-   * Need to do that because the businesses might have changed since last draft save.
+   * Re-fetches the draft amalgamating businesses information and updates the store.
+   * @returns The holding/primary business (if there is one).
    */
-  async refetchAmalgamatingBusinessesInfo (): Promise<void> {
+  async refetchAmalgamatingBusinessesInfo (): Promise<AmalgamatingBusinessIF> {
     const fetchTingInfo = async (item: any): Promise<AmalgamatingBusinessIF> => {
       const tingBusiness = await this.fetchAmalgamatingBusinessInfo(item.identifier)
       // no auth info and business info means foreign, otherwise LEAR (affiliated or non-affiliated)
@@ -300,7 +311,7 @@ export default class AmalgamationMixin extends Vue {
           name: tingBusiness.businessInfo.legalName,
           email: tingBusiness.authInfo?.contacts[0].email,
           legalType: tingBusiness.businessInfo.legalType,
-          address: tingBusiness.addresses?.registeredOffice.mailingAddress,
+          addresses: tingBusiness.addresses,
           isNotInGoodStanding: (tingBusiness.businessInfo.goodStanding === false),
           isFrozen: (tingBusiness.businessInfo.adminFreeze === true),
           isFutureEffective: this.isFutureEffective(tingBusiness),
@@ -315,6 +326,79 @@ export default class AmalgamationMixin extends Vue {
     const promises = this.getAmalgamatingBusinesses.map(fetchTingInfo)
     const amalgamatingBusinesses = await Promise.all(promises)
     this.setAmalgamatingBusinesses(amalgamatingBusinesses)
+
+    // return the holding/primary business (or undefined)
+    return this.getAmalgamatingBusinesses.find(business =>
+      (business.role === AmlRoles.HOLDING || business.role === AmlRoles.PRIMARY)
+    )
+  }
+
+  /**
+   * (Re)fetches the holding/primary business' data and updates the prepopulated data.
+   * @param business The holding/primary business.
+   * @param isNew Whether the business is new (ie, set by user, not restored from draft).
+   */
+  async updatePrepopulatedData (business: AmalgamatingBusinessIF, isNew = false): Promise<void> {
+    // safety check
+    if (!business || business.type !== AmlTypes.LEAR) {
+      throw new Error('updatePrepopulatedData(): invalid business')
+    }
+
+    // first, fetch new directors/share structure/auth info
+    // NB - business addresses have already been fetched
+    // NB - make all API calls concurrently without rejection
+    // NB - if any call failed, that item will be null
+    const [ directors, shareStructure, authInfo ] =
+      await Promise.allSettled([
+        LegalServices.fetchDirectors(business.identifier),
+        LegalServices.fetchShareStructure(business.identifier),
+        AuthServices.fetchAuthInfo(business.identifier)
+      ]).then(results => results.map((result: any) => result.value || null))
+
+    // check for errors before changing anything
+    if (!directors) throw new Error('Unable to fetch directors')
+    if (!shareStructure) throw new Error('Unable to fetch share structure')
+    if (!authInfo) throw new Error('Unable to fetch auth info')
+
+    // unset previous holding/primary business, if any
+    const previous = this.getAmalgamatingBusinesses.find((b: AmalgamatingBusinessIF) =>
+      b.role === AmlRoles.HOLDING || b.role === AmlRoles.PRIMARY
+    )
+    if (previous) {
+      previous.role = AmlRoles.AMALGAMATING
+    }
+
+    // set this business as the new holding/primary business
+    if (this.isAmalgamationFilingVertical) business.role = AmlRoles.HOLDING
+    if (this.isAmalgamationFilingHorizontal) business.role = AmlRoles.PRIMARY
+
+    // overwrite office addresses
+    this.setOfficeAddresses(business.addresses)
+
+    // overwrite directors (but keep completing party, if there is one)
+    const completingParty = this.getAddPeopleAndRoleStep.orgPeople.find((p: OrgPersonIF) =>
+      p.roles.some(role => role.roleType === RoleTypes.COMPLETING_PARTY)
+    )
+    if (completingParty) this.setOrgPersonList([ ...directors, completingParty ])
+    else this.setOrgPersonList(directors)
+
+    // overwrite share structure
+    this.setShareClasses(shareStructure.shareClasses)
+
+    // overwrite business contact -- only when user has marked new holding/primary business,
+    // otherwise leave existing data from restored draft
+    if (isNew) {
+      this.setBusinessContact({
+        email: authInfo.contacts[0].email,
+        confirmEmail: authInfo.contacts[0].email,
+        phone: authInfo.contacts[0].phone,
+        extension: authInfo.contacts[0].extension
+      })
+    }
+
+    // set new resulting business name and type
+    this.setNameRequestApprovedName(business.name)
+    this.setEntityType(business.legalType)
   }
 
   //

--- a/src/mixins/document-mixin.ts
+++ b/src/mixins/document-mixin.ts
@@ -37,7 +37,7 @@ export default class DocumentMixin extends Vue {
         }
         return data
       }).catch(error => {
-        console.log('Get presigned url error =', error) // eslint-disable-line no-console
+        console.log('Error getting presigned url =', error) // eslint-disable-line no-console
         throw error
       })
   }

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -3,17 +3,18 @@ import { Getter, Action } from 'pinia-class'
 import { useStore } from '@/store/store'
 import { AmalgamationMixin, DateMixin } from '@/mixins'
 import {
-  AmalgamationFilingIF, BusinessAddressIF, ContactPointIF, CertifyIF, CompletingPartyIF, ContinuationInFilingIF,
-  CourtOrderIF, CourtOrderStepIF, CreateMemorandumIF, CreateResolutionIF, CreateRulesIF, DefineCompanyIF,
-  DissolutionFilingIF, DissolutionStatementIF, DocumentDeliveryIF, EffectiveDateTimeIF, EmptyContactPoint,
-  EmptyNaics, IncorporationAgreementIF, IncorporationFilingIF, NaicsIF, NameRequestFilingIF,
-  NameTranslationIF, OfficeAddressIF, OrgPersonIF, PartyIF, PeopleAndRoleIF, RegisteredRecordsAddressesIF,
-  RegistrationFilingIF, RegistrationStateIF, RestorationFilingIF, RestorationStateIF, ShareClassIF,
-  ShareStructureIF, SpecialResolutionIF, StaffPaymentIF, StaffPaymentStepIF, UploadAffidavitIF
+  AmalgamationFilingIF, BusinessAddressIF, ContactPointIF, CertifyIF, CompletingPartyIF,
+  ContinuationInFilingIF, CourtOrderIF, CourtOrderStepIF, CreateMemorandumIF, CreateResolutionIF,
+  CreateRulesIF, DefineCompanyIF, DissolutionFilingIF, DissolutionStatementIF, DocumentDeliveryIF,
+  EffectiveDateTimeIF, EmptyContactPoint, EmptyNaics, IncorporationAgreementIF, IncorporationFilingIF,
+  NaicsIF, NameRequestFilingIF, NameTranslationIF, OfficeAddressIF, OrgPersonIF, PartyIF,
+  RegistrationFilingIF, RegistrationStateIF, RestorationFilingIF, RestorationStateIF, ShareStructureIF,
+  SpecialResolutionIF, StaffPaymentIF, StaffPaymentStepIF, UploadAffidavitIF
 } from '@/interfaces'
 import {
   AmalgamationTypes, ApprovalTypes, BusinessTypes, CoopTypes, CorrectNameOptions, DissolutionTypes,
-  EffectOfOrders, FilingTypes, PartyTypes, RelationshipTypes, RestorationTypes, RoleTypes, StaffPaymentOptions
+  EffectOfOrders, FilingTypes, PartyTypes, RelationshipTypes, RestorationTypes, RoleTypes,
+  StaffPaymentOptions
 } from '@/enums'
 import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module/'
 
@@ -22,7 +23,7 @@ import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module/'
  */
 @Component({})
 export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateMixin) {
-  @Getter(useStore) getAddPeopleAndRoleStep!: PeopleAndRoleIF
+  // @Getter(useStore) getAddPeopleAndRoleStep!: PeopleAndRoleIF
   @Getter(useStore) getAffidavitStep!: UploadAffidavitIF
   @Getter(useStore) getAmalgamationCourtApproval!: boolean
   @Getter(useStore) getAmalgamationType!: AmalgamationTypes
@@ -73,7 +74,7 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
   // @Action(useStore) setAmalgamatingBusinesses!: (x: Array<any>) => void
   @Action(useStore) setAmalgamationCourtApproval!: (x: boolean) => void
   @Action(useStore) setBusinessAddress!: (x: OfficeAddressIF) => void
-  @Action(useStore) setBusinessContact!: (x: ContactPointIF) => void
+  // @Action(useStore) setBusinessContact!: (x: ContactPointIF) => void
   @Action(useStore) setCertifyState!: (x: CertifyIF) => void
   @Action(useStore) setCooperativeType!: (x: CoopTypes) => void
   // @Action(useStore) setCorrectNameOption!: (x: CorrectNameOptions) => void
@@ -84,7 +85,7 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
   @Action(useStore) setDissolutionType!: (x: DissolutionTypes) => void
   @Action(useStore) setDocumentOptionalEmail!: (x: string) => void
   @Action(useStore) setEffectiveDate!: (x: Date) => void
-  @Action(useStore) setEntityType!: (x: CorpTypeCd) => void
+  // @Action(useStore) setEntityType!: (x: CorpTypeCd) => void
   @Action(useStore) setFilingId!: (x: number) => void
   @Action(useStore) setFolioNumber!: (x: string) => void
   @Action(useStore) setIncorporationAgreementStepData!: (x: IncorporationAgreementIF) => void
@@ -96,8 +97,8 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
   @Action(useStore) setMemorandum!: (x: CreateMemorandumIF) => void
   // @Action(useStore) setNameRequestApprovedName!: (x: string) => void
   // @Action(useStore) setNameTranslations!: (x: NameTranslationIF[]) => void
-  @Action(useStore) setOfficeAddresses!: (x: RegisteredRecordsAddressesIF) => void
-  @Action(useStore) setOrgPersonList!: (x: OrgPersonIF[]) => void
+  // @Action(useStore) setOfficeAddresses!: (x: RegisteredRecordsAddressesIF) => void
+  // @Action(useStore) setOrgPersonList!: (x: OrgPersonIF[]) => void
   @Action(useStore) setRegistrationBusinessAddress!: (x: BusinessAddressIF) => void
   @Action(useStore) setRegistrationBusinessNumber!: (x: string) => void
   @Action(useStore) setRegistrationBusinessType!: (x: BusinessTypes) => void
@@ -114,7 +115,7 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
   @Action(useStore) setRestorationRelationships!: (x: RelationshipTypes[]) => void
   @Action(useStore) setRestorationType!: (x: RestorationTypes) => void
   @Action(useStore) setRules!: (x: CreateRulesIF) => void
-  @Action(useStore) setShareClasses!: (x: ShareClassIF[]) => void
+  // @Action(useStore) setShareClasses!: (x: ShareClassIF[]) => void
   @Action(useStore) setStaffPayment!: (x: StaffPaymentIF) => void
   @Action(useStore) setBusinessStartDate!: (x: string) => void
   @Action(useStore) setTransactionalFolioNumber!: (x: string) => void
@@ -206,11 +207,9 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
    * Parses a draft amalgamation application filing into the store. Used when loading a filing.
    * @param draftFiling the filing body to parse
    */
-  parseAmalgamationDraft (draftFiling: any): void {
+  async parseAmalgamationDraft (draftFiling: any): Promise<void> {
     // FUTURE: set types so each of these validate their parameters
     // ref: https://www.typescriptlang.org/docs/handbook/generics.html
-
-    // NB: don't parse Name Request object -- NR is fetched from namex/NRO instead
 
     // save filing id
     this.setFilingId(+draftFiling.header.filingId)
@@ -221,22 +220,36 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
     // restore Entity Type
     this.setEntityType(draftFiling.amalgamationApplication.nameRequest.legalType)
 
-    // restore the amalgamating businesses array
+    // restore Office Addresses
+    // NB - short-form amalg will overwrite this from the holding/primary business
+    if (draftFiling.amalgamationApplication.offices) {
+      this.setOfficeAddresses(draftFiling.amalgamationApplication.offices)
+    }
+
+    // restore Persons and Organizations
+    // NB - short-form amalg will overwrite this from the holding/primary business
+    if (draftFiling.amalgamationApplication.parties) {
+      this.setOrgPersonList(draftFiling.amalgamationApplication.parties)
+    }
+
+    // restore Share Classes
+    // NB - short-form amalg will overwrite this from the holding/primary business
+    if (draftFiling.amalgamationApplication.shareStructure) {
+      this.setShareClasses(draftFiling.amalgamationApplication.shareStructure.shareClasses)
+    }
+
+    // restore the Amalgamating Businesses
     if (draftFiling.amalgamationApplication.amalgamatingBusinesses) {
       this.setAmalgamatingBusinesses([
         ...draftFiling.amalgamationApplication.amalgamatingBusinesses
       ])
-      this.refetchAmalgamatingBusinessesInfo()
-    }
 
-    // restore the amalgamation court approval selection which the saved value is either true or false
-    if (draftFiling.amalgamationApplication.courtApproval !== null) {
-      this.setAmalgamationCourtApproval(draftFiling.amalgamationApplication.courtApproval)
-    }
-
-    // restore Office Addresses
-    if (draftFiling.amalgamationApplication.offices) {
-      this.setOfficeAddresses(draftFiling.amalgamationApplication.offices)
+      // Re-fetch the business table data. We do this in case one of the businesses has changed
+      // (eg, became historical) since the last draft save.
+      const holdingPrimary = await this.refetchAmalgamatingBusinessesInfo()
+      // If there's a holding or primary business, fetch its data and update the prepopulated data.
+      // This will overwrite office addresses, directors and share structure from above.
+      if (holdingPrimary) await this.updatePrepopulatedData(holdingPrimary)
     }
 
     // restore business name data
@@ -275,19 +288,21 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
         ...draftFiling.amalgamationApplication.contactPoint,
         confirmEmail: draftFiling.amalgamationApplication.contactPoint.email
       })
-    } else {
-      this.setBusinessContact({ ...EmptyContactPoint })
     }
 
-    // restore Persons and Organizations
-    if (draftFiling.amalgamationApplication.parties) {
-      this.setOrgPersonList(draftFiling.amalgamationApplication.parties || [])
+    // restore Future Effective data
+    if (draftFiling.header.isFutureEffective) {
+      this.setIsFutureEffective(true)
+      const effectiveDate = this.apiToDate(draftFiling.header.effectiveDate)
+      // Check that Effective Date is in the future, to improve UX and
+      // to work around the default effective date set by the back end.
+      if (effectiveDate >= this.getCurrentJsDate) this.setEffectiveDate(effectiveDate)
     }
 
-    // restore Share Structure
-    this.setShareClasses(draftFiling.amalgamationApplication.shareStructure
-      ? draftFiling.amalgamationApplication.shareStructure.shareClasses
-      : [])
+    // restore the Amalgamation Court Approval if it's True or False
+    if (draftFiling.amalgamationApplication.courtApproval !== null) {
+      this.setAmalgamationCourtApproval(draftFiling.amalgamationApplication.courtApproval)
+    }
 
     // restore court order file number / POA
     if (draftFiling.amalgamationApplication.courtOrder?.fileNumber) {
@@ -303,21 +318,14 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
       certifiedBy: draftFiling.header.certifiedBy
     })
 
-    // restore Future Effective data
-    if (draftFiling.header.isFutureEffective) {
-      this.setIsFutureEffective(true)
-      const effectiveDate = this.apiToDate(draftFiling.header.effectiveDate)
-      // Check that Effective Date is in the future, to improve UX and
-      // to work around the default effective date set by the back end.
-      if (effectiveDate >= this.getCurrentJsDate) this.setEffectiveDate(effectiveDate)
-    }
-
+    // NB: Staff role is mutually exclusive with premium account.
     if (this.isRoleStaff) {
       // restore Staff Payment data
       this.parseStaffPayment(draftFiling)
     }
 
     // if this is a premium account and Folio Number exists then restore it
+    // NB: Premium account is mutually exclusive with staff role.
     if (this.isPremiumAccount) {
       if (draftFiling.header.folioNumber) {
         this.setFolioNumber(draftFiling.header.folioNumber)
@@ -477,12 +485,14 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
       if (effectiveDate >= this.getCurrentJsDate) this.setEffectiveDate(effectiveDate)
     }
 
+    // NB: Staff role is mutually exclusive with premium account.
     if (this.isRoleStaff) {
       // restore Staff Payment data
       this.parseStaffPayment(draftFiling)
     }
 
     // if this is a premium account and Folio Number exists then restore it
+    // NB: Premium account is mutually exclusive with staff role.
     if (this.isPremiumAccount) {
       if (draftFiling.header.folioNumber) {
         this.setFolioNumber(draftFiling.header.folioNumber)
@@ -707,12 +717,14 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
       if (effectiveDate >= this.getCurrentJsDate) this.setEffectiveDate(effectiveDate)
     }
 
+    // NB: Staff role is mutually exclusive with premium account.
     if (this.isRoleStaff) {
       // restore Staff Payment data
       this.parseStaffPayment(draftFiling)
     }
 
     // if this is a premium account and Folio Number exists then restore it
+    // NB: Premium account is mutually exclusive with staff role.
     if (this.isPremiumAccount) {
       if (draftFiling.header.folioNumber) {
         this.setFolioNumber(draftFiling.header.folioNumber)

--- a/src/rules/phone-rules.ts
+++ b/src/rules/phone-rules.ts
@@ -1,5 +1,5 @@
 import { VuetifyRuleFunction } from '@/types'
 
 export const PhoneRules: Array<VuetifyRuleFunction> = [
-  (v: any) => (v.length === 0 || v.length === 14) || 'Phone number is invalid'
+  (v: any) => (!v || v.length === 0 || v.length === 14) || 'Phone number is invalid'
 ]

--- a/src/views/Amalgamation/BusinessInfo.vue
+++ b/src/views/Amalgamation/BusinessInfo.vue
@@ -68,10 +68,15 @@
           Enter the contact information for the resulting business. The BC Business Registry will use this
           to communicate with the business in the future, including sending documents and notifications.
         </p>
-        <p v-if="isAmalgamationFilingHorizontal || isAmalgamationFilingVertical">
-          The resulting business will use this contact information adopted from the holding / primary business
-          in this amalgamation. The BC Business Registry will use this to communicate with the business in the
-          future, including sending documents and notifications.
+        <p v-if="isAmalgamationFilingHorizontal">
+          The resulting business will use this contact information adopted from the primary business in this
+          amalgamation. The BC Business Registry will use this to communicate with the business in the future,
+          including sending documents and notifications.
+        </p>
+        <p v-if="isAmalgamationFilingVertical">
+          The resulting business will use this contact information adopted from the holding business in this
+          amalgamation. The BC Business Registry will use this to communicate with the business in the future,
+          including sending documents and notifications.
         </p>
       </header>
 


### PR DESCRIPTION
*Issue #:* bcgov/entity#19037

**I'm presently working on the unit tests, but I think all the functionality is complete and working correctly.**

*Description of changes:*
- added eslint rule
- app version = 5.8.4
- fixed parseAmalgamationDraft to async
- added code for new holding/primary business
- now save TING complete addresses
- updated tables to show reg office mailing address
- don't show actions menu for holding/primary business
- added more actions menu only for short-form amalgamating businesses
- make business table reactive to holding/primary change
- update prepopulated data on file and pay
- fixed Business Contact Info reactivity bug
- opened name translations sub-menu to the left (per Yui)
- now return the holding/primary business from refetchAmalgamatingBusinessesInfo()
- added mixin method to fetch holding/primary business data and update prepopulated data
- cleaned up parseAmalgamationDraft()
- update prepopulated data on draft restore
- fixed Phone Rules bug
- added fetchDirectors() and fetchShareStructure() to Legal Services

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).