### PR TITLE
19698 Added Account-Id to auth api call + check for null auth info + small cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.8.14",
+  "version": "5.8.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.8.14",
+      "version": "5.8.15",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.8.14",
+  "version": "5.8.15",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -260,8 +260,8 @@ import { AmalgamationRegResources, AmalgamationShortResources, ContinuationInRes
 import { AuthServices, LegalServices, PayServices } from '@/services/'
 
 // Enums and Constants
-import { EntityStates, ErrorTypes, FilingCodes, FilingNames, FilingStatus, FilingTypes, NameRequestStates, RouteNames,
-  StaffPaymentOptions } from '@/enums'
+import { EntityStates, ErrorTypes, FilingCodes, FilingNames, FilingStatus, FilingTypes, NameRequestStates,
+  RouteNames, StaffPaymentOptions } from '@/enums'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module'
 
@@ -291,7 +291,6 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
   @Getter(useStore) getFilingName!: FilingNames
   @Getter(useStore) getFilingType!: FilingTypes
   @Getter(useStore) getHaveChanges!: boolean
-  @Getter(useStore) getKeycloakRoles!: Array<string>
   @Getter(useStore) getOrgInformation!: OrgInformationIF
   @Getter(useStore) getSteps!: Array<StepIF>
   @Getter(useStore) getUserFirstName!: string
@@ -305,7 +304,6 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
   @Getter(useStore) isDissolutionFiling!: boolean
   @Getter(useStore) isIncorporationFiling!: boolean
   @Getter(useStore) isMobile!: boolean
-  @Getter(useStore) isRestorationFiling!: boolean
   @Getter(useStore) isSbcStaff!: boolean
 
   @Action(useStore) setAccountInformation!: (x: AccountInformationIF) => void
@@ -875,6 +873,8 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
     // set the resources
     if (!resources) throw new Error(`Invalid ${this.getEntityType} resources`)
     this.setResources(resources)
+    // NB - for some reason, need to call this here so the store updates this getter
+    const dummy = this.getFilingData // eslint-disable-line
 
     // Fetch and validate the NR and set the data to the store. This method is different
     // from the validateNameRequest method in Actions.vue. This method sets the data to

--- a/src/resources/BreadcrumbResource.ts
+++ b/src/resources/BreadcrumbResource.ts
@@ -31,7 +31,7 @@ function getNumberedEntityName (): string {
 
 /** Returns URL param string with Account ID if present, else empty string. */
 function getParams (): string {
-  const accountId: number = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
+  const accountId = store.getAccountId
   return accountId ? `?accountid=${accountId}` : ''
 }
 

--- a/src/services/auth-services.ts
+++ b/src/services/auth-services.ts
@@ -2,6 +2,11 @@
 import { AxiosInstance as axios } from '@/utils'
 import { AuthInformationIF, ContactPointIF } from '@/interfaces'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
+import { createPinia, setActivePinia } from 'pinia'
+import { useStore } from '@/store/store'
+
+setActivePinia(createPinia())
+const store = useStore()
 
 /**
  * Class that provides integration with the Auth API.
@@ -34,8 +39,9 @@ export default class AuthServices {
 
     const authApiUrl = sessionStorage.getItem(SessionStorageKeys.AuthApiUrl)
     const url = `${authApiUrl}entities/${businessId}`
+    const config = { headers: { 'Account-Id': store.getAccountId } }
 
-    return axios.get(url).then(response => {
+    return axios.get(url, config).then(response => {
       if (response?.data) {
         return {
           contacts: response.data.contacts

--- a/src/services/legal-services.ts
+++ b/src/services/legal-services.ts
@@ -4,23 +4,16 @@ import { BusinessIF, DissolutionFilingIF, IncorporationFilingIF, NameRequestIF, 
   from '@/interfaces'
 import { FilingTypes, RoleTypes } from '@/enums'
 import { ShareStructureIF } from '@bcrs-shared-components/interfaces'
+import { createPinia, setActivePinia } from 'pinia'
+import { useStore } from '@/store/store'
+
+setActivePinia(createPinia())
+const store = useStore()
 
 /**
  * Class that provides integration with the Legal API.
  */
 export default class LegalServices {
-  /** The Account ID, from session storage. */
-  static get accountId (): string {
-    // if we can't get account id from ACCOUNT_ID
-    // then try to get it from CURRENT_ACCOUNT
-    let accountId = sessionStorage.getItem('ACCOUNT_ID')
-    if (!accountId) {
-      const currentAccount = sessionStorage.getItem('CURRENT_ACCOUNT')
-      accountId = JSON.parse(currentAccount)?.id
-    }
-    return accountId
-  }
-
   /**
    * Fetches filings list.
    * @param businessId the business identifier (aka entity inc no)
@@ -136,9 +129,9 @@ export default class LegalServices {
     if (isDraft) {
       url += '?draft=true'
     }
+    const config = { headers: { 'Account-Id': store.getAccountId } }
 
-    return axios.put(url, { filing },
-      { headers: { 'Account-Id': this.accountId } }).then(response => {
+    return axios.put(url, { filing }, config).then(response => {
       const filing = response?.data?.filing
       const filingId = +filing?.header?.filingId || 0
 

--- a/src/services/legal-services.ts
+++ b/src/services/legal-services.ts
@@ -21,6 +21,7 @@ export default class LegalServices {
    */
   static async fetchFilings (businessId: string): Promise<any[]> {
     const url = `businesses/${businessId}/filings`
+
     return axios.get(url)
       .then(response => {
         const filings = response?.data?.filings
@@ -76,6 +77,7 @@ export default class LegalServices {
    */
   static async fetchFirstTask (businessId: string): Promise<any> {
     const url = `businesses/${businessId}/tasks`
+
     return axios.get(url)
       .then(response => {
         const filing = response?.data?.tasks?.[0]?.task.filing
@@ -155,6 +157,7 @@ export default class LegalServices {
     if (!nrNumber) throw new Error('Invalid parameter \'nrNumber\'')
 
     const url = `nameRequests/${nrNumber}/validate?phone=${phone}&email=${email}`
+
     return axios.get(url)
       .then(response => {
         const data = response?.data
@@ -179,6 +182,7 @@ export default class LegalServices {
    */
   static async fetchParties (businessId: string): Promise<any> {
     const url = `businesses/${businessId}/parties`
+
     return axios.get(url).then(response => {
       const data = response?.data
       if (!data) throw new Error('Invalid API response')
@@ -260,6 +264,7 @@ export default class LegalServices {
    */
   static async fetchAddresses (businessId: string): Promise<any> {
     const url = `businesses/${businessId}/addresses`
+
     return axios.get(url).then(response => {
       const data = response?.data
       if (!data) throw new Error('Invalid API response')
@@ -279,6 +284,7 @@ export default class LegalServices {
    */
   static async fetchBusinessInfo (businessId: string): Promise<BusinessIF> {
     const url = `businesses/${businessId}`
+
     return axios.get(url).then(response => {
       const data = response?.data
       if (!data) throw new Error('Invalid API response')

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -77,6 +77,18 @@ import {
 export const useStore = defineStore('store', {
   state: (): StateIF => ({ resourceModel, stateModel }),
   getters: {
+    /** The Account ID, from session storage. */
+    getAccountId (): string {
+      // if we can't get account id from ACCOUNT_ID
+      // then try to get it from CURRENT_ACCOUNT
+      let accountId = sessionStorage.getItem('ACCOUNT_ID')
+      if (!accountId) {
+        const currentAccount = sessionStorage.getItem('CURRENT_ACCOUNT')
+        accountId = JSON.parse(currentAccount)?.id
+      }
+      return accountId
+    },
+
     /** True if current screen width is mobile. */
     isMobile (): boolean {
     // fall back to base window width if no window size changes have occurred

--- a/src/utils/Navigate.ts
+++ b/src/utils/Navigate.ts
@@ -1,3 +1,9 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { useStore } from '@/store/store'
+
+setActivePinia(createPinia())
+const store = useStore()
+
 /**
  * Navigates to the specified URL, including Account ID param if available.
  * This function may or may not return. The caller should account for this!
@@ -5,7 +11,7 @@
 export function Navigate (url: string): boolean {
   try {
     // get account id and set in params
-    const accountId = JSON.parse(sessionStorage.getItem('CURRENT_ACCOUNT'))?.id
+    const accountId = store.getAccountId
     if (accountId) {
       if (url.includes('?')) {
         url += `&accountid=${accountId}`

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -650,42 +650,6 @@ describe('Voluntary Dissolution - Define Dissolution page for a BEN', () => {
     store.stateModel.effectiveDateTime.isFutureEffective = false
     store.stateModel.staffPaymentStep.staffPayment.isPriority = false
 
-    const feesPromise = new Promise(resolve => resolve({
-      data:
-      {
-        filingFees: 20.0,
-        filingType: 'Voluntary dissolution',
-        filingTypeCode: 'DIS_VOL',
-        futureEffectiveFees: 0,
-        priorityFees: 0,
-        processingFees: 0,
-        serviceFees: 1.50,
-        tax: {
-          gst: 0,
-          pst: 0
-        },
-        total: 21.5
-      }
-    }))
-
-    const feesFutureEffectivePromise = new Promise(resolve => resolve({
-      data:
-      {
-        filingFees: 20.0,
-        filingType: 'Voluntary dissolution',
-        filingTypeCode: 'DIS_VOL',
-        futureEffectiveFees: 100.0,
-        priorityFees: 0,
-        processingFees: 0,
-        serviceFees: 1.5,
-        tax: {
-          gst: 0,
-          pst: 0
-        },
-        total: 121.5
-      }
-    }))
-
     const get = sinon.stub(axios, 'get')
 
     // GET current user's info
@@ -732,11 +696,43 @@ describe('Voluntary Dissolution - Define Dissolution page for a BEN', () => {
 
     // GET filing fees
     get.withArgs('https://pay.api.url/fees/BEN/DIS_VOL')
-      .returns(feesPromise)
+      .returns(new Promise(resolve => resolve({
+        data:
+        {
+          filingFees: 20.0,
+          filingType: 'Voluntary dissolution',
+          filingTypeCode: 'DIS_VOL',
+          futureEffectiveFees: 0,
+          priorityFees: 0,
+          processingFees: 0,
+          serviceFees: 1.50,
+          tax: {
+            gst: 0,
+            pst: 0
+          },
+          total: 21.5
+        }
+      })))
 
     // GET filing fees with future effective flag
     get.withArgs('https://pay.api.url/fees/BEN/DIS_VOL?futureEffective=true')
-      .returns(feesFutureEffectivePromise)
+      .returns(new Promise(resolve => resolve({
+        data:
+        {
+          filingFees: 20.0,
+          filingType: 'Voluntary dissolution',
+          filingTypeCode: 'DIS_VOL',
+          futureEffectiveFees: 100.0,
+          priorityFees: 0,
+          processingFees: 0,
+          serviceFees: 1.5,
+          tax: {
+            gst: 0,
+            pst: 0
+          },
+          total: 121.5
+        }
+      })))
 
     // GET auth info
     get.withArgs('https://auth.api.url/entities/BC0870803')


### PR DESCRIPTION
*Issue #:* bcgov/entity#19698

*Description of changes:*
    - app version = 5.8.15
    - added get after set to update store
    - added check for empty auth info when re-fetching ting business info
    - added some safety checks when updating prepopulated data (ie, new holding/primary business)
    - moved accountId computed to store
    - added Account-Id header to fetchAuthInfo()
    - deleted some unused getters/local code
    - cleaned up some App unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).