### PR TITLE
22845 -  Update Confirm Page Delivery Email

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.11.15",
+  "version": "5.11.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.11.15",
+      "version": "5.11.16",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.11.15",
+  "version": "5.11.16",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/views/Amalgamation/ReviewConfirm.vue
+++ b/src/views/Amalgamation/ReviewConfirm.vue
@@ -384,7 +384,8 @@ export default class AmalgamationReviewConfirm extends Vue {
     return (this.getValidateSteps && !this.getDocumentDelivery.valid)
   }
 
-  /** Get the Document Delievery email when a staff files.
+  /**
+   * Get the Document Delivery email when a staff files.
    * Default: staff email; editable.
    */
   get documentOptionalEmail (): string {

--- a/src/views/Amalgamation/ReviewConfirm.vue
+++ b/src/views/Amalgamation/ReviewConfirm.vue
@@ -117,9 +117,15 @@
       >
         <DocumentDelivery
           class="py-8 px-6"
+          :class="{ 'invalid-section': isDocumentDeliveryInvalid }"
+          :editableCompletingParty="isRoleStaff"
+          :invalidSection="isDocumentDeliveryInvalid"
           :contactValue="getBusinessContact.email"
           :completingPartyEmail="getUserEmail"
+          :documentOptionalEmail="documentOptionalEmail"
           contactLabel="Registered Office"
+          @update:optionalEmail="setDocumentOptionalEmail($event)"
+          @valid="setDocumentOptionalEmailValidity($event)"
         />
       </v-card>
     </section>
@@ -263,7 +269,7 @@ import { Component, Vue } from 'vue-property-decorator'
 import { Action, Getter } from 'pinia-class'
 import { useStore } from '@/store/store'
 import { ContactPointIF, CertifyIF, EffectiveDateTimeIF, ShareStructureIF,
-  CourtOrderStepIF } from '@/interfaces'
+  CourtOrderStepIF, DocumentDeliveryIF } from '@/interfaces'
 import CardHeader from '@/components/common/CardHeader.vue'
 import Certify from '@/components/common/Certify.vue'
 import { CourtOrderPoa } from '@bcrs-shared-components/court-order-poa'
