### PR TITLE
21110 Deleted documents that were cleared by user

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.10.23",
+  "version": "5.10.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.10.23",
+      "version": "5.10.24",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.10.23",
+  "version": "5.10.24",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/ContinuationIn/ContinuationAuthorization.vue
+++ b/src/components/ContinuationIn/ContinuationAuthorization.vue
@@ -270,6 +270,8 @@ export default class ExtraproRegistration extends Mixins(DocumentMixin) {
         fileName: file.name
       })
     } else {
+      // delete file from Minio; ignore errors
+      await this.deleteDocument(this.authorization.files[index].fileKey).catch(() => null)
       // remove file from array
       this.authorization.files.splice(index, 1)
     }

--- a/src/components/ContinuationIn/UploadAffidavit.vue
+++ b/src/components/ContinuationIn/UploadAffidavit.vue
@@ -91,11 +91,12 @@ export default class UploadAffidavit extends Mixins(DateMixin, DocumentMixin) {
         this.$set(this.business, 'affidavitFileName', file.name)
       }
     } else {
+      // delete file from Minio; ignore errors
+      await this.deleteDocument(this.business.affidavitFileKey).catch(() => null)
       // delete properties reactively when the file is cleared
       this.$delete(this.business, 'affidavitFile')
       this.$delete(this.business, 'affidavitFileKey')
       this.$delete(this.business, 'affidavitFileName')
-      // FUTURE: should also delete the file from Minio
     }
   }
 }

--- a/src/components/Dissolution/CompleteAffidavit.vue
+++ b/src/components/Dissolution/CompleteAffidavit.vue
@@ -347,6 +347,9 @@ export default class CompleteAffidavit extends Mixins(CommonMixin, DocumentMixin
         this.uploadAffidavitDocKey = null
       }
     } else {
+      // delete file from Minio; ignore errors
+      await this.deleteDocument(this.uploadAffidavitDocKey).catch(() => null)
+      // clear local variables
       this.uploadAffidavitDoc = null
       this.uploadAffidavitDocKey = null
       this.setAffidavit({

--- a/src/components/Incorporation/UploadMemorandum.vue
+++ b/src/components/Incorporation/UploadMemorandum.vue
@@ -413,6 +413,9 @@ export default class UploadMemorandum extends Mixins(CommonMixin, DocumentMixin)
         this.uploadMemorandumDocKey = null
       }
     } else {
+      // delete file from Minio; ignore errors
+      await this.deleteDocument(this.uploadMemorandumDocKey).catch(() => null)
+      // clear local variables
       this.uploadMemorandumDoc = null
       this.uploadMemorandumDocKey = null
       this.setMemorandum({

--- a/src/components/Incorporation/UploadRules.vue
+++ b/src/components/Incorporation/UploadRules.vue
@@ -354,6 +354,9 @@ export default class UploadRules extends Mixins(CommonMixin, DocumentMixin) {
         this.uploadRulesDocKey = null
       }
     } else {
+      // delete file from Minio; ignore errors
+      await this.deleteDocument(this.uploadRulesDocKey).catch(() => null)
+      // clear local variables
       this.uploadRulesDoc = null
       this.uploadRulesDocKey = null
       this.setRules({

--- a/src/mixins/document-mixin.ts
+++ b/src/mixins/document-mixin.ts
@@ -71,6 +71,22 @@ export default class DocumentMixin extends Vue {
   }
 
   /**
+   * Deletes a Minio document from Legal API.
+   * @param documentKey the document key
+   * @returns a promise to return the axios response or the error response
+   */
+  async deleteDocument (documentKey: string): Promise<AxiosResponse> {
+    // safety checks
+    if (!documentKey) {
+      throw new Error('Invalid parameters')
+    }
+
+    const url = `documents/${documentKey}`
+
+    return axios.delete(url)
+  }
+
+  /**
    * Downloads a Minio document from Legal API and prompts browser to open/save it.
    * @param documentKey the document key
    * @param documentName the document filename


### PR DESCRIPTION
*Issue #:* bcgov/entity#21110

**This is part 1 of the ticket (when user clears an uploaded file). Part 2 will be in a separate PR. Unfortunately this isn't testable at the moment because the Legal API endpoint doesn't exist, but it can be verified that this code change doesn't break anything. I will test when I work on part 2.**

*Description of changes:*
- app version = 5.10.24
- added document deletion to Continuation Authorization
- added document deletion to Upload Affidavit
- added document deletion to Complete Affidavit
- added document deletion to Upload Memorandum
- added document deletion to Upload Rules
- added deleteDocument() method

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).