### PR TITLE
21241 - Hide Court Order and POA for Users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.10.9",
+  "version": "5.10.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.10.10",
+      "version": "5.10.11",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.10.10",
+  "version": "5.10.11",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/views/Incorporation/IncorporationReviewConfirm.vue
+++ b/src/views/Incorporation/IncorporationReviewConfirm.vue
@@ -183,7 +183,7 @@
 
     <!-- Court Order and Plan of Arrangement -->
     <section
-      v-if="isBaseCompany"
+      v-if="isBaseCompany && isRoleStaff"
       id="court-order-poa-section"
       class="mt-10"
     >

--- a/tests/unit/IncorporationReviewConfirm.spec.ts
+++ b/tests/unit/IncorporationReviewConfirm.spec.ts
@@ -81,19 +81,19 @@ for (const test of reviewConfirmTestCases) {
       expect(wrapper.find('#certify-section').exists()).toBe(true)
     })
 
-    it('displays Court Order and Plan of Arrangement section only for BEN, ULC, CC, BC', () => {
+    it('displays Court Order and POA only for BEN, ULC, CC, BC; and only for staff', () => {
       wrapper = shallowWrapperFactory(
         IncorporationReviewConfirm,
         null,
         {
-          entityType: test.entityType
+          entityType: test.entityType,
+          tombstone: { keycloakRoles: test.isStaff ? ['staff'] : [] }
         },
         null,
         IncorporationResources
       )
-
-      expect(wrapper.find('#court-order-poa-section').exists()).toBe(['BEN', 'ULC', 'CC', 'BC']
-        .includes(test.entityType))
+      const shouldBeVisible = ['BEN', 'ULC', 'CC', 'BC'].includes(test.entityType) && test.isStaff
+      expect(wrapper.find('#court-order-poa-section').exists()).toBe(shouldBeVisible)
     })
 
     it('displays Staff Payment section only for staff', () => {


### PR DESCRIPTION
*Issue #:* /bcgov/entity# 21241

*Description of changes:*
- Hided Court Order and POA components for users

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
