### PR TITLE
23970 - Allow editable certify legal name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.14.1",
+  "version": "5.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.14.1",
+      "version": "5.14.2",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.14.1",
+  "version": "5.14.2",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/views/Amalgamation/ReviewConfirm.vue
+++ b/src/views/Amalgamation/ReviewConfirm.vue
@@ -237,7 +237,7 @@
         <Certify
           class="py-8 px-6"
           :class="{ 'invalid-section': isCertifyInvalid }"
-          :disableEdit="!isRoleStaff"
+          :disableEdit="false"
           :invalidSection="isCertifyInvalid"
           :isStaff="isRoleStaff"
         />

--- a/src/views/ContinuationIn/ContinuationInReviewConfirm.vue
+++ b/src/views/ContinuationIn/ContinuationInReviewConfirm.vue
@@ -161,7 +161,7 @@
         <Certify
           class="py-8 px-6"
           :class="{ 'invalid-section': isCertifyInvalid }"
-          :disableEdit="!isRoleStaff"
+          :disableEdit="false"
           :invalidSection="isCertifyInvalid"
           :isStaff="isRoleStaff"
         />

--- a/src/views/Dissolution/DissolutionReviewConfirm.vue
+++ b/src/views/Dissolution/DissolutionReviewConfirm.vue
@@ -309,7 +309,7 @@
         <Certify
           class="py-8 px-6"
           :class="{ 'invalid-section': isCertifyInvalid }"
-          :disableEdit="!isRoleStaff"
+          :disableEdit="false"
           :invalidSection="isCertifyInvalid"
           :isStaff="isRoleStaff"
         />

--- a/src/views/Restoration/RestorationReviewConfirm.vue
+++ b/src/views/Restoration/RestorationReviewConfirm.vue
@@ -101,7 +101,7 @@
         <Certify
           class="py-8 px-6"
           :class="{ 'invalid-section': isCertifyInvalid }"
-          :disableEdit="!isRoleStaff"
+          :disableEdit="false"
           :invalidSection="isCertifyInvalid"
           :isStaff="isRoleStaff"
         />


### PR DESCRIPTION
*Issue #:* /bcgov/entity#23970

*Description of changes:*

- Updated the Certify Legal Name editing condition on the Review/Confirm page to allow editing of the legal name for all users.

    - The following filing types have been modified:
       - Amalgamation
       - Continuation In
       - Dissolution
       - Restoration (while general users cannot access this page, we ensure that the Certify Legal Name is editable in all filings for safety measures.)

**Note**:
According to Mihai's feedback, firms and coops types are not considered in this bug fix.
  - The following filings remain unchanged:
     - Dissolution Firm
     - Registration
     - IA

**Result**:
Before:
<img width="1028" alt="image" src="https://github.com/user-attachments/assets/b44dbc55-a82d-4dc1-9285-964692eb62b1">

After:
<img width="1040" alt="image" src="https://github.com/user-attachments/assets/b6c3a3ea-c882-49ec-9b35-457f6e96e4ff">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
