### PR TITLE
19874 Changed some snackbar messages to dialogs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.9.4",
+  "version": "5.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.9.4",
+      "version": "5.9.5",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.9.4",
+  "version": "5.9.5",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/RegistriesContactInfo.vue
+++ b/src/components/common/RegistriesContactInfo.vue
@@ -7,7 +7,7 @@
       >
         mdi-phone
       </v-icon>
-      <span class="px-2">Canada and U.S. Toll Free:</span>
+      <span class="px-2 font-weight-bold">Canada and U.S. Toll Free:</span>
       <a
         href="tel:+1-877-526-1526"
         class="contact-value"
@@ -20,7 +20,7 @@
       >
         mdi-phone
       </v-icon>
-      <span class="px-2">Victoria Office:</span>
+      <span class="px-2 font-weight-bold">Victoria Office:</span>
       <a
         href="tel:+1-250-387-7848"
         class="contact-value"
@@ -33,7 +33,7 @@
       >
         mdi-email
       </v-icon>
-      <span class="px-2">Email:</span>
+      <span class="px-2 font-weight-bold">Email:</span>
       <a
         href="mailto:BCRegistries@gov.bc.ca"
         class="contact-value"

--- a/src/dialogs/GenericErrorDialog.vue
+++ b/src/dialogs/GenericErrorDialog.vue
@@ -1,0 +1,61 @@
+<template>
+  <v-dialog
+    v-model="dialog"
+    width="45rem"
+    persistent
+    :attach="attach"
+    content-class="generic-error-dialog"
+    @keydown.esc="close()"
+  >
+    <v-card>
+      <v-card-title>{{ title }}</v-card-title>
+
+      <v-card-text class="pre-wrap">
+        <div
+          v-show="!!message"
+          class="font-15"
+          v-html="message"
+        />
+
+        <RegistriesContactInfo class="mt-6" />
+      </v-card-text>
+
+      <v-card-actions class="justify-center pt-0 pb-9">
+        <v-btn
+          color="primary"
+          large
+          @click="close()"
+        >
+          Close
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import { Component, Emit, Prop, Vue } from 'vue-property-decorator'
+import RegistriesContactInfo from '@/components/common/RegistriesContactInfo.vue'
+
+@Component({
+  components: {
+    RegistriesContactInfo
+  }
+})
+export default class GenericErrorDialog extends Vue {
+  @Prop({ default: '' }) readonly attach!: string
+  @Prop({ default: false }) readonly dialog!: boolean
+  @Prop({ default: 'Please contact us:' }) readonly message!: string
+  @Prop({ default: 'An error occurred' }) readonly title!: string
+
+  @Emit() close (): void {}
+}
+</script>
+
+<style lang="scss" scoped>
+@import '@/assets/styles/theme.scss';
+
+.v-card__text {
+  color: $gray7 !important;
+}
+</style>

--- a/src/dialogs/index.ts
+++ b/src/dialogs/index.ts
@@ -8,6 +8,7 @@ export { default as AccountContactMissingDialog } from './AccountContactMissingD
 export { default as FetchErrorDialog } from './FetchErrorDialog.vue'
 export { default as FileAndPayInvalidNameRequestDialog } from './FileAndPayInvalidNameRequestDialog.vue'
 export { default as FilingSurveyDialog } from './FilingSurveyDialog.vue'
+export { default as GenericErrorDialog } from './GenericErrorDialog.vue'
 export { default as InvalidFilingDialog } from './InvalidFilingDialog.vue'
 export { default as InvalidRouteDialog } from './InvalidRouteDialog.vue'
 export { default as NameRequestInvalidErrorDialog } from './NameRequestInvalidErrorDialog.vue'

--- a/tests/unit/GenericErrorDialog.spec.ts
+++ b/tests/unit/GenericErrorDialog.spec.ts
@@ -1,0 +1,61 @@
+import { mount } from '@vue/test-utils'
+import Vuetify from 'vuetify'
+import GenericErrorDialog from '@/dialogs/GenericErrorDialog.vue'
+import RegistriesContactInfo from '@/components/common/RegistriesContactInfo.vue'
+
+const vuetify = new Vuetify({})
+
+describe('GenericErrorDialog.vue', () => {
+  it('does not render the dialog when disabled', () => {
+    const wrapper = mount(GenericErrorDialog, {
+      vuetify
+    })
+
+    expect(wrapper.find('div[role="dialog"]').exists()).toBe(false)
+
+    wrapper.destroy()
+  })
+
+  it('renders the dialog with default title and message', () => {
+    const wrapper = mount(GenericErrorDialog, {
+      vuetify,
+      propsData: { dialog: true }
+    })
+
+    expect(wrapper.find('div[role="dialog"]').exists()).toBe(true)
+    expect(wrapper.find('.v-card__title').text()).toBe('An error occurred')
+    expect(wrapper.find('.v-card__text > div').text()).toBe('Please contact us:')
+    expect(wrapper.find('.v-card__text').findComponent(RegistriesContactInfo).exists()).toBe(true)
+    expect(wrapper.find('.v-card__actions').text()).toBe('Close')
+
+    wrapper.destroy()
+  })
+
+  it('renders the dialog with custom title and message', () => {
+    const wrapper = mount(GenericErrorDialog, {
+      vuetify,
+      propsData: { dialog: true, message: 'Custom message', title: 'Custom title' }
+    })
+
+    expect(wrapper.find('div[role="dialog"]').exists()).toBe(true)
+    expect(wrapper.find('.v-card__title').text()).toBe('Custom title')
+    expect(wrapper.find('.v-card__text > div').text()).toBe('Custom message')
+    expect(wrapper.find('.v-card__text').findComponent(RegistriesContactInfo).exists()).toBe(true)
+    expect(wrapper.find('.v-card__actions').text()).toBe('Close')
+
+    wrapper.destroy()
+  })
+
+  it('emits close event when the Close button is clicked', async () => {
+    const wrapper = mount(GenericErrorDialog, {
+      vuetify,
+      propsData: { dialog: true }
+    })
+
+    expect(wrapper.emitted('close')).toBeUndefined()
+    await wrapper.find('.v-btn').trigger('click')
+    expect(wrapper.emitted('close')).toEqual([[]])
+
+    wrapper.destroy()
+  })
+})


### PR DESCRIPTION
*Issue #:* bcgov/entity#19874

*Description of changes:*
    - app version = 5.9.5
    - used error dialog for "business not in LEAR" scenario
    - used error dialog for "unable to add business" scenario
    - used error dialog for "error marking new business" scenario
    - bolded labels in RegistriesContactInfo component
    - added generic error dialog component
    - created test suite for new dialog

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).