### PR TITLE
32827: Support migrated "Other" currency for amalgamations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.18.1",
+  "version": "5.18.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.18.1",
+  "version": "5.18.2",
   "private": true,
   "appName": "Business Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/ListShareClass.vue
+++ b/src/components/common/ListShareClass.vue
@@ -163,7 +163,7 @@
             <td class="color-md-text text-right">
               {{ formatParValue(row.item) }}
             </td>
-            <td>{{ formatCurrency(row.item) }}</td>
+            <td>{{ formatCurrency(seriesItem.currency ? seriesItem : row.item) }}</td>
             <td>{{ seriesItem.hasRightsOrRestrictions ? 'Yes' : 'No' }}</td>
 
             <!-- Share Series Edit Btn -->
@@ -241,6 +241,7 @@
 import { Component, Emit, Prop, Vue } from 'vue-property-decorator'
 import { RouteNames } from '@/enums'
 import { arrayMoveMutable } from 'array-move'
+import { OTHER_CURRENCY } from '@/constants'
 import { FormatDecimal } from '@/utils'
 
 @Component({})
@@ -280,7 +281,7 @@ export default class ListShareClass extends Vue {
    * free-text `currencyAdditional` value, falling back to "Other" if blank.
    */
   formatCurrency (item: any): string {
-    if (item.currency === 'OTHER') {
+    if (item.currency === OTHER_CURRENCY) {
       return item.currencyAdditional || 'Other'
     }
     return item.currency

--- a/src/components/common/ListShareClass.vue
+++ b/src/components/common/ListShareClass.vue
@@ -57,7 +57,7 @@
               {{ formatParValue(row.item) }}
             </td>
             <td class="color-md-text">
-              {{ row.item.currency }}
+              {{ formatCurrency(row.item) }}
             </td>
             <td class="color-md-text">
               {{ row.item.hasRightsOrRestrictions ? 'Yes' : 'No' }}
@@ -163,7 +163,7 @@
             <td class="color-md-text text-right">
               {{ formatParValue(row.item) }}
             </td>
-            <td>{{ row.item.currency }}</td>
+            <td>{{ formatCurrency(row.item) }}</td>
             <td>{{ seriesItem.hasRightsOrRestrictions ? 'Yes' : 'No' }}</td>
 
             <!-- Share Series Edit Btn -->
@@ -272,6 +272,18 @@ export default class ListShareClass extends Vue {
     ]
     if (!this.isSummary) headers.push({ text: '', value: 'actions' })
     return headers
+  }
+
+  /**
+   * Returns a currency formatted for display in the shares table.
+   * For grandfathered "OTHER" currency (migrated from COLIN), shows the
+   * free-text `currencyAdditional` value, falling back to "Other" if blank.
+   */
+  formatCurrency (item: any): string {
+    if (item.currency === 'OTHER') {
+      return item.currencyAdditional || 'Other'
+    }
+    return item.currency
   }
 
   /** Returns a par value formatted for display in the shares table. */

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,3 +1,6 @@
 export const ADDRESSCHANGED = 'addressChanged'
 export const ISFUTUREEFFECTIVE = 'isFutureEffective'
 export const ISIMMEDIATE = 'isImmediate'
+
+// Grandfathered share-class currency value migrated from COLIN; not supported for new share classes.
+export const OTHER_CURRENCY = 'OTHER'

--- a/src/interfaces/stepper-interfaces/CreateShareStructure/create-share-structure-interface.ts
+++ b/src/interfaces/stepper-interfaces/CreateShareStructure/create-share-structure-interface.ts
@@ -8,6 +8,7 @@ export interface ShareClassIF {
   hasParValue?: boolean
   parValue?: number
   currency?: string
+  currencyAdditional?: string
   hasRightsOrRestrictions: boolean
   series?: ShareClassIF[]
 }

--- a/src/views/Amalgamation/ReviewConfirm.vue
+++ b/src/views/Amalgamation/ReviewConfirm.vue
@@ -64,17 +64,19 @@
           icon="mdi-sitemap"
           label="Share Structure"
         />
-        <MessageBox
+        <div
           v-if="hasOtherCurrency"
           id="other-currency-notice"
-          color="gold"
-          class="mx-5 mt-5"
+          class="d-flex align-start px-5 pt-5 pb-3"
         >
+          <v-icon class="mr-2">
+            mdi-information-outline
+          </v-icon>
           <p class="ma-0">
             <strong>Important:</strong> Existing share classes may continue to use &ldquo;Other&rdquo;
             but this option is not supported for new share classes.
           </p>
-        </MessageBox>
+        </div>
         <ListShareClass
           :isSummary="true"
           :shareClasses="getCreateShareStructureStep.shareClasses"
@@ -294,7 +296,6 @@ import AmalgamationStatement from '@/components/Amalgamation/AmalgamationStateme
 import EffectiveDateTime from '@/components/common/EffectiveDateTime.vue'
 import ListPeopleAndRoles from '@/components/common/ListPeopleAndRoles.vue'
 import ListShareClass from '@/components/common/ListShareClass.vue'
-import MessageBox from '@/components/common/MessageBox.vue'
 import SummaryDefineCompany from '@/components/common/SummaryDefineCompany.vue'
 import StaffPayment from '@/components/common/StaffPayment.vue'
 import { CorpTypeCd, GetCorpFullDescription } from '@bcrs-shared-components/corp-type-module'
@@ -314,7 +315,6 @@ import { IsAuthorized } from '@/utils'
     ListPeopleAndRoles,
     ListShareClass,
     ListResolutions,
-    MessageBox,
     SummaryDefineCompany,
     StaffPayment
   }

--- a/src/views/Amalgamation/ReviewConfirm.vue
+++ b/src/views/Amalgamation/ReviewConfirm.vue
@@ -64,22 +64,17 @@
           icon="mdi-sitemap"
           label="Share Structure"
         />
-        <div
+        <MessageBox
           v-if="hasOtherCurrency"
           id="other-currency-notice"
-          class="d-flex align-start pa-5"
+          color="gold"
+          class="mx-5 mt-5"
         >
-          <v-icon
-            class="mr-2"
-            color="primary"
-          >
-            mdi-information-outline
-          </v-icon>
           <p class="ma-0">
             <strong>Important:</strong> Existing share classes may continue to use &ldquo;Other&rdquo;
             but this option is not supported for new share classes.
           </p>
-        </div>
+        </MessageBox>
         <ListShareClass
           :isSummary="true"
           :shareClasses="getCreateShareStructureStep.shareClasses"
@@ -285,6 +280,7 @@
 import { Component, Vue } from 'vue-property-decorator'
 import { Action, Getter } from 'pinia-class'
 import { useStore } from '@/store/store'
+import { OTHER_CURRENCY } from '@/constants'
 import { AuthorizedActions } from '@/enums'
 import { ContactPointIF, CertifyIF, EffectiveDateTimeIF, ShareStructureIF,
   CourtOrderStepIF, DocumentDeliveryIF } from '@/interfaces'
@@ -298,6 +294,7 @@ import AmalgamationStatement from '@/components/Amalgamation/AmalgamationStateme
 import EffectiveDateTime from '@/components/common/EffectiveDateTime.vue'
 import ListPeopleAndRoles from '@/components/common/ListPeopleAndRoles.vue'
 import ListShareClass from '@/components/common/ListShareClass.vue'
+import MessageBox from '@/components/common/MessageBox.vue'
 import SummaryDefineCompany from '@/components/common/SummaryDefineCompany.vue'
 import StaffPayment from '@/components/common/StaffPayment.vue'
 import { CorpTypeCd, GetCorpFullDescription } from '@bcrs-shared-components/corp-type-module'
@@ -317,6 +314,7 @@ import { IsAuthorized } from '@/utils'
     ListPeopleAndRoles,
     ListShareClass,
     ListResolutions,
+    MessageBox,
     SummaryDefineCompany,
     StaffPayment
   }
