### PR TITLE
29124 Fetch addresses and make non-editable for restoration filing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.16.0",
+  "version": "5.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.16.0",
+      "version": "5.16.1",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.16.0",
+  "version": "5.16.1",
   "private": true,
   "appName": "Business Create UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -351,6 +351,7 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
   @Action(useStore) setUserLastName!: (x: string) => void
   @Action(useStore) setUserPhone!: (x: string) => void
   @Action(useStore) setHaveChanges!: (x: boolean) => void
+  // @Action(useStore) setOfficeAddresses!: (x: RegisteredRecordsAddressesIF) => void
   @Action(useStore) setOrgInformation!: (x: OrgInformationIF) => void
   @Action(useStore) setShowErrors!: (x: boolean) => void
   @Action(useStore) setTempId!: (x: string) => void
@@ -794,6 +795,11 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
         await this.loadPartiesInformation(this.getBusinessId)
       }
 
+      // load office addresses only for restorations
+      if (this.isRestorationFiling) {
+        await this.loadOfficeAddresses(this.getBusinessId)
+      }
+
       // special route checks for Continuation In filing
       if (this.isContinuationInFiling) {
         if (this.isAuthorizationStatus) {
@@ -1190,7 +1196,7 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
   }
 
   /** Gets account info and stores it. */
-  private async loadAccountInformation (): Promise<any> {
+  private async loadAccountInformation (): Promise<void> {
     const currentAccount = await getCurrentAccount()
     if (currentAccount) {
       const accountInfo: AccountInformationIF = {
@@ -1209,7 +1215,7 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
      * Gets current account from object in session storage.
      * Waits up to 5 sec for current account to be synced (typically by SbcHeader).
      */
-    async function getCurrentAccount (): Promise<any> {
+    async function getCurrentAccount (): Promise<AccountInformationIF> {
       let account = null
       for (let i = 0; i < 50; i++) {
         const currentAccount = sessionStorage.getItem(SessionStorageKeys.CurrentAccount)
@@ -1316,7 +1322,7 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
   }
 
   /** Fetches and stores parties info . */
-  private async loadPartiesInformation (businessId: string): Promise<any> {
+  private async loadPartiesInformation (businessId: string): Promise<void> {
     // NB: will throw if API error
     const parties = await LegalServices.fetchParties(businessId)
 
@@ -1324,6 +1330,17 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
       this.setParties(parties.parties)
     } else {
       throw new Error('Invalid parties')
+    }
+  }
+
+  private async loadOfficeAddresses (businessId: string): Promise<void> {
+    // NB: will throw if API error
+    const addresses = await LegalServices.fetchAddresses(businessId)
+
+    if (addresses) {
+      this.setOfficeAddresses(addresses)
+    } else {
+      throw new Error('Invalid office addresses')
     }
   }
 

--- a/src/components/common/OfficeAddresses.vue
+++ b/src/components/common/OfficeAddresses.vue
@@ -323,10 +323,9 @@
 import { Component, Emit, Mixins, Prop, Watch } from 'vue-property-decorator'
 import { Getter } from 'pinia-class'
 import { useStore } from '@/store/store'
-import { isEmpty } from 'lodash'
 import { OfficeAddressSchema } from '@/schemas'
 import { BaseAddress } from '@bcrs-shared-components/base-address'
-import { AddressIF, DefineCompanyIF, RegisteredRecordsAddressesIF } from '@/interfaces'
+import { AddressIF, DefineCompanyIF, EmptyAddress, RegisteredRecordsAddressesIF } from '@/interfaces'
 import { CommonMixin } from '@/mixins'
 
 @Component({
@@ -364,13 +363,8 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
   // Local properties
   protected addresses: RegisteredRecordsAddressesIF = this.inputAddresses
   readonly defaultAddress: AddressIF = {
-    addressCity: '',
-    addressCountry: 'CA',
-    addressRegion: 'BC',
-    deliveryInstructions: '',
-    postalCode: '',
-    streetAddress: '',
-    streetAddressAdditional: ''
+    ...EmptyAddress,
+    addressRegion: 'BC'
   }
 
   // The 4 addresses that are the current state of the BaseAddress components:
@@ -476,18 +470,6 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
       (this.recMailingAddressValid && (this.inheritRecMailingAddress || this.recDeliveryAddressValid))
 
     return registeredOfficeValid && recordsOfficeValid
-  }
-
-  /** Whether the address object is empty or with only with default input values */
-  isEmptyAddress (address: AddressIF): boolean {
-    return isEmpty(address) ||
-           (!address.addressCity &&
-           (!address.addressCountry || address.addressCountry === 'CA') &&
-           (!address.addressRegion || address.addressRegion === 'BC') &&
-           !address.deliveryInstructions &&
-           !address.postalCode &&
-           !address.streetAddress &&
-           !address.streetAddressAdditional)
   }
 
   /** Whether to show the delivery address by default. */
@@ -704,6 +686,11 @@ export default class OfficeAddresses extends Mixins(CommonMixin) {
 
 .summary-section-header {
   font-size: $px-14;
+  font-weight: bold;
+}
+
+#summary-registered-address label,
+#summary-records-address label {
   font-weight: bold;
 }
 </style>

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -90,6 +90,7 @@ export type {
 } from '@bcrs-shared-components/interfaces'
 
 export {
+  EmptyAddress,
   EmptyBusinessLookup,
   EmptyContactPoint,
   EmptyNaics,

--- a/src/interfaces/stepper-interfaces/DefineCompany/address-interfaces.ts
+++ b/src/interfaces/stepper-interfaces/DefineCompany/address-interfaces.ts
@@ -11,7 +11,9 @@ export interface OfficeAddressIF {
 /** Interface to define an incorporation address. */
 export interface RegisteredRecordsAddressesIF {
   registeredOffice: OfficeAddressIF
-  // Records Address is required for BCOMPs.
-  // Records Address may be optional for other app types.
+  // Records Office is required for BCOMPs.
+  // Records Office may be optional for other app types.
   recordsOffice?: OfficeAddressIF
+  // Custodial Office is present for restoration filings
+  custodialOffice?: OfficeAddressIF
 }

--- a/src/interfaces/store-interfaces/state-interfaces/account-information-interface.ts
+++ b/src/interfaces/store-interfaces/state-interfaces/account-information-interface.ts
@@ -5,6 +5,7 @@ export interface AccountInformationIF {
   label: string
   type: string
   // NB: there are other fields but we don't need them
+  [x: string | number | symbol]: unknown
 }
 
 export const EmptyAccountInformation: AccountInformationIF = {

--- a/src/mixins/common-mixin.ts
+++ b/src/mixins/common-mixin.ts
@@ -1,6 +1,6 @@
 import { Component, Vue } from 'vue-property-decorator'
-import { isEqual, omit } from 'lodash'
-import { ValidationItemDetailIF } from '@/interfaces'
+import { isEmpty, isEqual, omit } from 'lodash'
+import { AddressIF, ValidationItemDetailIF } from '@/interfaces'
 import { getName } from 'country-list'
 
 /**
@@ -129,5 +129,21 @@ export default class CommonMixin extends Vue {
     }
 
     return null
+  }
+
+  /**
+   * Whether the address object is empty or with only with default input values.
+   * See also EmptyAddress.
+   */
+  isEmptyAddress (address: AddressIF): boolean {
+    return isEmpty(address) || (
+      !address.addressCity &&
+      (!address.addressCountry || address.addressCountry === 'CA') &&
+      (!address.addressRegion || address.addressRegion === 'BC') &&
+      !address.deliveryInstructions &&
+      !address.postalCode &&
+      !address.streetAddress &&
+      !address.streetAddressAdditional
+    )
   }
 }

--- a/src/views/Restoration/RestorationBusinessInformation.vue
+++ b/src/views/Restoration/RestorationBusinessInformation.vue
@@ -7,20 +7,43 @@
     >
       <header id="office-address-header">
         <h2>Registered and Records Office Addresses</h2>
-        <p>
-          Enter the Registered Office and Records Office Mailing and Delivery Addresses. All addresses must be
-          located in B.C.
-        </p>
+
+        <template v-if="allowEditingOfficeAddresses">
+          <p>
+            Enter the Registered Office and Records Office Mailing and Delivery Addresses. All addresses must be
+            located in B.C.
+          </p>
+        </template>
+        <template v-else>
+          <p>
+            Here are the Registered Office and Records Office Mailing and Delivery Addresses from the time of
+            dissolution. If they need to be updated, an Address Change filing will need to be done.
+          </p>
+        </template>
       </header>
 
-      <div :class="{ 'invalid-section': getShowErrors && !addressFormValid }">
+      <div
+        v-if="allowEditingOfficeAddresses"
+        :class="{ 'invalid-section': getShowErrors && !addressFormValid }"
+      >
         <OfficeAddresses
           :showErrors="getShowErrors"
-          :inputAddresses="addresses"
+          :inputAddresses="officeAddresses"
           @update:addresses="setOfficeAddresses($event)"
           @valid="onAddressFormValidityChange($event)"
         />
       </div>
+
+      <v-card
+        v-else
+        flat
+        class="py-8 px-6"
+      >
+        <OfficeAddresses
+          :inputAddresses="officeAddresses"
+          :isEditing="false"
+        />
+      </v-card>
     </section>
 
     <!-- Registered Office Contact Information -->
@@ -57,7 +80,7 @@
 import { Component, Mixins, Watch } from 'vue-property-decorator'
 import { Getter, Action } from 'pinia-class'
 import { useStore } from '@/store/store'
-import { AddressIF, ContactPointIF, DefineCompanyIF, RegisteredRecordsAddressesIF }
+import { AddressIF, ContactPointIF, DefineCompanyIF, EmptyAddress, RegisteredRecordsAddressesIF }
   from '@/interfaces'
 import { CommonMixin } from '@/mixins'
 import { RouteNames } from '@/enums'
@@ -85,12 +108,13 @@ export default class RestorationBusinessInformation extends Mixins(CommonMixin) 
 
   // Local variables
   businessContactFormValid = false
-  addressFormValid = false
+  addressFormValid = true
+  allowEditingOfficeAddresses = false
 
   // Enum for template
   readonly CorpTypeCd = CorpTypeCd
 
-  get addresses (): RegisteredRecordsAddressesIF {
+  get officeAddresses (): RegisteredRecordsAddressesIF {
     return this.getDefineCompanyStep.officeAddresses
   }
 
@@ -99,8 +123,10 @@ export default class RestorationBusinessInformation extends Mixins(CommonMixin) 
     // temporarily ignore data changes
     this.setIgnoreChanges(true)
 
-    // if no addresses were fetched or are 'undefined', set default addresses
+    // if no addresses were fetched or are empty, set default addresses
     if (this.isEmptyRecordsAddress || this.isEmptyRegisteredAddress) {
+      this.allowEditingOfficeAddresses = true
+      this.addressFormValid = false
       this.setDefaultAddresses()
     }
 
@@ -111,31 +137,24 @@ export default class RestorationBusinessInformation extends Mixins(CommonMixin) 
   }
 
   get isEmptyRecordsAddress () : boolean {
-    if (!this.addresses.recordsOffice?.mailingAddress || !this.addresses.recordsOffice?.deliveryAddress) {
-      return true
-    } else {
-      return false
-    }
+    return (
+      this.isEmptyAddress(this.officeAddresses.recordsOffice?.mailingAddress) ||
+      this.isEmptyAddress(this.officeAddresses.recordsOffice?.deliveryAddress)
+    )
   }
 
   get isEmptyRegisteredAddress () : boolean {
-    if (!this.addresses.registeredOffice?.mailingAddress || !this.addresses.registeredOffice?.deliveryAddress) {
-      return true
-    } else {
-      return false
-    }
+    return (
+      this.isEmptyAddress(this.officeAddresses.registeredOffice?.mailingAddress) ||
+      this.isEmptyAddress(this.officeAddresses.registeredOffice?.deliveryAddress)
+    )
   }
 
   /** Sets default addresses in filing. (Will get overwritten by a fetched draft filing if there is one.) */
   private setDefaultAddresses (): void {
     const defaultAddress: AddressIF = {
-      addressCity: '',
-      addressCountry: 'CA',
-      addressRegion: 'BC',
-      deliveryInstructions: '',
-      postalCode: '',
-      streetAddress: '',
-      streetAddressAdditional: ''
+      ...EmptyAddress,
+      addressRegion: 'BC'
     }
 
     if (this.isBaseCompany) {

--- a/src/views/Restoration/RestorationBusinessInformation.vue
+++ b/src/views/Restoration/RestorationBusinessInformation.vue
@@ -16,8 +16,8 @@
         </template>
         <template v-else>
           <p>
-            Here are the Registered Office and Records Office Mailing and Delivery Addresses from the time of
-            dissolution. If they need to be updated, an Address Change filing will need to be done.
+            The Registered and Records Office are shown with the addresses at the time of dissolution. If these are
+            no longer correct, you will need to file an Address Change once the Restoration has been completed.
           </p>
         </template>
       </header>

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -24,7 +24,7 @@ import * as utils from '@/utils'
 import { PublicUserActions, BusinessRegistryStaffActions } from './test-data/AuthorizedActionsLists'
 import { setAuthRole } from '../set-auth-role'
 
-// mock fetch() as it is not defined in Jest
+// mock fetch() as it is not defined in Vitest
 // NB: it should be `global.fetch` but that doesn't work and this does
 window.fetch = vi.fn().mockImplementation(() => {
   return {
@@ -34,7 +34,7 @@ window.fetch = vi.fn().mockImplementation(() => {
   }
 })
 
-// mock alert() as it is not defined in Jest
+// mock alert() as it is not defined in Vitest
 window.alert = vi.fn()
 
 // mock the console.warn function to hide "[Vuetify] Unable to locate target XXX"
@@ -1054,6 +1054,46 @@ describe('Restoration - App page', () => {
         }
       })))
 
+    // GET addresses
+    get.withArgs('businesses/BC0870803/addresses')
+      .returns(new Promise(resolve => resolve({
+        data:
+        {
+          registeredOffice: {
+            deliveryAddress: {
+              streetAddress: 'delivery_address - address line one',
+              addressCity: 'delivery_address city',
+              addressCountry: 'delivery_address country',
+              postalCode: 'H0H0H0',
+              addressRegion: 'BC'
+            },
+            mailingAddress: {
+              streetAddress: 'mailing_address - address line one',
+              addressCity: 'mailing_address city',
+              addressCountry: 'mailing_address country',
+              postalCode: 'H0H0H0',
+              addressRegion: 'BC'
+            }
+          },
+          recordsOffice: {
+            deliveryAddress: {
+              streetAddress: 'delivery_address - address line one',
+              addressCity: 'delivery_address city',
+              addressCountry: 'delivery_address country',
+              postalCode: 'H0H0H0',
+              addressRegion: 'BC'
+            },
+            mailingAddress: {
+              streetAddress: 'mailing_address - address line one',
+              addressCity: 'mailing_address city',
+              addressCountry: 'mailing_address country',
+              postalCode: 'H0H0H0',
+              addressRegion: 'BC'
+            }
+          }
+        }
+      })))
+
     // GET permissions
     get.withArgs('permissions')
       .returns(new Promise(resolve => resolve({
@@ -1099,7 +1139,7 @@ describe('Restoration - App page', () => {
     expect(wrapper.findComponent(Actions).exists()).toBe(true)
   })
 
-  it('displays the fee summary amount properly for restoration application', async () => {
+  it('displays the fee summary amount properly for restoration application', () => {
     const feeSummary = wrapper.findComponent(SbcFeeSummary)
     // when restoration type is initially not chosen, the fee summary is called with empty []
     expect(feeSummary.props('filingData')).toEqual([])

--- a/tests/unit/FileUploadPreview.spec.ts
+++ b/tests/unit/FileUploadPreview.spec.ts
@@ -7,8 +7,8 @@ import { waitForUpdate } from '../wait-for-update'
 
 const vuetify = new Vuetify({})
 
-// Note: the following arrayBuffer code is needed as jest does not provide arrayBuffer
-//  and this is required to test the scenarios where the pdf.js library is used.
+// Note: the following arrayBuffer code is needed as Vitest does not provide arrayBuffer
+//       and this is required to test the scenarios where the pdf.js library is used.
 File.prototype.arrayBuffer = File.prototype.arrayBuffer || myArrayBuffer as any
 Blob.prototype.arrayBuffer = Blob.prototype.arrayBuffer || myArrayBuffer as any
 

--- a/tests/unit/RestorationBusinessInformation.spec.ts
+++ b/tests/unit/RestorationBusinessInformation.spec.ts
@@ -1,4 +1,4 @@
-import { shallowWrapperFactory } from '../vitest-wrapper-factory'
+import { wrapperFactory } from '../vitest-wrapper-factory'
 import { RestorationBusinessInformation } from '@/views'
 import { RestorationResources } from '@/resources/'
 import OfficeAddresses from '@/components/common/OfficeAddresses.vue'
@@ -45,8 +45,43 @@ for (const test of restorationBusinessInfo) {
     let wrapper: any
 
     beforeAll(() => {
+      store.getDefineCompanyStep.officeAddresses = {
+        registeredOffice: {
+          deliveryAddress: {
+            streetAddress: 'delivery_address - address line one',
+            addressCity: 'delivery_address city',
+            addressCountry: 'delivery_address country',
+            postalCode: 'H0H0H0',
+            addressRegion: 'BC'
+          },
+          mailingAddress: {
+            streetAddress: 'mailing_address - address line one',
+            addressCity: 'mailing_address city',
+            addressCountry: 'mailing_address country',
+            postalCode: 'H0H0H0',
+            addressRegion: 'BC'
+          }
+        },
+        recordsOffice: {
+          deliveryAddress: {
+            streetAddress: 'delivery_address - address line one',
+            addressCity: 'delivery_address city',
+            addressCountry: 'delivery_address country',
+            postalCode: 'H0H0H0',
+            addressRegion: 'BC'
+          },
+          mailingAddress: {
+            streetAddress: 'mailing_address - address line one',
+            addressCity: 'mailing_address city',
+            addressCountry: 'mailing_address country',
+            postalCode: 'H0H0H0',
+            addressRegion: 'BC'
+          }
+        }
+      }
       setAuthRole(store, AuthorizationRoles.STAFF)
-      wrapper = shallowWrapperFactory(
+
+      wrapper = wrapperFactory(
         RestorationBusinessInformation,
         null,
         { entityType: test.entityType },
@@ -67,6 +102,12 @@ for (const test of restorationBusinessInfo) {
       const section = wrapper.findAll('section').at(0)
       expect(section.find('header h2').text()).toBe('Registered and Records Office Addresses')
       expect(section.findComponent(OfficeAddresses).exists()).toBe(true)
+
+      // verify addresses are not editable
+      console.log('>>> section =', section.html())
+      expect(section.find('#summary-registered-address').exists()).toBe(true)
+      expect(section.find('#summary-records-address').exists()).toBe(true)
+      expect(section.find('.address-edit-header').exists()).toBe(false)
     })
 
     it('displays Registered Office Contact Information section', () => {


### PR DESCRIPTION
*Issue #:* bcgov/entity#29124

*Description of changes:*
- app version = 5.16.1
- load office addresses for restorations only
- used EmptyAddresses for some inits
- moved isEmptyAddress to common mixin
- set labels to bold
- added logic to show static vs editable addresses in restoration
- fixed/updated unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).