### PR TITLE
21248 Fixed continuation authorization reactivity issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.10.15",
+  "version": "5.10.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.10.15",
+      "version": "5.10.16",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.10.15",
+  "version": "5.10.16",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/ContinuationIn/ContinuationAuthorization.vue
+++ b/src/components/ContinuationIn/ContinuationAuthorization.vue
@@ -191,8 +191,8 @@ export default class ExtraproRegistration extends Mixins(DocumentMixin) {
 
   /** Called when this component is mounted. */
   mounted (): void {
-    // set or initialize authorization object
-    this.authorization = this.getContinuationAuthorization || { files: [] } as ContinuationAuthorizationIF
+    this.authorization = this.getContinuationAuthorization ||
+      { files: [], date: null, expiryDate: null } as ContinuationAuthorizationIF
   }
 
   /**
@@ -268,10 +268,11 @@ export default class ExtraproRegistration extends Mixins(DocumentMixin) {
   @Watch('authorization', { deep: true })
   @Emit('valid')
   private onComponentValid (): boolean {
-    // first save the authorization to the store
+    // sync local object to the store
     this.setContinuationAuthorization(this.authorization)
 
-    // then emit the validity
+    // this component is valid if we have the authorization date
+    // and at least one file uploaded
     return (
       !!this.authorization.date &&
       (this.authorization.files.length >= 1)


### PR DESCRIPTION
*Issue #:* bcgov/entity#21248

*Description of changes:*
- app = 5.10.16
- initialized rest of Continuation Authorization object variable so they are reactive

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).