### PR TITLE
26856 - Fix Styling for Share Class More Actions Drop Down Menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.14.18",
+  "version": "5.14.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.14.18",
+      "version": "5.14.19",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.14.18",
+  "version": "5.14.19",
   "private": true,
   "appName": "Business Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/ListShareClass.vue
+++ b/src/components/common/ListShareClass.vue
@@ -120,7 +120,9 @@
                         :disabled="!row.item.hasRightsOrRestrictions"
                         @click="emitAddSeries(row.index)"
                       >
-                        <v-list-item-subtitle><v-icon>mdi-playlist-plus</v-icon> Add Series</v-list-item-subtitle>
+                        <v-list-item-subtitle class="actions-item-subtitle">
+                          <v-icon>mdi-playlist-plus</v-icon> Add Series
+                        </v-list-item-subtitle>
                       </v-list-item>
                       <v-list-item
                         class="actions-dropdown_item"
@@ -128,7 +130,7 @@
                         :disabled="isMoveDisabled(row.index, 'up')"
                         @click="moveIndex(row.index, 'up')"
                       >
-                        <v-list-item-subtitle class="move-up-selector">
+                        <v-list-item-subtitle class="actions-item-subtitle">
                           <v-icon>mdi-arrow-up</v-icon> Move Up
                         </v-list-item-subtitle>
                       </v-list-item>
@@ -138,7 +140,7 @@
                         :disabled="isMoveDisabled(row.index, 'down')"
                         @click="moveIndex(row.index, 'down')"
                       >
-                        <v-list-item-subtitle class="move-down-selector">
+                        <v-list-item-subtitle class="actions-item-subtitle">
                           <v-icon>mdi-arrow-down</v-icon> Move Down
                         </v-list-item-subtitle>
                       </v-list-item>
@@ -146,7 +148,9 @@
                         class="actions-dropdown_item"
                         @click="emitRemoveClass(row.index)"
                       >
-                        <v-list-item-subtitle><v-icon>mdi-delete</v-icon> Remove</v-list-item-subtitle>
+                        <v-list-item-subtitle class="actions-item-subtitle">
+                          <v-icon>mdi-delete</v-icon> Remove
+                        </v-list-item-subtitle>
                       </v-list-item>
                     </v-list>
                   </v-menu>
@@ -210,7 +214,7 @@
                         :disabled="isMoveDisabled(row.index, 'up', index)"
                         @click="moveIndex(row.index, 'up', index)"
                       >
-                        <v-list-item-subtitle class="move-up-selector">
+                        <v-list-item-subtitle class="actions-item-subtitle">
                           <v-icon>mdi-arrow-up</v-icon> Move Up
                         </v-list-item-subtitle>
                       </v-list-item>
@@ -220,7 +224,7 @@
                         :disabled="isMoveDisabled(row.index, 'down', index)"
                         @click="moveIndex(row.index, 'down', index)"
                       >
-                        <v-list-item-subtitle class="move-down-selector">
+                        <v-list-item-subtitle class="actions-item-subtitle">
                           <v-icon>mdi-arrow-down</v-icon> Move Down
                         </v-list-item-subtitle>
                       </v-list-item>
@@ -228,7 +232,9 @@
                         class="actions-dropdown_item"
                         @click="emitRemoveSeries(row.index, index)"
                       >
-                        <v-list-item-subtitle><v-icon>mdi-delete</v-icon> Remove</v-list-item-subtitle>
+                        <v-list-item-subtitle class="actions-item-subtitle">
+                          <v-icon>mdi-delete</v-icon> Remove
+                        </v-list-item-subtitle>
                       </v-list-item>
                     </v-list>
                   </v-menu>
@@ -429,8 +435,13 @@ tbody {
   }
 
   .actions-dropdown_item {
-    min-height: 0!important;
+    min-height: 0 !important;
     margin: 1rem 0;
+
+    .v-icon,
+    .actions-item-subtitle {
+      color: $app-blue !important;
+    }
   }
 }
 

--- a/src/components/common/ListShareClass.vue
+++ b/src/components/common/ListShareClass.vue
@@ -130,7 +130,7 @@
                         :disabled="isMoveDisabled(row.index, 'up')"
                         @click="moveIndex(row.index, 'up')"
                       >
-                        <v-list-item-subtitle class="actions-item-subtitle">
+                        <v-list-item-subtitle class="actions-item-subtitle move-up-selector">
                           <v-icon>mdi-arrow-up</v-icon> Move Up
                         </v-list-item-subtitle>
                       </v-list-item>
@@ -140,7 +140,7 @@
                         :disabled="isMoveDisabled(row.index, 'down')"
                         @click="moveIndex(row.index, 'down')"
                       >
-                        <v-list-item-subtitle class="actions-item-subtitle">
+                        <v-list-item-subtitle class="actions-item-subtitle move-down-selector">
                           <v-icon>mdi-arrow-down</v-icon> Move Down
                         </v-list-item-subtitle>
                       </v-list-item>
@@ -214,7 +214,7 @@
                         :disabled="isMoveDisabled(row.index, 'up', index)"
                         @click="moveIndex(row.index, 'up', index)"
                       >
-                        <v-list-item-subtitle class="actions-item-subtitle">
+                        <v-list-item-subtitle class="actions-item-subtitle move-up-selector">
                           <v-icon>mdi-arrow-up</v-icon> Move Up
                         </v-list-item-subtitle>
                       </v-list-item>
@@ -224,7 +224,7 @@
                         :disabled="isMoveDisabled(row.index, 'down', index)"
                         @click="moveIndex(row.index, 'down', index)"
                       >
-                        <v-list-item-subtitle class="actions-item-subtitle">
+                        <v-list-item-subtitle class="actions-item-subtitle move-down-selector">
                           <v-icon>mdi-arrow-down</v-icon> Move Down
                         </v-list-item-subtitle>
                       </v-list-item>


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26856

*Description of changes:*
- Make the icons and text in the Share Class "more actions" drop down blue

![image](https://github.com/user-attachments/assets/01e24edd-5648-4341-ac35-1c06459c67fc)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
