### PR TITLE
19629 Update legal type when adopting a business' name or new NR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.8.5",
+  "version": "5.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.8.5",
+      "version": "5.8.6",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",
@@ -18,7 +18,7 @@
         "@bcrs-shared-components/confirm-dialog": "1.2.1",
         "@bcrs-shared-components/contact-info": "1.2.15",
         "@bcrs-shared-components/corp-type-module": "1.0.15",
-        "@bcrs-shared-components/correct-name": "1.0.36",
+        "@bcrs-shared-components/correct-name": "1.0.40",
         "@bcrs-shared-components/court-order-poa": "3.0.11",
         "@bcrs-shared-components/date-picker": "1.2.15",
         "@bcrs-shared-components/document-delivery": "1.2.0",
@@ -326,15 +326,15 @@
       "integrity": "sha512-g/TcNSR7zJsG2lBjn/NnM+/+k7dJzhAiy5PiPj0ObN56bUV1PrUWVVlg5lz4/JZUEAZetWhwnyAzPVGsn7kr1w=="
     },
     "node_modules/@bcrs-shared-components/correct-name": {
-      "version": "1.0.36",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/correct-name/-/correct-name-1.0.36.tgz",
-      "integrity": "sha512-IQZgdcKbIR9111y/8zXfwvFv+EpXqP4YPlGErWkQofGsp42HjRefcTcLpSV2tcAkaDoqmZiGiP7w+QefxI4TmA==",
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/correct-name/-/correct-name-1.0.40.tgz",
+      "integrity": "sha512-9ySmLiwq0n8fLfBNRJ9ayuNiv3eDmELSeqpU5Ce1m54hOceGE8RYQjyZoC7iS9Ln9BkeFMTTGwN5dyKb8yAktg==",
       "dependencies": {
         "@bcrs-shared-components/confirm-dialog": "^1.2.3",
-        "@bcrs-shared-components/corp-type-module": "^1.0.14",
-        "@bcrs-shared-components/enums": "^1.1.5",
-        "@bcrs-shared-components/interfaces": "^1.1.5",
-        "@bcrs-shared-components/mixins": "^1.1.34",
+        "@bcrs-shared-components/corp-type-module": "^1.0.15",
+        "@bcrs-shared-components/enums": "^1.1.7",
+        "@bcrs-shared-components/interfaces": "^1.1.7",
+        "@bcrs-shared-components/mixins": "^1.1.36",
         "@bcrs-shared-components/types": "^1.0.1",
         "vue": "^2.7.14"
       }
@@ -344,6 +344,29 @@
       "resolved": "https://registry.npmjs.org/@bcrs-shared-components/confirm-dialog/-/confirm-dialog-1.2.3.tgz",
       "integrity": "sha512-QCXRqnGkhyzNbyOSQ2E6A5rsUUYnLuv5hwqXCO6zTyg9NrrsFy+6UF4/6t/Muz9EBSyYNbGr1DmziuvLZ9zDGw==",
       "dependencies": {
+        "vue": "^2.7.14"
+      }
+    },
+    "node_modules/@bcrs-shared-components/correct-name/node_modules/@bcrs-shared-components/interfaces": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/interfaces/-/interfaces-1.1.7.tgz",
+      "integrity": "sha512-E9zvZQb1FRfHcH88ZYNmSV5ocH4o5C5vqBvhUDg6D/BU7n3Fnw+tS69Mm6iQo1V/WXFOgF0x57fc7tMzT0dy1w==",
+      "dependencies": {
+        "@bcrs-shared-components/corp-type-module": "^1.0.15",
+        "@bcrs-shared-components/enums": "^1.1.7",
+        "vue": "^2.7.14"
+      }
+    },
+    "node_modules/@bcrs-shared-components/correct-name/node_modules/@bcrs-shared-components/mixins": {
+      "version": "1.1.36",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/mixins/-/mixins-1.1.36.tgz",
+      "integrity": "sha512-J9Zy1HKIIkZ04Kq30Q43+5D+ABzgjqhgUfXVltVYjI+qyMLUcC/IhvMvYicyfqZeOA2Z537k8EfS/mGcMwaAKg==",
+      "dependencies": {
+        "@bcrs-shared-components/enums": "^1.1.7",
+        "@bcrs-shared-components/interfaces": "^1.1.7",
+        "country-list": "^2.3.0",
+        "lodash": "4.17.21",
+        "provinces": "^1.11.0",
         "vue": "^2.7.14"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.8.5",
+  "version": "5.8.6",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",
@@ -23,7 +23,7 @@
     "@bcrs-shared-components/confirm-dialog": "1.2.1",
     "@bcrs-shared-components/contact-info": "1.2.15",
     "@bcrs-shared-components/corp-type-module": "1.0.15",
-    "@bcrs-shared-components/correct-name": "1.0.36",
+    "@bcrs-shared-components/correct-name": "1.0.40",
     "@bcrs-shared-components/court-order-poa": "3.0.11",
     "@bcrs-shared-components/date-picker": "1.2.15",
     "@bcrs-shared-components/document-delivery": "1.2.0",

--- a/src/components/Amalgamation/BusinessTable.vue
+++ b/src/components/Amalgamation/BusinessTable.vue
@@ -162,10 +162,11 @@ export default class BusinessTable extends Mixins(AmalgamationMixin) {
 
   /** Whether to show the more actions menu for specified item. */
   showMoreActionsMenu (item: AmalgamatingBusinessIF): boolean {
-    // only show for short-form amalgamating businesses
+    // only show for short-form amalgamating LEAR businesses
     return (
       (this.isAmalgamationFilingHorizontal || this.isAmalgamationFilingVertical) &&
-      item.role === AmlRoles.AMALGAMATING
+      item.role === AmlRoles.AMALGAMATING &&
+      item.type === AmlTypes.LEAR
     )
   }
 


### PR DESCRIPTION
*Issue #:* bcgov/entity#19629

*Description of changes:*
- app version = 5.8.6
- imported latest shared correct-name components
- pass in null entity type so it's not checked
- if adopting a business' name, also adopt its legal type
- when using a new NR, also use its legal type

Also, a bugfix from bcgov/entity#19037:
- only show more actions menu for LEAR businesses

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).