### PR TITLE
19774 Fixed null officer email schema error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.8.10",
+  "version": "5.8.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.8.10",
+      "version": "5.8.11",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.8.10",
+  "version": "5.8.11",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -1468,14 +1468,15 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
   }
 
   /**
-   * Fixes addresses by deleting the type in case it was null.
+   * Fixes addresses by deleting the type in case it is null. Also fixes null officer email.
    * @param orgPeople The array of orgs/people
-   * @returns the array of orgs/people after addresses been fixed
+   * @returns the array of orgs/people with fixed address types and email
    */
   fixNullAddressType (orgPeople: OrgPersonIF[]): OrgPersonIF[] {
     return orgPeople.map(p => {
       if (p.deliveryAddress?.addressType === null) delete p.deliveryAddress.addressType
       if (p.mailingAddress?.addressType === null) delete p.mailingAddress.addressType
+      if (p.officer?.email === null) delete p.officer.email
       return p
     })
   }


### PR DESCRIPTION
*Issue #:* bcgov/entity#19774

*Description of changes:*
- app version = 5.8.11
- delete officer email if it's null

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).