### PR TITLE
19903 Handle business Forbidden vs Not Found vs error cases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.9.6",
+  "version": "5.9.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.9.6",
+      "version": "5.9.7",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.9.6",
+  "version": "5.9.7",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/interfaces/store-interfaces/state-interfaces/auth-information-interface.ts
+++ b/src/interfaces/store-interfaces/state-interfaces/auth-information-interface.ts
@@ -2,6 +2,7 @@ import { ContactPointIF } from '@/interfaces'
 
 // Auth information interface
 export interface AuthInformationIF {
+  status?: string
   contacts: ContactPointIF[]
   folioNumber: string
 }

--- a/src/services/auth-services.ts
+++ b/src/services/auth-services.ts
@@ -1,5 +1,5 @@
-// Libraries
 import { AxiosInstance as axios } from '@/utils'
+import { StatusCodes } from 'http-status-codes'
 import { AuthInformationIF, ContactPointIF } from '@/interfaces'
 import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 import { createPinia, setActivePinia } from 'pinia'
@@ -25,7 +25,7 @@ export default class AuthServices {
 
     return axios.get(url).then(response => {
       if (response?.data?.roles) return response.data.roles
-      throw new Error('Invalid response data ')
+      throw new Error('Invalid response data')
     })
   }
 
@@ -54,7 +54,14 @@ export default class AuthServices {
           folioNumber: response.data.folioNumber
         }
       }
-      throw new Error('Invalid response data ')
+      throw new Error('Invalid response data')
+    }).catch(error => {
+      if (error?.response?.status === StatusCodes.FORBIDDEN) {
+        return { status: 'FORBIDDEN' } as AuthInformationIF
+      } else if (error?.response?.status === StatusCodes.NOT_FOUND) {
+        return { status: 'NOT_FOUND' } as AuthInformationIF
+      }
+      throw error
     })
   }
 
@@ -68,7 +75,7 @@ export default class AuthServices {
 
     return axios.get(url).then(response => {
       if (response?.data) return response.data
-      throw new Error('Invalid response data ')
+      throw new Error('Invalid response data')
     })
   }
 


### PR DESCRIPTION
*Issue #:* bcgov/entity#19903

*Description of changes:*
- app version = 5.9.7
- handled Forbidden vs Not Found vs missing auth info scenarios separately
- added status to Auth Info response to handle scenarios above
- updated unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).