### PR TITLE
19754 Update amalgamation resources for Certify component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.8.12",
+  "version": "5.8.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.8.12",
+      "version": "5.8.13",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.8.12",
+  "version": "5.8.13",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/resources/AmalgamationRegular/BC.ts
+++ b/src/resources/AmalgamationRegular/BC.ts
@@ -33,11 +33,10 @@ export const AmalgamationRegResourceBc: AmalgamationResourceIF = {
   reviewAndConfirm: {
     completingPartyStatement: {
       certifyStatements: [
-        ResourcePhrases.RELEVANT_KNOWLEDGE_OF_BUSINESS,
         ResourcePhrases.AMALGAMATION_CANNOT_BE_REVERSED
       ],
       certifyClause: ResourcePhrases.OFFENCE_SECTION_427,
-      entityDisplay: null
+      entityDisplay: 'business'
     }
   }
 }

--- a/src/resources/AmalgamationRegular/BEN.ts
+++ b/src/resources/AmalgamationRegular/BEN.ts
@@ -33,11 +33,10 @@ export const AmalgamationRegResourceBen: AmalgamationResourceIF = {
   reviewAndConfirm: {
     completingPartyStatement: {
       certifyStatements: [
-        ResourcePhrases.RELEVANT_KNOWLEDGE_OF_BUSINESS,
         ResourcePhrases.AMALGAMATION_CANNOT_BE_REVERSED
       ],
       certifyClause: ResourcePhrases.OFFENCE_SECTION_427,
-      entityDisplay: null
+      entityDisplay: 'business'
     }
   }
 }

--- a/src/resources/AmalgamationRegular/CC.ts
+++ b/src/resources/AmalgamationRegular/CC.ts
@@ -33,11 +33,10 @@ export const AmalgamationRegResourceCc: AmalgamationResourceIF = {
   reviewAndConfirm: {
     completingPartyStatement: {
       certifyStatements: [
-        ResourcePhrases.RELEVANT_KNOWLEDGE_OF_BUSINESS,
         ResourcePhrases.AMALGAMATION_CANNOT_BE_REVERSED
       ],
       certifyClause: ResourcePhrases.OFFENCE_SECTION_427,
-      entityDisplay: null
+      entityDisplay: 'business'
     }
   }
 }

--- a/src/resources/AmalgamationRegular/ULC.ts
+++ b/src/resources/AmalgamationRegular/ULC.ts
@@ -33,11 +33,10 @@ export const AmalgamationRegResourceUlc: AmalgamationResourceIF = {
   reviewAndConfirm: {
     completingPartyStatement: {
       certifyStatements: [
-        ResourcePhrases.RELEVANT_KNOWLEDGE_OF_BUSINESS,
         ResourcePhrases.AMALGAMATION_CANNOT_BE_REVERSED
       ],
       certifyClause: ResourcePhrases.OFFENCE_SECTION_427,
-      entityDisplay: null
+      entityDisplay: 'business'
     }
   }
 }

--- a/src/resources/AmalgamationShort/BC.ts
+++ b/src/resources/AmalgamationShort/BC.ts
@@ -36,11 +36,10 @@ export const AmalgamationShortResourceBc: AmalgamationResourceIF = {
   reviewAndConfirm: {
     completingPartyStatement: {
       certifyStatements: [
-        ResourcePhrases.RELEVANT_KNOWLEDGE_OF_BUSINESS,
         ResourcePhrases.AMALGAMATION_CANNOT_BE_REVERSED
       ],
       certifyClause: ResourcePhrases.OFFENCE_SECTION_427,
-      entityDisplay: null
+      entityDisplay: 'business'
     }
   }
 }

--- a/src/resources/AmalgamationShort/BEN.ts
+++ b/src/resources/AmalgamationShort/BEN.ts
@@ -36,11 +36,10 @@ export const AmalgamationShortResourceBen: AmalgamationResourceIF = {
   reviewAndConfirm: {
     completingPartyStatement: {
       certifyStatements: [
-        ResourcePhrases.RELEVANT_KNOWLEDGE_OF_BUSINESS,
         ResourcePhrases.AMALGAMATION_CANNOT_BE_REVERSED
       ],
       certifyClause: ResourcePhrases.OFFENCE_SECTION_427,
-      entityDisplay: null
+      entityDisplay: 'business'
     }
   }
 }

--- a/src/resources/AmalgamationShort/CC.ts
+++ b/src/resources/AmalgamationShort/CC.ts
@@ -36,11 +36,10 @@ export const AmalgamationShortResourceCc: AmalgamationResourceIF = {
   reviewAndConfirm: {
     completingPartyStatement: {
       certifyStatements: [
-        ResourcePhrases.RELEVANT_KNOWLEDGE_OF_BUSINESS,
         ResourcePhrases.AMALGAMATION_CANNOT_BE_REVERSED
       ],
       certifyClause: ResourcePhrases.OFFENCE_SECTION_427,
-      entityDisplay: null
+      entityDisplay: 'business'
     }
   }
 }

--- a/src/resources/AmalgamationShort/ULC.ts
+++ b/src/resources/AmalgamationShort/ULC.ts
@@ -36,11 +36,10 @@ export const AmalgamationShortResourceUlc: AmalgamationResourceIF = {
   reviewAndConfirm: {
     completingPartyStatement: {
       certifyStatements: [
-        ResourcePhrases.RELEVANT_KNOWLEDGE_OF_BUSINESS,
         ResourcePhrases.AMALGAMATION_CANNOT_BE_REVERSED
       ],
       certifyClause: ResourcePhrases.OFFENCE_SECTION_427,
-      entityDisplay: null
+      entityDisplay: 'business'
     }
   }
 }


### PR DESCRIPTION
*Issue #:* bcgov/entity#19754

*Description of changes:*
- app version = 5.8.13
- removed redundant first certify bullet
- set certify entity display to "business"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).