### PR TITLE
21310 Implement Authorization Date min date validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.10.19",
+  "version": "5.10.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.10.19",
+      "version": "5.10.20",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.10.19",
+  "version": "5.10.20",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/ContinuationIn/ContinuationAuthorization.vue
+++ b/src/components/ContinuationIn/ContinuationAuthorization.vue
@@ -172,10 +172,13 @@ export default class ExtraproRegistration extends Mixins(DocumentMixin) {
   fileValidity = false
   customErrorMessage = ['', '', '', '', ''] // max 5 files
 
+  /**
+   * The minimum date for the Authorization Date:
+   * - the BC Founding Date (if it exists, ie, expro business)
+   * - else the Home Jurisdiction Incorporation Date (ie, manual entry)
+   * - else fall back to null (not undefined)
+   */
   get minAuthorizationDate (): string {
-    // the BC Founding Date (if it exists, ie, expro business)
-    // else the Home Jurisdiction Incorporation Date (ie, manual entry)
-    // else fall back to null (not undefined)
     return (
       this.getExistingBusinessInfo.bcFoundingDate ||
       this.getExistingBusinessInfo.homeIncorporationDate ||

--- a/src/components/ContinuationIn/ContinuationAuthorization.vue
+++ b/src/components/ContinuationIn/ContinuationAuthorization.vue
@@ -36,6 +36,7 @@
             :persistentHint="true"
             :initialValue="authorization.date"
             :inputRules="getShowErrors ? authorizationDateRules : []"
+            :minDate="minAuthorizationDate"
             :maxDate="getCurrentDate"
             @emitDateSync="authorization.date = $event"
           />
@@ -136,7 +137,7 @@ import { Action, Getter } from 'pinia-class'
 import { StatusCodes } from 'http-status-codes'
 import { useStore } from '@/store/store'
 import { DocumentMixin } from '@/mixins'
-import { ContinuationAuthorizationIF, FormIF, PresignedUrlIF } from '@/interfaces'
+import { ContinuationAuthorizationIF, ExistingBusinessInfoIF, FormIF, PresignedUrlIF } from '@/interfaces'
 import { PdfPageSize } from '@/enums'
 import { VuetifyRuleFunction } from '@/types'
 import FileUploadPreview from '@/components/common/FileUploadPreview.vue'
@@ -160,6 +161,7 @@ export default class ExtraproRegistration extends Mixins(DocumentMixin) {
 
   @Getter(useStore) getContinuationAuthorization!: ContinuationAuthorizationIF
   @Getter(useStore) getCurrentDate!: string
+  @Getter(useStore) getExistingBusinessInfo!: ExistingBusinessInfoIF
   @Getter(useStore) getKeycloakGuid!: string
   @Getter(useStore) getShowErrors!: boolean
 
@@ -170,10 +172,28 @@ export default class ExtraproRegistration extends Mixins(DocumentMixin) {
   fileValidity = false
   customErrorMessage = ['', '', '', '', ''] // max 5 files
 
+  get minAuthorizationDate (): string {
+    // the BC Founding Date (if it exists, ie, expro business)
+    // else the Home Jurisdiction Incorporation Date (ie, manual entry)
+    // else fall back to null (not undefined)
+    return (
+      this.getExistingBusinessInfo.bcFoundingDate ||
+      this.getExistingBusinessInfo.homeIncorporationDate ||
+      null
+    )
+  }
+
   get authorizationDateRules (): Array<VuetifyRuleFunction> {
+    const bcFoundingDate = this.getExistingBusinessInfo.bcFoundingDate
+    const homeIncorporationDate = this.getExistingBusinessInfo.homeIncorporationDate
+
     return [
       (v) => !!v || 'Authorization Date is required',
-      () => (this.authorization.date <= this.getCurrentDate) || 'Authorization Date cannot be in the future'
+      () => (this.authorization.date <= this.getCurrentDate) || 'Authorization Date cannot be in the future',
+      () => (!bcFoundingDate || (this.authorization.date >= bcFoundingDate)) ||
+        'Authorization Date cannot be before Date of Registration in B.C.',
+      () => (!homeIncorporationDate || (this.authorization.date >= homeIncorporationDate)) ||
+        'Authorization Date cannot be before Date of Incorporation in Home Jurisdiction'
     ]
   }
 
@@ -253,6 +273,7 @@ export default class ExtraproRegistration extends Mixins(DocumentMixin) {
   }
 
   @Watch('getShowErrors')
+  @Watch('minAuthorizationDate') // because Authorization Date depends on this
   @Watch('authorization.date') // because Expiry Date depends on this
   private async onGetShowErrors (): Promise<void> {
     if (this.getShowErrors) {

--- a/src/components/ContinuationIn/ExtraproRegistration.vue
+++ b/src/components/ContinuationIn/ExtraproRegistration.vue
@@ -132,7 +132,7 @@
             sm="9"
           >
             <v-text-field
-              v-model="business.homeIdentifier"
+              v-model.trim="business.homeIdentifier"
               class="identifying-number-home"
               filled
               hide-details="auto"
@@ -159,7 +159,7 @@
             sm="9"
           >
             <v-text-field
-              v-model="business.homeLegalName"
+              v-model.trim="business.homeLegalName"
               class="name-home-jurisdiction"
               filled
               hide-details="auto"
@@ -475,13 +475,13 @@ export default class ExtraproRegistration extends Mixins(DateMixin) {
   }
 
   readonly homeIdentifierRules: Array<VuetifyRuleFunction> = [
-    (v) => !!v || 'Identifying Number is required',
-    (v) => (v && v.length <= 50) || 'Cannot exceed 50 characters'
+    (v) => !!v?.trim() || 'Identifying Number is required',
+    (v) => (v && v.trim().length <= 50) || 'Cannot exceed 50 characters'
   ]
 
   readonly homeLegalNameRules: Array<VuetifyRuleFunction> = [
-    (v) => !!v || 'Name is required',
-    (v) => (v && v.length <= 1000) || 'Cannot exceed 1000 characters'
+    (v) => !!v?.trim() || 'Name is required',
+    (v) => (v && v.trim().length <= 1000) || 'Cannot exceed 1000 characters'
   ]
 
   get incorporationDateRules (): Array<VuetifyRuleFunction> {
@@ -640,10 +640,8 @@ export default class ExtraproRegistration extends Mixins(DateMixin) {
 
   /** Emits form validity. */
   @Watch('isBusinessActive')
-  @Watch('business.homeJurisdiction')
-  @Watch('business.homeIncorporationDate')
+  @Watch('business', { deep: true })
   @Watch('isContinuationInAffidavitRequired')
-  @Watch('business.affidavitFileKey')
   @Watch('formValid')
   @Emit('valid')
   private onComponentValid (): boolean {

--- a/src/components/ContinuationIn/ManualBusinessInfo.vue
+++ b/src/components/ContinuationIn/ManualBusinessInfo.vue
@@ -97,7 +97,7 @@
             sm="9"
           >
             <v-text-field
-              v-model="business.homeIdentifier"
+              v-model.trim="business.homeIdentifier"
               class="identifying-number"
               filled
               hide-details="auto"
@@ -124,7 +124,7 @@
             sm="9"
           >
             <v-text-field
-              v-model="business.homeLegalName"
+              v-model.trim="business.homeLegalName"
               class="business-name"
               filled
               hide-details="auto"
@@ -296,13 +296,13 @@ export default class ManualBusinessInfo extends Mixins(CountriesProvincesMixin, 
   formValid = false
 
   readonly identifyingNumberRules: Array<VuetifyRuleFunction> = [
-    (v) => !!v || 'Identifying Number is required',
-    (v) => (v && v.length <= 50) || 'Cannot exceed 50 characters'
+    (v) => !!v?.trim() || 'Identifying Number is required',
+    (v) => (v && v.trim().length <= 50) || 'Cannot exceed 50 characters'
   ]
 
   readonly businessNameRules: Array<VuetifyRuleFunction> = [
-    (v) => !!v || 'Business Name is required',
-    (v) => (v && v.length <= 1000) || 'Cannot exceed 1000 characters'
+    (v) => !!v?.trim() || 'Business Name is required',
+    (v) => (v && v.trim().length <= 1000) || 'Cannot exceed 1000 characters'
   ]
 
   get incorporationDateRules (): Array<VuetifyRuleFunction> {
@@ -383,8 +383,7 @@ export default class ManualBusinessInfo extends Mixins(CountriesProvincesMixin, 
   }
 
   /** Emits form validity. */
-  @Watch('business.homeJurisdiction')
-  @Watch('business.homeIncorporationDate')
+  @Watch('business', { deep: true })
   @Watch('formValid')
   @Emit('valid')
   private onComponentValid (): boolean {


### PR DESCRIPTION
*Issue #:* bcgov/entity#21310

*Description of changes:*

Commit 1:
- app version = 5.10.20
- added Authorization Date min date validation

Commit 2:
- trimmed whitespace from text input fields
- now deep-watch objects

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).

*Screenshots:*

Minimum date is May 16, 2001 because that's the date of registration in BC.
![image](https://github.com/bcgov/business-create-ui/assets/10002889/50223d9f-d3aa-49f8-a407-8329f1521425)

![image](https://github.com/bcgov/business-create-ui/assets/10002889/655f1c6b-7724-4216-bbb9-7dbf4d8a2112)

Minimum date is Jan 15, 20024 because that's the date of incorporation in home jurisdiction.
![image](https://github.com/bcgov/business-create-ui/assets/10002889/368027c7-91dc-4629-a95b-bc8e6eaee1ab)

![image](https://github.com/bcgov/business-create-ui/assets/10002889/aec5f09c-f57d-4375-b15c-f85bad818b9f)
