### PR TITLE
28384 - Fix Empty Amalgamation Table for Drafts with Unaffiliated Businesses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.15.2",
+  "version": "5.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.15.2",
+      "version": "5.15.3",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.15.2",
+  "version": "5.15.3",
   "private": true,
   "appName": "Business Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Amalgamation/BusinessTable.vue
+++ b/src/components/Amalgamation/BusinessTable.vue
@@ -207,12 +207,9 @@ export default class BusinessTable extends Mixins(AmalgamationMixin) {
   }
 
   email (item: AmalgamatingBusinessIF): string | null {
-    if (item?.type !== AmlTypes.LEAR) {
-      return null // should never happen
-    }
-
-    const contact = item.authInfo?.contacts?.[0]
-    return contact?.email || 'Email not available'
+    return item?.type === AmlTypes.LEAR
+      ? item.authInfo?.contacts?.[0]?.email || 'Email not available'
+      : null // should never happen
   }
 
   type (item: AmalgamatingBusinessIF): string {

--- a/src/components/Amalgamation/BusinessTable.vue
+++ b/src/components/Amalgamation/BusinessTable.vue
@@ -206,10 +206,9 @@ export default class BusinessTable extends Mixins(AmalgamationMixin) {
     return '(Unknown)' // should never happen
   }
 
-  email (item: AmalgamatingBusinessIF): string | null {
-    return item?.type === AmlTypes.LEAR
-      ? item.authInfo?.contacts?.[0]?.email || 'Email not available'
-      : null // should never happen
+  email (item: AmalgamatingBusinessIF): string {
+    if (item?.type === AmlTypes.LEAR) return item.authInfo?.contacts?.[0]?.email || 'Email not available'
+    return null // should never happen
   }
 
   type (item: AmalgamatingBusinessIF): string {

--- a/src/components/Amalgamation/BusinessTable.vue
+++ b/src/components/Amalgamation/BusinessTable.vue
@@ -206,9 +206,13 @@ export default class BusinessTable extends Mixins(AmalgamationMixin) {
     return '(Unknown)' // should never happen
   }
 
-  email (item: AmalgamatingBusinessIF): string {
-    if (item?.type === AmlTypes.LEAR) return item.authInfo?.contacts[0]?.email
-    return null // should never happen
+  email (item: AmalgamatingBusinessIF): string | null {
+    if (item?.type !== AmlTypes.LEAR) {
+      return null // should never happen
+    }
+
+    const contact = item.authInfo?.contacts?.[0]
+    return contact?.email || 'Email not available'
   }
 
   type (item: AmalgamatingBusinessIF): string {

--- a/src/components/Amalgamation/BusinessTableSummary.vue
+++ b/src/components/Amalgamation/BusinessTableSummary.vue
@@ -78,10 +78,9 @@ export default class BusinessTableSummary extends Vue {
     return '(Unknown)' // should never happen
   }
 
-  email (item: AmalgamatingBusinessIF): string | null {
-    return item?.type === AmlTypes.LEAR
-      ? item.authInfo?.contacts?.[0]?.email || 'Email not available'
-      : null // should never happen
+  email (item: AmalgamatingBusinessIF): string {
+    if (item?.type === AmlTypes.LEAR) return item.authInfo?.contacts?.[0]?.email || 'Email not available'
+    return null // should never happen
   }
 
   registeredOfficeMailingAddress (item: AmalgamatingBusinessIF): AddressIF {

--- a/src/components/Amalgamation/BusinessTableSummary.vue
+++ b/src/components/Amalgamation/BusinessTableSummary.vue
@@ -79,12 +79,9 @@ export default class BusinessTableSummary extends Vue {
   }
 
   email (item: AmalgamatingBusinessIF): string | null {
-    if (item?.type !== AmlTypes.LEAR) {
-      return null // should never happen
-    }
-
-    const contact = item.authInfo?.contacts?.[0]
-    return contact?.email || 'Email not available'
+    return item?.type === AmlTypes.LEAR
+      ? item.authInfo?.contacts?.[0]?.email || 'Email not available'
+      : null // should never happen
   }
 
   registeredOfficeMailingAddress (item: AmalgamatingBusinessIF): AddressIF {

--- a/src/components/Amalgamation/BusinessTableSummary.vue
+++ b/src/components/Amalgamation/BusinessTableSummary.vue
@@ -78,9 +78,13 @@ export default class BusinessTableSummary extends Vue {
     return '(Unknown)' // should never happen
   }
 
-  email (item: AmalgamatingBusinessIF): string {
-    if (item?.type === AmlTypes.LEAR) return item.authInfo?.contacts[0]?.email
-    return null // should never happen
+  email (item: AmalgamatingBusinessIF): string | null {
+    if (item?.type !== AmlTypes.LEAR) {
+      return null // should never happen
+    }
+
+    const contact = item.authInfo?.contacts?.[0]
+    return contact?.email || 'Email not available'
   }
 
   registeredOfficeMailingAddress (item: AmalgamatingBusinessIF): AddressIF {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#28384 

*Description of changes:*
- Since we don't have access to the `contacts` for unaffiliated businesses, we will display the text "Email not available":

![image](https://github.com/user-attachments/assets/57a60f1b-607c-430c-be9b-61e9038c711d)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
