### PR TITLE
24082 Fix Review and Certify Stepper Validation when Incorporation Fails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.14.0",
+  "version": "5.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.14.0",
+      "version": "5.14.1",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.14.0",
+  "version": "5.14.1",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/views/Incorporation/IncorporationReviewConfirm.vue
+++ b/src/views/Incorporation/IncorporationReviewConfirm.vue
@@ -307,7 +307,7 @@ export default class IncorporationReviewConfirm extends Vue {
    * In case submitting the incorporation failed, we want to reset the validity of Certify.
    * This is since the checkbox has to be ticked again after the save dialog has been closed.
    */
-   mounted (): void {
+  mounted (): void {
     this.setCertifyState({
       certifiedBy: this.getCertifyState.certifiedBy,
       valid: false

--- a/src/views/Incorporation/IncorporationReviewConfirm.vue
+++ b/src/views/Incorporation/IncorporationReviewConfirm.vue
@@ -303,6 +303,17 @@ export default class IncorporationReviewConfirm extends Vue {
   @Action(useStore) setHasPlanOfArrangement!: (x: boolean) => void
   @Action(useStore) setIsFutureEffective!: (x: boolean) => void
 
+  /**
+   * In case submitting the incorporation failed, we want to reset the validity of Certify.
+   * This is since the checkbox has to be ticked again after the save dialog has been closed.
+   */
+   mounted (): void {
+    this.setCertifyState({
+      certifiedBy: this.getCertifyState.certifiedBy,
+      valid: false
+    })
+  }
+
   /** The entity description,  */
   get getEntityDescription (): string {
     return GetCorpFullDescription(this.getEntityType)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#24082

*Description of changes:*
- Add reset for CertifyState validity in case Incorporation Application fails when filed (same logic used in Amalgamation and Continuation In)
- Update patch version


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