@@ -301,6 +307,7 @@ export default class AmalgamationReviewConfirm extends Vue {
   @Getter(useStore) getCertifyState!: CertifyIF
   @Getter(useStore) getCourtOrderStep!: CourtOrderStepIF
   @Getter(useStore) getCreateShareStructureStep!: ShareStructureIF
+  @Getter(useStore) getDocumentDelivery!: DocumentDeliveryIF
   @Getter(useStore) getEffectiveDateTime!: EffectiveDateTimeIF
   @Getter(useStore) getEntityType!: CorpTypeCd
   @Getter(useStore) getFolioNumber!: string
@@ -316,6 +323,8 @@ export default class AmalgamationReviewConfirm extends Vue {
   @Action(useStore) setCertifyState!: (x: CertifyIF) => void
   @Action(useStore) setCourtOrderFileNumber!: (x: string) => void
   @Action(useStore) setCourtOrderValidity!: (x: boolean) => void
+  @Action(useStore) setDocumentOptionalEmail!: (x: string) => void
+  @Action(useStore) setDocumentOptionalEmailValidity!: (x: boolean) => void
   @Action(useStore) setEffectiveDate!: (x: Date) => void
   @Action(useStore) setEffectiveDateTimeValid!: (x: boolean) => void
   @Action(useStore) setFolioNumber!: (x: string) => void
@@ -368,6 +377,18 @@ export default class AmalgamationReviewConfirm extends Vue {
   /** Is true when the amalgamation statement is not valid */
   get isAmalgamationStatementInvalid (): boolean {
     return (this.getValidateSteps && !this.getAmalgamationCourtApprovalValid)
+  }
+
+  /** Is true when the Document Delivery conditions are not met. */
+  get isDocumentDeliveryInvalid (): boolean {
+    return (this.getValidateSteps && !this.getDocumentDelivery.valid)
+  }
+
+  /** Get the Document Delievery email when a staff files.
+   * Default: staff email; editable.
+   */
+  get documentOptionalEmail (): string {
+    return this.getDocumentDelivery.documentOptionalEmail || this.getUserEmail
   }
 }
 </script>

--- a/src/views/ContinuationIn/ContinuationInReviewConfirm.vue
+++ b/src/views/ContinuationIn/ContinuationInReviewConfirm.vue
@@ -130,9 +130,15 @@
       >
         <DocumentDelivery
           class="py-8 px-6"
+          :class="{ 'invalid-section': isDocumentDeliveryInvalid }"
+          :editableCompletingParty="isRoleStaff"
+          :invalidSection="isDocumentDeliveryInvalid"
           :contactValue="getBusinessContact.email"
           :completingPartyEmail="getUserEmail"
+          :documentOptionalEmail="documentOptionalEmail"
           contactLabel="Registered Office"
+          @update:optionalEmail="setDocumentOptionalEmail($event)"
+          @valid="setDocumentOptionalEmailValidity($event)"
         />
       </v-card>
     </section>
@@ -222,7 +228,8 @@ import { Component, Vue } from 'vue-property-decorator'
 import { Action, Getter } from 'pinia-class'
 import { useStore } from '@/store/store'
 import { FilingStatus } from '@/enums'
-import { ContactPointIF, CertifyIF, EffectiveDateTimeIF, ShareStructureIF, CourtOrderStepIF } from '@/interfaces'
+import { ContactPointIF, CertifyIF, EffectiveDateTimeIF, ShareStructureIF,
+  CourtOrderStepIF, DocumentDeliveryIF } from '@/interfaces'
 import CardHeader from '@/components/common/CardHeader.vue'
 import Certify from '@/components/common/Certify.vue'
 import { DocumentDelivery } from '@bcrs-shared-components/document-delivery'
@@ -257,6 +264,7 @@ export default class ContinuationInReviewConfirm extends Vue {
   @Getter(useStore) getCertifyState!: CertifyIF
   @Getter(useStore) getCourtOrderStep!: CourtOrderStepIF
   @Getter(useStore) getCreateShareStructureStep!: ShareStructureIF
+  @Getter(useStore) getDocumentDelivery!: DocumentDeliveryIF
   @Getter(useStore) getEffectiveDateTime!: EffectiveDateTimeIF
   @Getter(useStore) getEntityType!: CorpTypeCd
   @Getter(useStore) getFilingStatus!: FilingStatus
@@ -267,6 +275,8 @@ export default class ContinuationInReviewConfirm extends Vue {
   @Action(useStore) setCertifyState!: (x: CertifyIF) => void
   @Action(useStore) setCourtOrderFileNumber!: (x: string) => void
   @Action(useStore) setCourtOrderValidity!: (x: boolean) => void
+  @Action(useStore) setDocumentOptionalEmail!: (x: string) => void
+  @Action(useStore) setDocumentOptionalEmailValidity!: (x: boolean) => void
   @Action(useStore) setEffectiveDate!: (x: Date) => void
   @Action(useStore) setEffectiveDateTimeValid!: (x: boolean) => void
   @Action(useStore) setHasPlanOfArrangement!: (x: boolean) => void
@@ -301,6 +311,18 @@ export default class ContinuationInReviewConfirm extends Vue {
   /** Is true when the Court Order conditions are not met. */
   get isCourtOrderInvalid (): boolean {
     return (this.getValidateSteps && !this.getCourtOrderStep.valid)
+  }
+
+  /** Is true when the Document Delivery conditions are not met. */
+  get isDocumentDeliveryInvalid (): boolean {
+    return (this.getValidateSteps && !this.getDocumentDelivery.valid)
+  }
+
+  /** Get the Document Delievery email when a staff files.
+   * Default: staff email; editable.
+   */
+  get documentOptionalEmail (): string {
+    return this.getDocumentDelivery.documentOptionalEmail || this.getUserEmail
   }
 }
 </script>

--- a/src/views/ContinuationIn/ContinuationInReviewConfirm.vue
+++ b/src/views/ContinuationIn/ContinuationInReviewConfirm.vue
@@ -318,7 +318,8 @@ export default class ContinuationInReviewConfirm extends Vue {
     return (this.getValidateSteps && !this.getDocumentDelivery.valid)
   }
 
-  /** Get the Document Delievery email when a staff files.
+  /**
+   * Get the Document Delivery email when a staff files.
    * Default: staff email; editable.
    */
   get documentOptionalEmail (): string {

--- a/src/views/Dissolution/DissolutionReviewConfirm.vue
+++ b/src/views/Dissolution/DissolutionReviewConfirm.vue
@@ -251,7 +251,7 @@
           :contactValue="getBusinessContact.email"
           :custodianEmail="getDissolutionCustodianEmail"
           :completingPartyEmail="getUserEmail"
-          :documentOptionalEmail="getDocumentDelivery.documentOptionalEmail"
+          :documentOptionalEmail="documentOptionalEmail"
           contactLabel="Registered Office"
           @update:optionalEmail="setDocumentOptionalEmail($event)"
           @valid="setDocumentOptionalEmailValidity($event)"
@@ -496,6 +496,13 @@ export default class DissolutionReviewConfirm extends Mixins(DateMixin) {
   /** Is true when the certify conditions are not met. */
   get isCertifyInvalid (): boolean {
     return this.getValidateSteps && !(this.getCertifyState.certifiedBy && this.getCertifyState.valid)
+  }
+
+  /** Get the Document Delievery email when a staff files.
+   * Default: staff email; editable.
+   */
+  get documentOptionalEmail (): string {
+    return this.getDocumentDelivery.documentOptionalEmail || this.getUserEmail
   }
 }
 </script>

--- a/src/views/Dissolution/DissolutionReviewConfirm.vue
+++ b/src/views/Dissolution/DissolutionReviewConfirm.vue
@@ -498,7 +498,8 @@ export default class DissolutionReviewConfirm extends Mixins(DateMixin) {
     return this.getValidateSteps && !(this.getCertifyState.certifiedBy && this.getCertifyState.valid)
   }
 
-  /** Get the Document Delievery email when a staff files.
+  /**
+   * Get the Document Delivery email when a staff files.
    * Default: staff email; editable.
    */
   get documentOptionalEmail (): string {

--- a/src/views/DissolutionFirm/DissolutionFirm.vue
+++ b/src/views/DissolutionFirm/DissolutionFirm.vue
@@ -125,7 +125,7 @@
           :contactValue="getBusinessContact.email"
           :custodianEmail="getDissolutionCustodianEmail"
           :completingPartyEmail="getUserEmail"
-          :documentOptionalEmail="getDocumentDelivery.documentOptionalEmail"
+          :documentOptionalEmail="documentOptionalEmail"
           :additionalLabel="additionalLabel"
           :additionalValue="additionalValue"
           contactLabel="Business Contact"
@@ -499,6 +499,13 @@ export default class DissolutionFirm extends Mixins(DateMixin) {
         `Dissolution Date must be after ${this.dateToPacificDate(this.startDateMin, true)} and up to
         ${this.dateToPacificDate(this.startDateMax, true)}`
     ]
+  }
+
+  /** Get the Document Delievery email when a staff files.
+   * Default: staff email; editable.
+   */
+  get documentOptionalEmail (): string {
+    return this.getDocumentDelivery.documentOptionalEmail || this.getUserEmail
   }
 
   /** The entity description.  */

--- a/src/views/DissolutionFirm/DissolutionFirm.vue
+++ b/src/views/DissolutionFirm/DissolutionFirm.vue
@@ -501,7 +501,8 @@ export default class DissolutionFirm extends Mixins(DateMixin) {
     ]
   }
 
-  /** Get the Document Delievery email when a staff files.
+  /**
+   * Get the Document Delivery email when a staff files.
    * Default: staff email; editable.
    */
   get documentOptionalEmail (): string {

--- a/src/views/Incorporation/IncorporationReviewConfirm.vue
+++ b/src/views/Incorporation/IncorporationReviewConfirm.vue
@@ -328,7 +328,8 @@ export default class IncorporationReviewConfirm extends Vue {
     return (this.getValidateSteps && !this.getDocumentDelivery.valid)
   }
 
-  /** Get the Document Delievery email when a staff files.
+  /**
+   * Get the Document Delivery email when a staff files.
    * Default: staff email; editable.
    */
   get documentOptionalEmail (): string {

--- a/src/views/Incorporation/IncorporationReviewConfirm.vue
+++ b/src/views/Incorporation/IncorporationReviewConfirm.vue
@@ -148,9 +148,15 @@
       >
         <DocumentDelivery
           class="py-8 px-6"
+          :class="{ 'invalid-section': isDocumentDeliveryInvalid }"
+          :editableCompletingParty="isRoleStaff"
+          :invalidSection="isDocumentDeliveryInvalid"
           :contactValue="getBusinessContact.email"
           :completingPartyEmail="getUserEmail"
+          :documentOptionalEmail="documentOptionalEmail"
           contactLabel="Registered Office"
+          @update:optionalEmail="setDocumentOptionalEmail($event)"
+          @valid="setDocumentOptionalEmailValidity($event)"
         />
       </v-card>
     </section>
@@ -240,7 +246,7 @@ import { Component, Vue } from 'vue-property-decorator'
 import { Action, Getter } from 'pinia-class'
 import { useStore } from '@/store/store'
 import { ContactPointIF, CertifyIF, EffectiveDateTimeIF, IncorporationAgreementIF,
-  ShareStructureIF, CourtOrderStepIF } from '@/interfaces'
+  ShareStructureIF, CourtOrderStepIF, DocumentDeliveryIF } from '@/interfaces'
 import AgreementType from '@/components/common/AgreementType.vue'
 import CardHeader from '@/components/common/CardHeader.vue'
 import Certify from '@/components/common/Certify.vue'
@@ -277,6 +283,7 @@ export default class IncorporationReviewConfirm extends Vue {
   @Getter(useStore) getCompanyDisplayName!: string
   @Getter(useStore) getCourtOrderStep!: CourtOrderStepIF
   @Getter(useStore) getCreateShareStructureStep!: ShareStructureIF
+  @Getter(useStore) getDocumentDelivery!: DocumentDeliveryIF
   @Getter(useStore) getEffectiveDateTime!: EffectiveDateTimeIF
   @Getter(useStore) getEntityType!: CorpTypeCd
   @Getter(useStore) getIncorporationAgreementStep!: IncorporationAgreementIF
@@ -289,6 +296,8 @@ export default class IncorporationReviewConfirm extends Vue {
   @Action(useStore) setCertifyState!: (x: CertifyIF) => void
   @Action(useStore) setCourtOrderFileNumber!: (x: string) => void
   @Action(useStore) setCourtOrderValidity!: (x: boolean) => void
+  @Action(useStore) setDocumentOptionalEmail!: (x: string) => void
+  @Action(useStore) setDocumentOptionalEmailValidity!: (x: boolean) => void
   @Action(useStore) setEffectiveDate!: (x: Date) => void
   @Action(useStore) setEffectiveDateTimeValid!: (x: boolean) => void
   @Action(useStore) setHasPlanOfArrangement!: (x: boolean) => void
@@ -312,6 +321,18 @@ export default class IncorporationReviewConfirm extends Vue {
   /** Is true when the Court Order conditions are not met. */
   get isCourtOrderInvalid (): boolean {
     return (this.getValidateSteps && !this.getCourtOrderStep.valid)
+  }
+
+  /** Is true when the Document Delivery conditions are not met. */
+  get isDocumentDeliveryInvalid (): boolean {
+    return (this.getValidateSteps && !this.getDocumentDelivery.valid)
+  }
+
+  /** Get the Document Delievery email when a staff files.
+   * Default: staff email; editable.
+   */
+  get documentOptionalEmail (): string {
+    return this.getDocumentDelivery.documentOptionalEmail || this.getUserEmail
   }
 }
 </script>

--- a/src/views/Registration/RegistrationReviewConfirm.vue
+++ b/src/views/Registration/RegistrationReviewConfirm.vue
@@ -63,6 +63,7 @@
           :contactValue="getBusinessContact.email"
           :editableCompletingParty="isRoleStaff || isSbcStaff"
           :completingPartyEmail="getUserEmail"
+          :documentOptionalEmail="documentOptionalEmail"
           :additionalLabel="documentDeliveryAdditionalLabel"
           :additionalValue="documentDeliveryAdditionalValue"
           :invalidSection="isDocumentDeliveryInvalid"
@@ -248,6 +249,13 @@ export default class RegistrationReviewConfirm extends Vue {
   /** Is true when the certify conditions are not met. */
   get isCertifyInvalid (): boolean {
     return this.getValidateSteps && !(this.getCertifyState.certifiedBy && this.getCertifyState.valid)
+  }
+
+  /** Get the Document Delievery email when a staff files.
+   * Default: staff email; editable.
+   */
+  get documentOptionalEmail (): string {
+    return this.getDocumentDelivery.documentOptionalEmail || this.getUserEmail
   }
 }
 </script>

--- a/src/views/Registration/RegistrationReviewConfirm.vue
+++ b/src/views/Registration/RegistrationReviewConfirm.vue
@@ -251,7 +251,8 @@ export default class RegistrationReviewConfirm extends Vue {
     return this.getValidateSteps && !(this.getCertifyState.certifiedBy && this.getCertifyState.valid)
   }
 
-  /** Get the Document Delievery email when a staff files.
+  /**
+   * Get the Document Delivery email when a staff files.
    * Default: staff email; editable.
    */
   get documentOptionalEmail (): string {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#22845

*Description of changes:*
- For the review & confirm page, updated the Documents Delivery Section:
  Made the Completing Party email address editable
  Keep prepopulating the default staff email address
- Only when it's a staff filing
- Updated for Amalgamation, Dissolution, Continuation, Incorporation, Registration. 
- Restoration seems not needed/ not updated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
