### PR TITLE
26104 - Display NR name when restoration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.14.7",
+  "version": "5.14.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.14.7",
+      "version": "5.14.8",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.14.7",
+  "version": "5.14.8",
   "private": true,
   "appName": "Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Restoration/BusinessName.vue
+++ b/src/components/Restoration/BusinessName.vue
@@ -91,7 +91,6 @@ import { NameRequestErrorDialog } from '@/dialogs/'
 export default class BusinessName extends Mixins(CommonMixin, DateMixin, NameRequestMixin) {
   // Global getters
   @Getter(useStore) getBusinessId!: string
-  @Getter(useStore) getBusinessLegalName!: string
   @Getter(useStore) getCorrectNameOption!: CorrectNameOptions
   @Getter(useStore) getEntityType!: CorpTypeCd
   @Getter(useStore) getNameRequest!: NameRequestIF
@@ -112,7 +111,7 @@ export default class BusinessName extends Mixins(CommonMixin, DateMixin, NameReq
 
   /** The company name. */
   get companyName (): string {
-    return (this.getNameRequestApprovedName || this.getBusinessLegalName)
+    return (this.getNameRequestApprovedName)
   }
 
   /** This section's validity state (when prompted by app). */

--- a/src/components/common/EntityInfo.vue
+++ b/src/components/common/EntityInfo.vue
@@ -142,7 +142,7 @@ export default class EntityInfo extends Mixins(DateMixin) {
       case FilingTypes.REGISTRATION:
         return (this.getNameRequestApprovedName || numberedDescription)
       case FilingTypes.RESTORATION:
-        return (this.getNameRequestApprovedName || this.getBusinessLegalName || numberedDescription)
+        return (this.getNameRequestApprovedName || numberedDescription)
     }
     return '' // should never happen
   }

--- a/src/components/common/EntityInfo.vue
+++ b/src/components/common/EntityInfo.vue
@@ -142,7 +142,7 @@ export default class EntityInfo extends Mixins(DateMixin) {
       case FilingTypes.REGISTRATION:
         return (this.getNameRequestApprovedName || numberedDescription)
       case FilingTypes.RESTORATION:
-        return (this.getBusinessLegalName || numberedDescription)
+        return (this.getNameRequestApprovedName || this.getBusinessLegalName || numberedDescription)
     }
     return '' // should never happen
   }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26104

*Description of changes:*
- The Bug is: When file a restoration, input a name request, the entity info doesn't show the NR name
- Fixed the bug for all company type restoration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
