### PR TITLE
29942 - Contact Info should be Pre-populated for Full Restoration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.16.6",
+  "version": "5.16.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.16.6",
+      "version": "5.16.7",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.16.6",
+  "version": "5.16.7",
   "private": true,
   "appName": "Business Create UI",
   "sbcName": "SBC Common Components",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1155,7 +1155,7 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
     // fetch auth org info for dissolution/restoration only
     // do not set auth org/contact info for Restoration as it is likely to change
     // (this data is not available for an incorporation/registration)
-    if (this.isDissolutionFiling) {
+    if (this.isDissolutionFiling || this.isRestorationFiling) {
       const { contacts, folioNumber } = await AuthServices.fetchAuthInfo(this.getBusinessId)
       if (contacts?.length > 0) {
         this.setBusinessContact(contacts[0])

--- a/src/App.vue
+++ b/src/App.vue
@@ -1153,7 +1153,6 @@ export default class App extends Mixins(CommonMixin, DateMixin, FilingTemplateMi
   /** Fetches auth and user info, stores it, and returns it. */
   private async loadUserInfo (): Promise<any> {
     // fetch auth org info for dissolution/restoration only
-    // do not set auth org/contact info for Restoration as it is likely to change
     // (this data is not available for an incorporation/registration)
     if (this.isDissolutionFiling || this.isRestorationFiling) {
       const { contacts, folioNumber } = await AuthServices.fetchAuthInfo(this.getBusinessId)

--- a/src/components/common/BusinessContactInfo.vue
+++ b/src/components/common/BusinessContactInfo.vue
@@ -202,10 +202,15 @@ export default class BusinessContactInfo extends Mixins(CommonMixin) {
 
   @Watch('initialValue', { deep: true, immediate: true })
   private onContactPropValueChanged (): void {
-    this.contact = this.initialValue
+    this.contact = { ...this.initialValue }
+
+    // If email exists, set confirmEmail to match
+    if (this.contact.email) {
+      this.contact.confirmEmail = this.contact.email
+    }
   }
 
-  @Watch('contact', { deep: true, immediate: true })
+  @Watch('contact', { deep: true })
   private onContactChanged (contact: ContactPointIF): void {
     this.emitContactInfo(contact)
   }

--- a/src/views/Restoration/RestorationBusinessInformation.vue
+++ b/src/views/Restoration/RestorationBusinessInformation.vue
@@ -65,7 +65,7 @@
         :class="{ 'invalid-section': getShowErrors && !businessContactFormValid }"
       >
         <BusinessContactInfo
-          :initialValue="getBusinessContact"
+          :initialValue="contactInitialValue"
           :isEditing="true"
           :showErrors="getShowErrors"
           @update="setBusinessContact($event)"
@@ -80,7 +80,7 @@
 import { Component, Mixins, Watch } from 'vue-property-decorator'
 import { Getter, Action } from 'pinia-class'
 import { useStore } from '@/store/store'
-import { AddressIF, ContactPointIF, DefineCompanyIF, EmptyAddress, RegisteredRecordsAddressesIF,
+import { AddressIF, ContactPointIF, DefineCompanyIF, EmptyAddress, EmptyContactPoint, RegisteredRecordsAddressesIF,
   RestorationStateIF } from '@/interfaces'
 import { CommonMixin } from '@/mixins'
 import { RestorationTypes, RouteNames } from '@/enums'
@@ -111,6 +111,7 @@ export default class RestorationBusinessInformation extends Mixins(CommonMixin) 
   businessContactFormValid = false
   addressFormValid = true
   allowEditingOfficeAddresses = false
+  contactInitialValue: ContactPointIF = { ...EmptyContactPoint }
 
   // Enum for template
   readonly CorpTypeCd = CorpTypeCd
@@ -194,15 +195,20 @@ export default class RestorationBusinessInformation extends Mixins(CommonMixin) 
   }
 
   /** Updates flags when restoration type is set or changes. */
-  @Watch('getRestoration.type', { immediate: true })
+  @Watch('getRestoration.type')
   private onRestorationTypeChanged (val: RestorationTypes) {
     if (val === RestorationTypes.FULL) {
       this.allowEditingOfficeAddresses = true
       this.addressFormValid = false
+      // pre-populate contact info for full restoration
+      this.contactInitialValue = { ...this.getBusinessContact }
     }
     if (val === RestorationTypes.LIMITED) {
       this.allowEditingOfficeAddresses = false
       this.addressFormValid = true
+
+      // do not pre-populate contact info for limited restoration
+      this.contactInitialValue = { ...EmptyContactPoint }
     }
     // else -- should never happen
   }

--- a/src/views/Restoration/RestorationReviewConfirm.vue
+++ b/src/views/Restoration/RestorationReviewConfirm.vue
@@ -49,7 +49,7 @@
       >
         <CardHeader
           icon="mdi-domain"
-          label="Business Information"
+          :label="isFullRestorationFiling ? 'Address and Contact Information' : 'Business Information'"
         />
         <SummaryDefineCompany />
       </v-card>

--- a/tests/unit/BusinessContactInfo.spec.ts
+++ b/tests/unit/BusinessContactInfo.spec.ts
@@ -68,6 +68,7 @@ describe('Business Contact Info component', () => {
 
   it('form is valid for correct input', async () => {
     const wrapper: Wrapper<BusinessContactInfo> = createComponent(email, email)
+    wrapper.vm.contact = { email, confirmEmail: email, phone: '' }
     await Vue.nextTick()
     expect(getLastEvent(wrapper, formValidEvent)).toBe(true)
     expect(getLastEvent(wrapper, formDataChangeEvent)).toStrictEqual({
@@ -80,6 +81,7 @@ describe('Business Contact Info component', () => {
 
   it('form is invalid for wrong email', async () => {
     const wrapper: Wrapper<BusinessContactInfo> = createComponent(invalidEmail, invalidEmail)
+    wrapper.vm.contact = { email: invalidEmail, confirmEmail: invalidEmail, phone: '' }
     await Vue.nextTick()
     expect(getLastEvent(wrapper, formValidEvent)).toBe(false)
     expect(getLastEvent(wrapper, formDataChangeEvent)).toStrictEqual({


### PR DESCRIPTION
*Issue #:* /bcgov/entity#29942 

*Description of changes:*
- Update Business Information label
- Pre-populate email and phone number
- Update app version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
