### PR TITLE
19745 Implemented compatible entity type check for adoptee businesses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.8.13",
+  "version": "5.8.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.8.13",
+      "version": "5.8.14",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",
@@ -18,7 +18,7 @@
         "@bcrs-shared-components/confirm-dialog": "1.2.1",
         "@bcrs-shared-components/contact-info": "1.2.15",
         "@bcrs-shared-components/corp-type-module": "1.0.15",
-        "@bcrs-shared-components/correct-name": "1.0.40",
+        "@bcrs-shared-components/correct-name": "1.0.42",
         "@bcrs-shared-components/court-order-poa": "3.0.11",
         "@bcrs-shared-components/date-picker": "1.2.15",
         "@bcrs-shared-components/document-delivery": "1.2.0",
@@ -326,9 +326,9 @@
       "integrity": "sha512-g/TcNSR7zJsG2lBjn/NnM+/+k7dJzhAiy5PiPj0ObN56bUV1PrUWVVlg5lz4/JZUEAZetWhwnyAzPVGsn7kr1w=="
     },
     "node_modules/@bcrs-shared-components/correct-name": {
-      "version": "1.0.40",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/correct-name/-/correct-name-1.0.40.tgz",
-      "integrity": "sha512-9ySmLiwq0n8fLfBNRJ9ayuNiv3eDmELSeqpU5Ce1m54hOceGE8RYQjyZoC7iS9Ln9BkeFMTTGwN5dyKb8yAktg==",
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/correct-name/-/correct-name-1.0.42.tgz",
+      "integrity": "sha512-f1Irq1qXlsKf52Zf0y5M0JPfwQfUcz8DUDB6d/S07NnKe1/5WsuQ10F/5/bIrEznKuNJpw5Qa2xWlCOl3U3SrA==",
       "dependencies": {
         "@bcrs-shared-components/confirm-dialog": "^1.2.3",
         "@bcrs-shared-components/corp-type-module": "^1.0.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.8.13",
+  "version": "5.8.14",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",
@@ -23,7 +23,7 @@
     "@bcrs-shared-components/confirm-dialog": "1.2.1",
     "@bcrs-shared-components/contact-info": "1.2.15",
     "@bcrs-shared-components/corp-type-module": "1.0.15",
-    "@bcrs-shared-components/correct-name": "1.0.40",
+    "@bcrs-shared-components/correct-name": "1.0.42",
     "@bcrs-shared-components/court-order-poa": "3.0.11",
     "@bcrs-shared-components/date-picker": "1.2.15",
     "@bcrs-shared-components/document-delivery": "1.2.0",

--- a/tests/unit/ResultingBusinessName.spec.ts
+++ b/tests/unit/ResultingBusinessName.spec.ts
@@ -1,0 +1,73 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { useStore } from '@/store/store'
+import { shallowMount } from '@vue/test-utils'
+import { AmlTypes } from '@/enums'
+import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module'
+import ResultingBusinessName from '@/components/Amalgamation/ResultingBusinessName.vue'
+
+// mock the console.warn function to hide "[Vuetify] Unable to locate target XXX"
+// console.warn = vi.fn()
+
+setActivePinia(createPinia())
+const store = useStore()
+
+describe('Resulting Business Name component', () => {
+  let wrapper: any
+
+  beforeAll(() => {
+    wrapper = shallowMount(ResultingBusinessName)
+  })
+
+  afterAll(() => {
+    wrapper.destroy()
+  })
+
+  it('renders the component properly', () => {
+    expect(wrapper.find('#resulting-business-name').exists()).toBe(true)
+  })
+
+  const FOREIGN = { type: AmlTypes.FOREIGN }
+  const CCC = { type: AmlTypes.LEAR, legalType: CorpTypeCd.BC_CCC }
+  const BC = { type: AmlTypes.LEAR, legalType: CorpTypeCd.BC_COMPANY }
+  const BEN = { type: AmlTypes.LEAR, legalType: CorpTypeCd.BENEFIT_COMPANY }
+  const ULC = { type: AmlTypes.LEAR, legalType: CorpTypeCd.BC_ULC_COMPANY }
+
+  const tests = [
+    { // variation 0
+      amalgamatingBusinesses: [ FOREIGN ],
+      computed: []
+    },
+    { // variation 1
+      entityType: CorpTypeCd.BC_CCC,
+      amalgamatingBusinesses: [ BC, BEN, CCC, ULC ],
+      computed: [ CCC ]
+    },
+    { // variation 2
+      entityType: CorpTypeCd.BC_ULC_COMPANY,
+      amalgamatingBusinesses: [ BC, BEN, CCC, ULC ],
+      computed: [ ULC ]
+    },
+    { // variation 3
+      entityType: CorpTypeCd.BC_COMPANY,
+      amalgamatingBusinesses: [ BC, BEN, CCC, ULC ],
+      computed: [ BC, BEN ]
+    },
+    { // variation 4
+      entityType: CorpTypeCd.BENEFIT_COMPANY,
+      amalgamatingBusinesses: [ BC, BEN, CCC, ULC ],
+      computed: [ BC, BEN ]
+    }
+  ]
+
+  for (let i = 0; i < tests.length; i++) {
+    const test = tests[i]
+    it(`correctly filters the list of amalgamating businesses - variation #${i}`, () => {
+      // set the entity type
+      store.setEntityType(test.entityType || null)
+      // set the amalgamating businesses
+      store.setAmalgamatingBusinesses(test.amalgamatingBusinesses as any[])
+      // verify the computed value
+      expect(wrapper.vm.amalgamatingBusinesses).toEqual(test.computed)
+    })
+  }
+})


### PR DESCRIPTION
*Issue #:* bcgov/entity#19745

*Description of changes:*
    - app version = 5.8.14
    - imported updated correct-name shared component
    - now filter adoptee businesses here instead of in shared component
    - added filter for entity type
    - added test suite

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).