@@ -380,8 +378,8 @@ export default class AmalgamationReviewConfirm extends Vue {
   get hasOtherCurrency (): boolean {
     const classes = this.getCreateShareStructureStep.shareClasses || []
     return classes.some(c =>
-      c.currency === 'OTHER' ||
-      (c.series || []).some(s => s.currency === 'OTHER')
+      c.currency === OTHER_CURRENCY ||
+      (c.series || []).some(s => s.currency === OTHER_CURRENCY)
     )
   }
 

--- a/src/views/Amalgamation/ReviewConfirm.vue
+++ b/src/views/Amalgamation/ReviewConfirm.vue
@@ -64,6 +64,22 @@
           icon="mdi-sitemap"
           label="Share Structure"
         />
+        <div
+          v-if="hasOtherCurrency"
+          id="other-currency-notice"
+          class="d-flex align-start pa-5"
+        >
+          <v-icon
+            class="mr-2"
+            color="primary"
+          >
+            mdi-information-outline
+          </v-icon>
+          <p class="ma-0">
+            <strong>Important:</strong> Existing share classes may continue to use &ldquo;Other&rdquo;
+            but this option is not supported for new share classes.
+          </p>
+        </div>
         <ListShareClass
           :isSummary="true"
           :shareClasses="getCreateShareStructureStep.shareClasses"
@@ -354,6 +370,19 @@ export default class AmalgamationReviewConfirm extends Vue {
   get showErrorSummary (): boolean {
     if (this.isAmalgamationFilingRegular) return (!this.getCreateShareStructureStep.valid)
     return false
+  }
+
+  /**
+   * Whether any share class or series in the filing carries the legacy "OTHER"
+   * currency type (migrated from COLIN). Used to surface a notice on the
+   * Review page that "Other" is grandfathered but not supported for new shares.
+   */
+  get hasOtherCurrency (): boolean {
+    const classes = this.getCreateShareStructureStep.shareClasses || []
+    return classes.some(c =>
+      c.currency === 'OTHER' ||
+      (c.series || []).some(s => s.currency === 'OTHER')
+    )
   }
 
   /** The entity description,  */

--- a/tests/unit/AmalgamationReviewConfirm.spec.ts
+++ b/tests/unit/AmalgamationReviewConfirm.spec.ts
@@ -249,3 +249,57 @@ for (const test of amalgamationBusinessInfo) {
     })
   })
 }
