### PR TITLE
21894 Added LTD to CCC numbered name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.11.2",
+  "version": "5.11.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.11.2",
+      "version": "5.11.3",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",
@@ -18,7 +18,7 @@
         "@bcrs-shared-components/confirm-dialog": "1.2.1",
         "@bcrs-shared-components/contact-info": "1.2.15",
         "@bcrs-shared-components/corp-type-module": "1.0.16",
-        "@bcrs-shared-components/correct-name": "1.0.46",
+        "@bcrs-shared-components/correct-name": "1.0.55",
         "@bcrs-shared-components/court-order-poa": "3.0.11",
         "@bcrs-shared-components/date-picker": "1.3.1",
         "@bcrs-shared-components/document-delivery": "1.2.0",
@@ -317,15 +317,15 @@
       "integrity": "sha512-3MumJZ/0Urfnp1AGJpnUifk5DMrLcjDD+8YiGXy1WXjvpVLwA0S4bNPuvFUf0w4My+0HyXWZ/XsZWiQydVGYHw=="
     },
     "node_modules/@bcrs-shared-components/correct-name": {
-      "version": "1.0.46",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/correct-name/-/correct-name-1.0.46.tgz",
-      "integrity": "sha512-CpZr0c3ImEPtfPv5fnBF7YaCiOyzudHRh8b3opQIOjWiyDlFwvWTkZf4TSrgLqL3sub/IVSgiRDLiM+71+Y8Lg==",
+      "version": "1.0.55",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/correct-name/-/correct-name-1.0.55.tgz",
+      "integrity": "sha512-mVH7aUXRyKpKJ9mCM0u5SaPEl7vfyvUm1yis3Jj+zUIbXorfoy6+C2B6vmlCz52AnrnyCjIjuNzIsC5hPoez8g==",
       "dependencies": {
         "@bcrs-shared-components/confirm-dialog": "^1.2.3",
-        "@bcrs-shared-components/corp-type-module": "^1.0.15",
-        "@bcrs-shared-components/enums": "^1.1.8",
-        "@bcrs-shared-components/interfaces": "^1.1.8",
-        "@bcrs-shared-components/mixins": "^1.1.39",
+        "@bcrs-shared-components/corp-type-module": "^1.0.16",
+        "@bcrs-shared-components/enums": "^1.1.10",
+        "@bcrs-shared-components/interfaces": "^1.1.15",
+        "@bcrs-shared-components/mixins": "^1.1.46",
         "@bcrs-shared-components/types": "^1.0.1",
         "vue": "^2.7.14"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.11.2",
+  "version": "5.11.3",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",
@@ -23,7 +23,7 @@
     "@bcrs-shared-components/confirm-dialog": "1.2.1",
     "@bcrs-shared-components/contact-info": "1.2.15",
     "@bcrs-shared-components/corp-type-module": "1.0.16",
-    "@bcrs-shared-components/correct-name": "1.0.46",
+    "@bcrs-shared-components/correct-name": "1.0.55",
     "@bcrs-shared-components/court-order-poa": "3.0.11",
     "@bcrs-shared-components/date-picker": "1.3.1",
     "@bcrs-shared-components/document-delivery": "1.2.0",

--- a/src/components/Amalgamation/ResultingBusinessName.vue
+++ b/src/components/Amalgamation/ResultingBusinessName.vue
@@ -36,7 +36,7 @@
               :businessId="getBusinessId"
               :companyName="companyName"
               :correctionNameChoices="correctionNameChoices"
-              :entityType="null"
+              :entityType="getEntityType"
               :fetchAndValidateNr="fetchAndValidateNr"
               :formType="formType"
               :nameRequest="getNameRequest"

--- a/src/components/common/MessageBox.vue
+++ b/src/components/common/MessageBox.vue
@@ -23,6 +23,7 @@ export default class MessageBox extends Vue {
 
 <style lang="scss" scoped>
 @import '@/assets/styles/theme.scss';
+
 .v-card {
   div {
     font-size: $px-14;

--- a/src/components/common/NameRequestInfo.vue
+++ b/src/components/common/NameRequestInfo.vue
@@ -277,11 +277,13 @@ export default class NameRequestInfo extends Mixins(CommonMixin, DateMixin) {
   @Getter(useStore) isAmalgamationFiling!: boolean
   @Getter(useStore) isTypeBcCcc!: boolean
   @Getter(useStore) isTypeBcUlcCompany!: boolean
-  @Getter(useStore) isTypeSoleProp: boolean
+  @Getter(useStore) isTypeCccContinueIn!: boolean
+  @Getter(useStore) isTypeSoleProp!: boolean
+  @Getter(useStore) isTypeUlcContinueIn!: boolean
 
   get numberedCompanySuffix (): string {
-    if (this.isTypeBcCcc) return 'B.C. COMMUNITY CONTRIBUTION COMPANY'
-    if (this.isTypeBcUlcCompany) return 'B.C. UNLIMITED LIABILITY COMPANY'
+    if (this.isTypeBcCcc || this.isTypeCccContinueIn) return 'B.C. COMMUNITY CONTRIBUTION COMPANY LTD.'
+    if (this.isTypeBcUlcCompany || this.isTypeUlcContinueIn) return 'B.C. UNLIMITED LIABILITY COMPANY'
     return 'B.C. LTD.'
   }
 

--- a/src/components/common/SummaryDefineCompany.vue
+++ b/src/components/common/SummaryDefineCompany.vue
@@ -245,7 +245,9 @@ export default class SummaryDefineCompany extends Vue {
   @Getter(useStore) isPremiumAccount!: boolean
   @Getter(useStore) isTypeBcCcc!: boolean
   @Getter(useStore) isTypeBcUlcCompany!: boolean
+  @Getter(useStore) isTypeCccContinueIn!: boolean
   @Getter(useStore) isTypeCoop!: boolean
+  @Getter(useStore) isTypeUlcContinueIn!: boolean
 
   /** Whether this section is invalid. */
   get invalidSection (): boolean {
@@ -268,10 +270,13 @@ export default class SummaryDefineCompany extends Vue {
     if (this.getNameRequestApprovedName) return this.getNameRequestApprovedName
 
     // otherwise name will be created from new incorporation number
-    const prefix = '[Incorporation Number]'
-    if (this.isTypeBcCcc) return `${prefix} B.C. COMMUNITY CONTRIBUTION COMPANY`
-    if (this.isTypeBcUlcCompany) return `${prefix} B.C. UNLIMITED LIABILITY COMPANY`
-    return `${prefix} B.C. LTD.`
+    if (this.isTypeBcCcc || this.isTypeCccContinueIn) {
+      return '[Incorporation Number] B.C. COMMUNITY CONTRIBUTION COMPANY LTD.'
+    }
+    if (this.isTypeBcUlcCompany || this.isTypeUlcContinueIn) {
+      return '[Incorporation Number] B.C. UNLIMITED LIABILITY COMPANY'
+    }
+    return '[Incorporation Number] B.C. LTD.'
   }
 
   /** The entity description. */

--- a/tests/unit/NameRequestInfo.spec.ts
+++ b/tests/unit/NameRequestInfo.spec.ts
@@ -265,9 +265,7 @@ describe('Name Request Info component without a NR', () => {
   let wrapper: any
 
   beforeEach(() => {
-    // Entity type will always be set with or without an NR
-    store.stateModel.entityType = CorpTypeCd.BENEFIT_COMPANY
-    // Temp Id will always be set with or without an NR
+    store.stateModel.entityType = CorpTypeCd.BC_COMPANY
     store.stateModel.tempId = 'T1234567'
     store.stateModel.nameRequest.nrNum = null
     store.stateModel.nameRequestApprovedName = null
@@ -286,16 +284,65 @@ describe('Name Request Info component without a NR', () => {
     expect(wrapper.vm.$el.querySelector('.numbered-company-list-items')).toBeDefined()
   })
 
-  it('renders the numbered company content', () => {
+  it('renders the numbered company content - BC Company', () => {
     const listItems = wrapper.vm.$el.querySelectorAll('.numbered-company-list-items li')
     expect(listItems.length).toEqual(5)
-
     expect(listItems[0].textContent).toContain('[Incorporation Number] B.C. LTD.')
-    expect(listItems[1].textContent).toContain('Entity Type: BC Benefit Company')
+    expect(listItems[1].textContent).toContain('Entity Type: BC Limited Company')
     expect(listItems[2].textContent).toContain(
       'The company is to be incorporated with a name created by adding "B.C. LTD." after the incorporation number.')
     expect(listItems[3].textContent).toContain(
       'Your Incorporation Number will be generated at the end of the filing transaction.')
     expect(listItems[4].textContent).toContain('It is not possible to request a specific Incorporation Number.')
+  })
+
+  it('renders the numbered company content - continued in BC', async () => {
+    store.setEntityType(CorpTypeCd.CONTINUE_IN)
+    await Vue.nextTick()
+
+    const listItems = wrapper.vm.$el.querySelectorAll('.numbered-company-list-items li')
+    expect(listItems.length).toEqual(5)
+    expect(listItems[0].textContent).toContain('[Incorporation Number] B.C. LTD.')
+    expect(listItems[1].textContent).toContain('Entity Type: BC Limited Company')
+  })
+
+  it('renders the numbered company content - Community Contribution Company', async () => {
+    store.setEntityType(CorpTypeCd.BC_CCC)
+    await Vue.nextTick()
+
+    const listItems = wrapper.vm.$el.querySelectorAll('.numbered-company-list-items li')
+    expect(listItems.length).toEqual(5)
+    expect(listItems[0].textContent).toContain('[Incorporation Number] B.C. COMMUNITY CONTRIBUTION COMPANY LTD.')
+    expect(listItems[1].textContent).toContain('Entity Type: BC Community Contribution Company')
+  })
+
+  it('renders the numbered company content - continued in CCC', async () => {
+    store.setEntityType(CorpTypeCd.CCC_CONTINUE_IN)
+    await Vue.nextTick()
+
+    const listItems = wrapper.vm.$el.querySelectorAll('.numbered-company-list-items li')
+    expect(listItems.length).toEqual(5)
+    expect(listItems[0].textContent).toContain('[Incorporation Number] B.C. COMMUNITY CONTRIBUTION COMPANY LTD.')
+    expect(listItems[1].textContent).toContain('Entity Type: BC Community Contribution Company')
+  })
+
+  it('renders the numbered company content - Unlimited Liability Company', async () => {
+    store.setEntityType(CorpTypeCd.BC_ULC_COMPANY)
+    await Vue.nextTick()
+
+    const listItems = wrapper.vm.$el.querySelectorAll('.numbered-company-list-items li')
+    expect(listItems.length).toEqual(5)
+    expect(listItems[0].textContent).toContain('[Incorporation Number] B.C. UNLIMITED LIABILITY COMPANY')
+    expect(listItems[1].textContent).toContain('Entity Type: BC Unlimited Liability Company')
+  })
+
+  it('renders the numbered company content - continued in ULC', async () => {
+    store.setEntityType(CorpTypeCd.ULC_CONTINUE_IN)
+    await Vue.nextTick()
+
+    const listItems = wrapper.vm.$el.querySelectorAll('.numbered-company-list-items li')
+    expect(listItems.length).toEqual(5)
+    expect(listItems[0].textContent).toContain('[Incorporation Number] B.C. UNLIMITED LIABILITY COMPANY')
+    expect(listItems[1].textContent).toContain('Entity Type: BC Unlimited Liability Company')
   })
 })


### PR DESCRIPTION
*Issue #:* bcgov/entity#21894

*Description of changes:*
- app version = 5.11.3
- imported latest correct-name shared component
- added CCC and CUL to numbered company suffix logic (2 places)
- added "LTD." to CCC numbered name (2 places)
- pass entity type to CorrectName so it can correctly show numbered name
- updated/added unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).