### PR TITLE
Fix-19483-Amalg/ContIn-Singular-Grammar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.11.6",
+  "version": "5.11.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.11.6",
+      "version": "5.11.7",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.11.6",
+  "version": "5.11.7",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/views/Amalgamation/BusinessInfo.vue
+++ b/src/views/Amalgamation/BusinessInfo.vue
@@ -10,7 +10,7 @@
 
         <p v-if="isAmalgamationFilingRegular">
           Enter the Registered Office and Records Office Mailing and Delivery Addresses of the resulting
-          businesses. All addresses must be located in B.C.
+          business. All addresses must be located in B.C.
         </p>
 
         <p v-if="isAmalgamationFilingHorizontal || isAmalgamationFilingVertical">

--- a/src/views/ContinuationIn/ContinuationInBusinessBc.vue
+++ b/src/views/ContinuationIn/ContinuationInBusinessBc.vue
@@ -28,7 +28,7 @@
         </h2>
         <p>
           Enter the Registered Office and Records Office Mailing and Delivery Addresses of the resulting
-          businesses. All addresses must be located in B.C.
+          business. All addresses must be located in B.C.
         </p>
       </header>
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19483

*Description of changes:*
- Changed the word "businesses" from Plural to Singular, now:  "... Office Mailing and Delivery Addresses of the resulting **business**..." for Amalg and ContIn

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