+
+describe('Amalgamation Review Confirm — "Other" currency notice', () => {
+  const buildWrapper = (shareClasses: any[]) => shallowWrapperFactory(
+    AmalgamationReviewConfirm,
+    null,
+    {
+      amalgamation: { type: AmalgamationTypes.REGULAR },
+      entityType: 'BEN',
+      tombstone: {
+        filingType: FilingTypes.AMALGAMATION_APPLICATION,
+        authorizedActions: []
+      },
+      createShareStructureStep: { valid: true, shareClasses }
+    },
+    null,
+    null
+  )
+
+  it('shows the notice when a share class uses "OTHER" currency', () => {
+    const wrapper = buildWrapper([
+      { name: 'Class A', currency: 'OTHER', currencyAdditional: 'Bitcoin', hasRightsOrRestrictions: false }
+    ])
+    expect(wrapper.find('#other-currency-notice').exists()).toBe(true)
+    wrapper.destroy()
+  })
+
+  it('shows the notice when a share series uses "OTHER" currency', () => {
+    const wrapper = buildWrapper([
+      {
+        name: 'Class A',
+        currency: 'CAD',
+        hasRightsOrRestrictions: false,
+        series: [{ name: 'Series 1', currency: 'OTHER', hasRightsOrRestrictions: false }]
+      }
+    ])
+    expect(wrapper.find('#other-currency-notice').exists()).toBe(true)
+    wrapper.destroy()
+  })
+
+  it('does not show the notice when no share class or series uses "OTHER" currency', () => {
+    const wrapper = buildWrapper([
+      { name: 'Class A', currency: 'CAD', hasRightsOrRestrictions: false },
+      { name: 'Class B', currency: 'USD', hasRightsOrRestrictions: false }
+    ])
+    expect(wrapper.find('#other-currency-notice').exists()).toBe(false)
+    wrapper.destroy()
+  })
+
+  it('does not show the notice when there are no share classes', () => {
+    const wrapper = buildWrapper([])
+    expect(wrapper.find('#other-currency-notice').exists()).toBe(false)
+    wrapper.destroy()
+  })
+})

--- a/tests/unit/ListShareClass.spec.ts
+++ b/tests/unit/ListShareClass.spec.ts
@@ -238,6 +238,89 @@ describe('formatParValue()', () => {
   })
 })
 
