### PR TITLE
32791: Dissolution - Adjust custodian name validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.18.2",
+  "version": "5.18.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.18.2",
+      "version": "5.18.3",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.1.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.18.2",
+  "version": "5.18.3",
   "private": true,
   "appName": "Business Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Dissolution/CustodianOfRecords.vue
+++ b/src/components/Dissolution/CustodianOfRecords.vue
@@ -39,7 +39,7 @@
                     v-model.trim="custodian.officer.firstName"
                     filled
                     label="First Name"
-                    :rules="Rules.FirstNameRules"
+                    :rules="Rules.FirstNameRulesCustodian"
                   />
                 </v-col>
                 <v-col>
@@ -49,7 +49,7 @@
                     filled
                     class="px-5"
                     label="Middle Name (Optional)"
-                    :rules="Rules.MiddleNameRules"
+                    :rules="Rules.MiddleNameRulesCustodian"
                   />
                 </v-col>
                 <v-col>
@@ -93,7 +93,7 @@
                       v-model.trim="custodian.officer.firstName"
                       filled
                       label="First Name"
-                      :rules="isPerson ? Rules.FirstNameRules : []"
+                      :rules="isPerson ? Rules.FirstNameRulesCustodian : []"
                       @input="syncCustodianPartyType(PartyTypes.PERSON)"
                     />
                   </v-col>
@@ -104,7 +104,7 @@
                       filled
                       class="px-5"
                       label="Middle Name (Optional)"
-                      :rules="isPerson ? Rules.MiddleNameRules : []"
+                      :rules="isPerson ? Rules.MiddleNameRulesCustodian : []"
                       @input="syncCustodianPartyType(PartyTypes.PERSON)"
                     />
                   </v-col>

--- a/src/rules/first-name-rules.ts
+++ b/src/rules/first-name-rules.ts
@@ -5,6 +5,12 @@ export const FirstNameRules: Array<VuetifyRuleFunction> = [
   v => (v?.length <= 20) || 'Cannot exceed 20 characters' // maximum character count
 ]
 
