### PR TITLE
33321 Fix divider color between edit button and dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.18.5",
+  "version": "5.18.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.18.5",
+      "version": "5.18.6",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.1.20",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.18.6",
+  "version": "5.18.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.18.6",
+      "version": "5.18.8",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.1.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.18.5",
+  "version": "5.18.6",
   "private": true,
   "appName": "Business Create UI",
   "sbcName": "SBC Common Components",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.18.6",
+  "version": "5.18.8",
   "private": true,
   "appName": "Business Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/ListShareClass.vue
+++ b/src/components/common/ListShareClass.vue
@@ -426,7 +426,7 @@ tbody {
   display: flex;
 
   .edit-action {
-    border-right: 1px solid $gray1;
+    border-right: 1px solid #D4D8DC;
   }
 
   .v-btn {


### PR DESCRIPTION
*Issue #33321:*
https://github.com/bcgov/entity/issues/33321

**Summary**
33321 Fix divider color between edit button and dropdown

**Changes**

* Updated divider color to `#D4D8DC` to match design specs

**Testing**

* Verified locally on Share Structure page
* Divider is visible and displays correct color
* No layout or hover issues observed