+describe('series currency rendering', () => {
+  const makeWrapper = (shareClasses) => mount(ListShareClass, {
+    localVue,
+    vuetify,
+    propsData: { shareClasses }
+  })
+
+  it('falls back to the parent class currency when the series currency is unset', async () => {
+    const wrapper = makeWrapper([{
+      id: 1,
+      name: 'Class A',
+      priority: 0,
+      maxNumberOfShares: 100,
+      parValue: 1,
+      currency: 'CAD',
+      hasRightsOrRestrictions: false,
+      series: [{
+        id: 1,
+        name: 'Series A1',
+        priority: 1,
+        maxNumberOfShares: 10,
+        hasRightsOrRestrictions: false
+      }]
+    }])
+    await flushPromises()
+
+    const seriesRow = wrapper.vm.$el.querySelectorAll('.v-data-table .series-row')[0]
+    expect(seriesRow.querySelectorAll('td')[3].textContent).toContain('CAD')
+    wrapper.destroy()
+  })
+
+  it('uses the series\' own currency when it differs from the parent class', async () => {
+    const wrapper = makeWrapper([{
+      id: 1,
+      name: 'Class A',
+      priority: 0,
+      maxNumberOfShares: 100,
+      parValue: 1,
+      currency: 'CAD',
+      hasRightsOrRestrictions: false,
+      series: [{
+        id: 1,
+        name: 'Series A1',
+        priority: 1,
+        maxNumberOfShares: 10,
+        currency: 'USD',
+        hasRightsOrRestrictions: false
+      }]
+    }])
+    await flushPromises()
+
+    const seriesRow = wrapper.vm.$el.querySelectorAll('.v-data-table .series-row')[0]
+    expect(seriesRow.querySelectorAll('td')[3].textContent).toContain('USD')
+    wrapper.destroy()
+  })
+
+  it('uses the series\' currencyAdditional when the series carries legacy OTHER currency', async () => {
+    const wrapper = makeWrapper([{
+      id: 1,
+      name: 'Class A',
+      priority: 0,
+      maxNumberOfShares: 100,
+      parValue: 1,
+      currency: 'CAD',
+      hasRightsOrRestrictions: false,
+      series: [{
+        id: 1,
+        name: 'Series A1',
+        priority: 1,
+        maxNumberOfShares: 10,
+        currency: 'OTHER',
+        currencyAdditional: 'Bitcoin',
+        hasRightsOrRestrictions: false
+      }]
+    }])
+    await flushPromises()
+
+    const seriesRow = wrapper.vm.$el.querySelectorAll('.v-data-table .series-row')[0]
+    expect(seriesRow.querySelectorAll('td')[3].textContent).toContain('Bitcoin')
+    wrapper.destroy()
+  })
+})
+
 describe('formatCurrency()', () => {
   let wrapper
 

--- a/tests/unit/ListShareClass.spec.ts
+++ b/tests/unit/ListShareClass.spec.ts
@@ -237,3 +237,34 @@ describe('formatParValue()', () => {
     })
   })
 })
+
+describe('formatCurrency()', () => {
+  let wrapper
+
+  beforeAll(() => {
+    wrapper = shallowMount(ListShareClass)
+  })
+
+  afterAll(() => {
+    wrapper.destroy()
+  })
+
+  it('returns the currency code for standard ISO currencies', () => {
+    expect(wrapper.vm.formatCurrency({ currency: 'CAD' })).toBe('CAD')
+    expect(wrapper.vm.formatCurrency({ currency: 'USD' })).toBe('USD')
+    expect(wrapper.vm.formatCurrency({ currency: 'EUR' })).toBe('EUR')
+  })
+
+  it('returns the free-text value for grandfathered OTHER currency', () => {
+    expect(wrapper.vm.formatCurrency({ currency: 'OTHER', currencyAdditional: 'Bitcoin' }))
+      .toBe('Bitcoin')
+    expect(wrapper.vm.formatCurrency({ currency: 'OTHER', currencyAdditional: 'Swiss Francs' }))
+      .toBe('Swiss Francs')
+  })
+
+  it('falls back to "Other" when OTHER currency has no free-text value', () => {
+    expect(wrapper.vm.formatCurrency({ currency: 'OTHER', currencyAdditional: '' })).toBe('Other')
+    expect(wrapper.vm.formatCurrency({ currency: 'OTHER', currencyAdditional: null })).toBe('Other')
+    expect(wrapper.vm.formatCurrency({ currency: 'OTHER' })).toBe('Other')
+  })
+})


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32827

*Description of changes:*

Add display handling for review page to show other currency value with additional_currency value if present. See comments in linked ticket for the amalgamation cases for share currency display)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
