### PR TITLE
19756 Small change so prepopulated data overrides legal name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.9.3",
+  "version": "5.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.9.3",
+      "version": "5.9.4",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.9.3",
+  "version": "5.9.4",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/Actions.vue
+++ b/src/components/common/Actions.vue
@@ -224,8 +224,9 @@ export default class Actions extends Mixins(AmalgamationMixin, CommonMixin,
         // Re-fetch the business table data. We do this in case one of the businesses has changed (eg,
         // became historical) while the draft was open.
         const holdingPrimary = await this.refetchAmalgamatingBusinessesInfo()
+
         // If there's a holding or primary business, re-fetch its data and update the prepopulated data.
-        // This will overwrite office addresses, directors and share structure.
+        // This will overwrite office addresses, directors, share structure, legal name and legal type.
         if (holdingPrimary) await this.updatePrepopulatedData(holdingPrimary)
       } catch (error) {
         console.log('Error validating table in onClickFilePay(): ', error) // eslint-disable-line no-console
@@ -233,6 +234,9 @@ export default class Actions extends Mixins(AmalgamationMixin, CommonMixin,
         return
       }
     }
+
+    // *** TODO: verify that filing is invalid if the business table now have invalid items
+    // or do we need to await this.$nextTick() here for things to validate?
 
     if (this.isFilingValid) {
       // prevent double saving

--- a/src/components/common/Actions.vue
+++ b/src/components/common/Actions.vue
@@ -235,9 +235,6 @@ export default class Actions extends Mixins(AmalgamationMixin, CommonMixin,
       }
     }
 
-    // *** TODO: verify that filing is invalid if the business table now have invalid items
-    // or do we need to await this.$nextTick() here for things to validate?
-
     if (this.isFilingValid) {
       // prevent double saving
       if (this.isBusySaving) return

--- a/src/mixins/amalgamation-mixin.ts
+++ b/src/mixins/amalgamation-mixin.ts
@@ -429,7 +429,7 @@ export default class AmalgamationMixin extends Vue {
     }
 
     // set new resulting business name and legal type
-    // and update resources (since legal  type may have changed)
+    // and update resources (since legal type may have changed)
     this.setNameRequestApprovedName(business.name)
     this.setEntityType(business.legalType)
     this.updateResources()

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -241,20 +241,6 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
       this.setShareClasses(draftFiling.amalgamationApplication.shareStructure.shareClasses)
     }
 
-    // restore the Amalgamating Businesses
-    if (draftFiling.amalgamationApplication.amalgamatingBusinesses) {
-      this.setAmalgamatingBusinesses([
-        ...draftFiling.amalgamationApplication.amalgamatingBusinesses
-      ])
-
-      // Re-fetch the business table data. We do this in case one of the businesses has changed
-      // (eg, became historical) since the last draft save.
-      const holdingPrimary = await this.refetchAmalgamatingBusinessesInfo()
-      // If there's a holding or primary business, fetch its data and update the prepopulated data.
-      // This will overwrite office addresses, directors and share structure that were set above.
-      if (holdingPrimary) await this.updatePrepopulatedData(holdingPrimary)
-    }
-
     // restore business name data
     const nameRequest = draftFiling.amalgamationApplication.nameRequest as NameRequestFilingIF
     switch (nameRequest?.correctNameOption) {
@@ -289,6 +275,22 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
         ...draftFiling.amalgamationApplication.contactPoint,
         confirmEmail: draftFiling.amalgamationApplication.contactPoint.email
       })
+    }
+
+    // restore the Amalgamating Businesses
+    if (draftFiling.amalgamationApplication.amalgamatingBusinesses) {
+      this.setAmalgamatingBusinesses([
+        ...draftFiling.amalgamationApplication.amalgamatingBusinesses
+      ])
+
+      // Re-fetch the business table data. We do this in case one of the businesses has changed
+      // (eg, became historical) since the last draft save.
+      const holdingPrimary = await this.refetchAmalgamatingBusinessesInfo()
+
+      // If there's a holding or primary business, fetch its data and update the prepopulated data.
+      // This will overwrite office addresses, directors, share structure, legal name and legal type
+      // that were set above from draft data.
+      if (holdingPrimary) await this.updatePrepopulatedData(holdingPrimary)
     }
 
     // restore Future Effective data


### PR DESCRIPTION
*Issue #:* bcgov/entity#19756

*Description of changes:*
- app version = 5.9.4
- updated some code comments
- on draft resume, update prepopulated data after the legal name is restored (as we may override it)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).