### PR TITLE
29124 allow editing for full resto + remove undesired custodial address

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.16.1",
+  "version": "5.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.16.1",
+      "version": "5.16.2",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.16.1",
+  "version": "5.16.2",
   "private": true,
   "appName": "Business Create UI",
   "sbcName": "SBC Common Components",

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -927,7 +927,12 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
         },
         nameTranslations: this.getNameTranslations,
         noticeDate: this.getRestoration.noticeDate || undefined, // can't be null
-        offices: this.getDefineCompanyStep.officeAddresses,
+        offices: {
+          // only save records and registered office
+          // do not save custodial office (if present)
+          recordsOffice: { ...this.getDefineCompanyStep.officeAddresses.recordsOffice },
+          registeredOffice: { ...this.getDefineCompanyStep.officeAddresses.registeredOffice }
+        },
         parties: this.orgPersonsToParties(this.getAddPeopleAndRoleStep.orgPeople),
         relationships: this.getRestoration.relationships,
         type: this.getRestoration.type

--- a/src/views/Restoration/RestorationBusinessInformation.vue
+++ b/src/views/Restoration/RestorationBusinessInformation.vue
@@ -100,6 +100,7 @@ export default class RestorationBusinessInformation extends Mixins(CommonMixin) 
   @Getter(useStore) getShowErrors!: boolean
   @Getter(useStore) isBaseCompany!: boolean
   @Getter(useStore) isEntityType!: boolean
+  @Getter(useStore) isFullRestorationFiling!: boolean
 
   @Action(useStore) setBusinessContact!: (x: ContactPointIF) => void
   @Action(useStore) setDefineCompanyStepValidity!: (x: boolean) => void
@@ -123,7 +124,13 @@ export default class RestorationBusinessInformation extends Mixins(CommonMixin) 
     // temporarily ignore data changes
     this.setIgnoreChanges(true)
 
-    // if no addresses were fetched or are empty, set default addresses
+    // allow editing addresses if full restoration
+    if (this.isFullRestorationFiling) {
+      this.allowEditingOfficeAddresses = true
+      this.addressFormValid = false
+    }
+
+    // if no addresses were fetched or are empty, allow editing and set default addresses
     if (this.isEmptyRecordsAddress || this.isEmptyRegisteredAddress) {
       this.allowEditingOfficeAddresses = true
       this.addressFormValid = false


### PR DESCRIPTION
*Issue #:* bcgov/entity#29124

*Description of changes:*
- app version = 5.16.2
- only save records and registered office (not custodial office)
- updated logic so addresses are non-editable only for limited restoration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).