+/** First name rules for custodian that sync to COLIN's CORP_PARTY table */
+export const FirstNameRulesCustodian: Array<VuetifyRuleFunction> = [
+  v => !!v?.trim() || 'First name is required',
+  v => (v?.length <= 30) || 'Cannot exceed 30 characters' // maximum character count
+]
+
 /** The validation rules for first name of completing party in registration. */
 export const FirstNameRulesFirmsCP: Array<VuetifyRuleFunction> = [
   v => (v?.length <= 30) || 'Cannot exceed 30 characters' // maximum character count

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -2,10 +2,10 @@ import { BusinessNumberRules } from './business-number-rules'
 import { CommonRules } from './common-rules'
 import { DateRules, DateRuleHelpers } from './date-rules'
 import { EmailRules } from './email-rules'
-import { FirstNameRules, FirstNameRulesFirms, FirstNameRulesFirmsCP } from './first-name-rules'
+import { FirstNameRules, FirstNameRulesCustodian, FirstNameRulesFirms, FirstNameRulesFirmsCP } from './first-name-rules'
 import { FolioNumberRules } from './folio-number-rules'
 import { LastNameRules } from './last-name-rules'
-import { MiddleNameRules, MiddleNameRulesFirms } from './middle-name-rules'
+import { MiddleNameRules, MiddleNameRulesCustodian, MiddleNameRulesFirms } from './middle-name-rules'
 import { OrgNameRules } from './org-name-rules'
 import { PhoneRules } from './phone-rules'
 
@@ -15,11 +15,13 @@ export const Rules = {
   DateRules,
   EmailRules,
   FirstNameRules,
+  FirstNameRulesCustodian,
   FirstNameRulesFirms,
   FirstNameRulesFirmsCP,
   FolioNumberRules,
   LastNameRules,
   MiddleNameRules,
+  MiddleNameRulesCustodian,
   MiddleNameRulesFirms,
   OrgNameRules,
   PhoneRules

--- a/src/rules/middle-name-rules.ts
+++ b/src/rules/middle-name-rules.ts
@@ -6,6 +6,13 @@ export const MiddleNameRules: Array<VuetifyRuleFunction> = [
   v => (!v || v.length <= 20) || 'Cannot exceed 20 characters' // maximum character count
 ]
 
+/** Middle name rules for custodian that sync to COLIN's CORP_PARTY table */
+export const MiddleNameRulesCustodian: Array<VuetifyRuleFunction> = [
+  v => !/^\s/g.test(v) || 'Invalid spaces', // leading spaces
+  v => !/\s$/g.test(v) || 'Invalid spaces', // trailing spaces
+  v => (!v || v.length <= 30) || 'Cannot exceed 30 characters' // maximum character count
+]
+
 export const MiddleNameRulesFirms: Array<VuetifyRuleFunction> = [
   v => !/^\s/g.test(v) || 'Invalid spaces', // leading spaces
   v => !/\s$/g.test(v) || 'Invalid spaces', // trailing spaces

--- a/tests/unit/name-rules.spec.ts
+++ b/tests/unit/name-rules.spec.ts
@@ -1,0 +1,81 @@
+import { FirstNameRulesCustodian } from '@/rules/first-name-rules'
+import { MiddleNameRulesCustodian } from '@/rules/middle-name-rules'
+
+// Custodians sync to COLIN's CORP_PARTY table where FIRST_NME / MIDDLE_NME are VARCHAR2(30).
+// These rules must allow up to 30 chars (vs. the default 20-char rules used for completing parties
+// that sync to COMPLETING_PARTY where FIRST_NME / MIDDLE_NME are VARCHAR2(20)).
+
+describe('FirstNameRulesCustodian', () => {
+  const requiredRule = FirstNameRulesCustodian[0]
+  const maxLengthRule = FirstNameRulesCustodian[1]
+
+  describe('required rule', () => {
+    it.each([
+      ['empty string', ''],
+      ['whitespace only', '   '],
+      ['null', null],
+      ['undefined', undefined]
+    ])('returns error when value is %s', (_label, value) => {
+      expect(requiredRule(value as string)).toBe('First name is required')
+    })
+
+    it('returns true when value has non-whitespace content', () => {
+      expect(requiredRule('Alice')).toBe(true)
+    })
+  })
+
+  describe('max length rule', () => {
+    it('accepts a 30-character first name', () => {
+      expect(maxLengthRule('a'.repeat(30))).toBe(true)
+    })
+
+    it('rejects a 31-character first name', () => {
+      expect(maxLengthRule('a'.repeat(31))).toBe('Cannot exceed 30 characters')
+    })
+
+    it('accepts a 20-character first name (would have been the default cap)', () => {
+      expect(maxLengthRule('a'.repeat(20))).toBe(true)
+    })
+  })
+})
+
+describe('MiddleNameRulesCustodian', () => {
+  const leadingSpaceRule = MiddleNameRulesCustodian[0]
+  const trailingSpaceRule = MiddleNameRulesCustodian[1]
+  const maxLengthRule = MiddleNameRulesCustodian[2]
+
+  describe('whitespace rules', () => {
+    it('rejects a value with a leading space', () => {
+      expect(leadingSpaceRule(' Alice')).toBe('Invalid spaces')
+    })
+
+    it('rejects a value with a trailing space', () => {
+      expect(trailingSpaceRule('Alice ')).toBe('Invalid spaces')
+    })
+
+    it.each([
+      ['empty string', ''],
+      ['null', null],
+      ['undefined', undefined]
+    ])('accepts %s (middle name is optional)', (_label, value) => {
+      expect(leadingSpaceRule(value as string)).toBe(true)
+      expect(trailingSpaceRule(value as string)).toBe(true)
+    })
+  })
+
+  describe('max length rule', () => {
+    it('accepts an empty value (middle name is optional)', () => {
+      expect(maxLengthRule('')).toBe(true)
+      expect(maxLengthRule(null)).toBe(true)
+      expect(maxLengthRule(undefined)).toBe(true)
+    })
+
+    it('accepts a 30-character middle name', () => {
+      expect(maxLengthRule('a'.repeat(30))).toBe(true)
+    })
+
+    it('rejects a 31-character middle name', () => {
+      expect(maxLengthRule('a'.repeat(31))).toBe('Cannot exceed 30 characters')
+    })
+  })
+})


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32791

*Description of changes:*
On the frontend set the specific dissolution name entry component to have a length of 30 for first and middle name.
Confirmed this migrates as as corp party to Colin which is a varchar(30).

A bit awkward with the different name length validations building up here... but need to keep the existing first/middle name validations on 20 since it covers the completing party (which is **20** in Colin!) at the same time as director/incorporator. That part has been discussed separately, probably better to simplify this stuff with common name controls when moving to the more modern nuxt UIs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
