### PR TITLE
31843 - Fix Cont in Authorization flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.18.4",
+  "version": "5.18.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.18.4",
+      "version": "5.18.5",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.1.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.18.4",
+  "version": "5.18.5",
   "private": true,
   "appName": "Business Create UI",
   "sbcName": "SBC Common Components",

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -374,9 +374,11 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
         filingId: this.getFilingId,
         folioNumber: this.getFolioNumber || undefined,
         isFutureEffective: this.getEffectiveDateTime.isFutureEffective,
-        ...(this.isBaseCompany
-          ? { authorizationReceived: this.getCertifyState.valid }
-          : { certifiedBy: this.getCertifyState.certifiedBy })
+        ...(this.isContinuationInAuthorization
+          ? { authorizationReceived: true }
+          : this.isBaseCompany
+            ? { authorizationReceived: this.getCertifyState.valid }
+            : { certifiedBy: this.getCertifyState.certifiedBy })
       },
       business: {
         identifier: this.getTempId,


### PR DESCRIPTION
*Issue #:* /bcgov/entity#31843

*Description of changes:*
- The first step in the Continuation In Filing (Authorization) does not include the certify/authorization component as part of the UI so we need to manually set the flag to true here otherwise the API raises an error

On Dev:
<img width="1240" height="688" alt="image" src="https://github.com/user-attachments/assets/309ca78a-5dcd-4c4f-862e-fbef038392b8" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
