### PR TITLE
28833 Updated share par value validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.15.8",
+  "version": "5.15.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.15.8",
+      "version": "5.15.9",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.15.8",
+  "version": "5.15.9",
   "private": true,
   "appName": "Business Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/ShareStructure.vue
+++ b/src/components/common/ShareStructure.vue
@@ -46,6 +46,8 @@
                             filled
                             label="Maximum Number of Shares"
                             persistent-hint
+                            type="number"
+                            hide-spin-buttons
                             :hint="'Enter the maximum number of shares in the ' + shareStructure.type"
                             :rules="getMaximumShareRule()"
                             :disabled="hasNoMaximumShares"
@@ -86,6 +88,8 @@
                             :rules="getParValueRule()"
                             hint="Enter the initial value of each share"
                             persistent-hint
+                            type="number"
+                            hide-spin-buttons
                           />
                         </v-col>
                         <v-col cols="6">
@@ -292,8 +296,9 @@ export default class ShareStructure extends Mixins(CurrencyLookupMixin) {
         v => (v !== '' && v !== null && v !== undefined) || 'Par value is required',
         v => v > 0 || 'Amount must be greater than 0',
         v => (v < 1)
-          ? (/^(\d+(\.\d{0,3})?|\.\d{0,3})$/.test(v) || 'Amounts less than 1 can be entered with up to 3 decimal place')
-          : (/^\d+(\.\d{1,2})?$/.test(v) || 'Amounts greater than 1 can be entered with up to 2 decimal place')]
+          ? (/^\d+(\.\d{0,6})?$/.test(v) || 'Amounts less than 1 can be entered with up to 6 decimal place')
+          : (/^\d+(\.\d{1,2})?$/.test(v) || 'Amounts greater than 1 can be entered with up to 2 decimal place')
+      ]
     }
     return []
   }
@@ -316,6 +321,9 @@ export default class ShareStructure extends Mixins(CurrencyLookupMixin) {
         const name = this.shareStructure.name
         this.shareStructure.name = name.substr(0, name.indexOf(' Shares'))
       }
+
+      // validate initial data
+      this.$nextTick(() => this.$refs.shareStructureForm.validate())
     }
   }
 

--- a/tests/unit/ShareStructure.spec.ts
+++ b/tests/unit/ShareStructure.spec.ts
@@ -266,11 +266,11 @@ describe('Share Structure component', () => {
     const shareClass = createShareStructure(null, 1, 'Class', 'Class B', true, 100, true, 0.50, 'CAD', true)
     const wrapper: Wrapper<ShareStructure> = createComponent(shareClass, -1, '1', null, [existingShareClass])
     const inputElement: Wrapper<Vue> = wrapper.find(classParValue)
-    inputElement.setValue(0.1111)
+    inputElement.setValue(0.1234567) // invalid
     inputElement.trigger('change')
     await waitForUpdate()
     expect(wrapper.find(formSelector).text())
-      .toContain('Amounts less than 1 can be entered with up to 3 decimal place')
+      .toContain('Amounts less than 1 can be entered with up to 6 decimal place')
     expect(wrapper.vm.$data.formValid).toBe(false)
     wrapper.destroy()
   })
@@ -280,7 +280,7 @@ describe('Share Structure component', () => {
     const shareClass = createShareStructure(null, 1, 'Class', 'Class B', true, 100, true, 0.50, 'CAD', true)
     const wrapper: Wrapper<ShareStructure> = createComponent(shareClass, -1, '1', null, [existingShareClass])
     const inputElement: Wrapper<Vue> = wrapper.find(classParValue)
-    inputElement.setValue(1.234)
+    inputElement.setValue(1.234) // invalid
     inputElement.trigger('change')
     await waitForUpdate()
     expect(wrapper.find(formSelector).text())


### PR DESCRIPTION
*Issue #:* bcgov/entity#28833

*Description of changes:*
- app version = 5.15.9
- added type to Number of Shares component
- added type to Par Value component
- updated par value regex to support 6 decimal places
- added initial validation (to help identify invalid data)
- updated unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).