### PR TITLE
19856 Fixed empty officer email schema issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.9.2",
+  "version": "5.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.9.2",
+      "version": "5.9.3",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.9.2",
+  "version": "5.9.3",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -157,7 +157,7 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
             : {}
         },
         courtApproval: this.getAmalgamationCourtApproval,
-        parties: this.fixNullAddressType(this.getAddPeopleAndRoleStep.orgPeople),
+        parties: this.fixOrgPeopleProperties(this.getAddPeopleAndRoleStep.orgPeople),
         shareStructure: {
           shareClasses: this.getCreateShareStructureStep.shareClasses
         }
@@ -371,7 +371,7 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
             ? { extension: +this.getBusinessContact.extension }
             : {}
         },
-        parties: this.fixNullAddressType(this.getAddPeopleAndRoleStep.orgPeople),
+        parties: this.fixOrgPeopleProperties(this.getAddPeopleAndRoleStep.orgPeople),
         shareStructure: {
           shareClasses: this.getCreateShareStructureStep.shareClasses
         }
@@ -537,7 +537,7 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
             ? { extension: +this.getBusinessContact.extension }
             : {}
         },
-        parties: this.fixNullAddressType(this.getAddPeopleAndRoleStep.orgPeople)
+        parties: this.fixOrgPeopleProperties(this.getAddPeopleAndRoleStep.orgPeople)
       }
     }
 
@@ -1467,15 +1467,18 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
   }
 
   /**
-   * Fixes addresses by deleting the type in case it is null. Also fixes null officer email.
-   * @param orgPeople The array of orgs/people
-   * @returns the array of orgs/people with fixed address types and email
+   * For all orgs/people elements, fixes the following properties:
+   * - delivery address type if it's null
+   * - mailing address type if it's null
+   * - officer email if it's null or empty
+   * @param orgPeople the original array of orgs/people
+   * @returns a new array of orgs/people with fixed properties
    */
-  fixNullAddressType (orgPeople: OrgPersonIF[]): OrgPersonIF[] {
+  fixOrgPeopleProperties (orgPeople: OrgPersonIF[]): OrgPersonIF[] {
     return orgPeople.map(p => {
       if (p.deliveryAddress?.addressType === null) delete p.deliveryAddress.addressType
       if (p.mailingAddress?.addressType === null) delete p.mailingAddress.addressType
-      if (p.officer?.email === null) delete p.officer.email
+      if (p.officer?.email === null || p.officer?.email === '') delete p.officer.email
       return p
     })
   }


### PR DESCRIPTION
*Issue #:* bcgov/entity#19856

*Description of changes:*
- app version = 5.9.3
- delete officer email property if it's empty ("")

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).