### PR TITLE
26471 Exclude App-Name from reg search API calls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ VUE_APP_STATUS_API_URL="https://status-api-dev.apps.gold.devops.gov.bc.ca"
 VUE_APP_STATUS_API_VERSION="/api/v1"
 VUE_APP_PAY_API_URL="https://pay-api-dev.apps.silver.devops.gov.bc.ca"
 VUE_APP_PAY_API_VERSION="/api/v1"
-VUE_APP_REGISTRIES_SEARCH_API_URL="https://bcregistry-dev.apigee.net/registry-search"
+VUE_APP_REGISTRIES_SEARCH_API_URL="https://test.api.connect.gov.bc.ca/registry-search-dev"
 VUE_APP_REGISTRIES_SEARCH_API_VERSION="/api/v1"
 VUE_APP_REGISTRIES_SEARCH_API_KEY=
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.14.15",
+  "version": "5.14.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.14.15",
+      "version": "5.14.16",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.14.15",
+  "version": "5.14.16",
   "private": true,
   "appName": "Business Create UI",
   "sbcName": "SBC Common Components",

--- a/src/services/business-lookup-services.ts
+++ b/src/services/business-lookup-services.ts
@@ -1,7 +1,8 @@
+import axios from 'axios'
 import { BusinessLookupResultIF } from '@/interfaces'
-import { AxiosInstance as axios } from '@/utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { useStore } from '@/store/store'
+import { SessionStorageKeys } from 'sbc-common-components/src/util/constants'
 
 setActivePinia(createPinia())
 const store = useStore()
@@ -31,14 +32,17 @@ export default class BusinessLookupServices {
     let url = this.searchApiUrl + 'businesses/search/facets?start=0&rows=20'
     url += `&categories=legalType:${legalTypes}${status ? '::status:' + status : ''}`
     url += `&query=value:${encodeURIComponent(query)}`
+    const kcToken = sessionStorage.getItem(SessionStorageKeys.KeyCloakToken)
 
     const config = {
       headers: {
+        Authorization: `Bearer ${kcToken}`,
         'x-apikey': this.searchApiKey,
         'Account-Id': store.getAccountId
       }
     }
 
+    // NOTE: this service uses a separate Axios instance from the rest of the app
     return axios.get(url, config).then(response => {
       const results: Array<BusinessLookupResultIF> = response?.data?.searchResults?.results
       if (!results) {

--- a/tests/unit/business-lookup-services.spec.ts
+++ b/tests/unit/business-lookup-services.spec.ts
@@ -1,5 +1,5 @@
+import axios from 'axios'
 import sinon from 'sinon'
-import { AxiosInstance as axios } from '@/utils'
 import BusinessLookupServices from '@/services/business-lookup-services'
 
 describe('Business Lookup Services', () => {


### PR DESCRIPTION
*Issue #:* bcgov/entity#26571

*Description of changes:*
- app version = 5.14.16
- updated reg search URL in example env file
- used separate Axios instance in business lookup services, with own headers that don't include App-Name

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).