### PR TITLE
23554 - Fixed the Restoration Application Fee Summary Bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.12.1",
+  "version": "5.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.12.1",
+      "version": "5.12.2",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.12.1",
+  "version": "5.12.2",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1083,6 +1083,7 @@ export const useStore = defineStore('store', {
       switch (true) {
         case this.isFullRestorationFiling: return [this.resourceModel.filingData[0]]
         case this.isLimitedRestorationFiling: return [this.resourceModel.filingData[1]]
+        case (this.isRestorationFiling && !this.isFullRestorationFiling && !this.isLimitedRestorationFiling): return []
         case this.isAmalgamationFilingHorizontal: return [this.resourceModel.filingData[0]]
         case this.isAmalgamationFilingVertical: return [this.resourceModel.filingData[1]]
         default: return this.resourceModel.filingData

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -1041,7 +1041,7 @@ describe('Restoration - App page', () => {
                   foundingDate: '2021-10-07T20:37:41+00:00'
                 },
                 restoration: {
-                  type: 'fullRestoration'
+                  type: '' // initially set to null, to test the fee summary
                 },
                 header: {
                   affectedFilings: [],
@@ -1101,6 +1101,12 @@ describe('Restoration - App page', () => {
     expect(wrapper.findComponent(EntityInfo).exists()).toBe(true)
     expect(wrapper.findComponent(Stepper).exists()).toBe(true)
     expect(wrapper.findComponent(Actions).exists()).toBe(true)
+  })
+
+  it('displays the fee summary amount properly for restoration application', async () => {
+    const feeSummary = wrapper.findComponent(SbcFeeSummary)
+    // when restoration type is initially not chosen, the fee summary is called with empty []
+    expect(feeSummary.props('filingData')).toEqual([])
   })
 })
 


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23554

*Description of changes:*
- Fixed the Restoration Application page Fee Summary Bug, now showing $0 initially, until the user selects a restoration type

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
