### PR TITLE
32780 - Remove Completing Party from Incorporation Application

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.18.12",
+  "version": "5.18.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.18.12",
+      "version": "5.18.13",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.1.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.18.12",
+  "version": "5.18.13",
   "private": true,
   "appName": "Business Create UI",
   "sbcName": "SBC Common Components",

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -732,8 +732,14 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
     })
 
     // restore Persons and Organizations
+    // NB: base company incorporations no longer use a Completing Party, so strip it from
+    // any older draft data (this also keeps it out of the People table and filing submission)
     if (draftFiling.incorporationApplication.parties) {
-      this.setOrgPersonList(draftFiling.incorporationApplication.parties)
+      this.setOrgPersonList(
+        this.isBaseCompany
+          ? this.removeCompletingParty(draftFiling.incorporationApplication.parties)
+          : draftFiling.incorporationApplication.parties
+      )
     }
 
     // conditionally restore the entity-specific sections
@@ -1620,5 +1626,21 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
       if (p.officer?.email === null || p.officer?.email === '') delete p.officer.email
       return p
     })
+  }
+
+  /**
+   * Removes the Completing Party role from the given parties, and drops any party
+   * left with no roles. Used to strip the Completing Party from base company
+   * incorporations, which no longer use one.
+   * @param parties the parties to strip
+   * @returns the parties without any Completing Party
+   */
+  removeCompletingParty (parties: OrgPersonIF[]): OrgPersonIF[] {
+    return parties
+      .map(party => ({
+        ...party,
+        roles: party.roles.filter(role => role.roleType !== RoleTypes.COMPLETING_PARTY)
+      }))
+      .filter(party => party.roles.length > 0)
   }
 }

--- a/src/resources/Incorporation/BC.ts
+++ b/src/resources/Incorporation/BC.ts
@@ -21,11 +21,6 @@ export const IncorporationResourceBc: IncorporationResourceIF = {
     addOrganization: true,
     rules: [
       {
-        id: RuleIds.NUM_COMPLETING_PARTY,
-        text: 'The Completing Party',
-        test: (num) => { return (num === 1) }
-      },
-      {
         id: RuleIds.NUM_INCORPORATORS,
         text: 'At least one Incorporator',
         test: (num) => { return (num >= 1) }

--- a/src/resources/Incorporation/BEN.ts
+++ b/src/resources/Incorporation/BEN.ts
@@ -21,11 +21,6 @@ export const IncorporationResourceBen: IncorporationResourceIF = {
     addOrganization: true,
     rules: [
       {
-        id: RuleIds.NUM_COMPLETING_PARTY,
-        text: 'The Completing Party',
-        test: (num) => { return (num === 1) }
-      },
-      {
         id: RuleIds.NUM_INCORPORATORS,
         text: 'At least one Incorporator',
         test: (num) => { return (num >= 1) }

--- a/src/resources/Incorporation/CC.ts
+++ b/src/resources/Incorporation/CC.ts
@@ -21,11 +21,6 @@ export const IncorporationResourceCc: IncorporationResourceIF = {
     addOrganization: true,
     rules: [
       {
-        id: RuleIds.NUM_COMPLETING_PARTY,
-        text: 'The Completing Party',
-        test: (num) => { return (num === 1) }
-      },
-      {
         id: RuleIds.NUM_INCORPORATORS,
         text: 'At least one Incorporator',
         test: (num) => { return (num >= 1) }

--- a/src/resources/Incorporation/ULC.ts
+++ b/src/resources/Incorporation/ULC.ts
@@ -21,11 +21,6 @@ export const IncorporationResourceUlc: IncorporationResourceIF = {
     addOrganization: true,
     rules: [
       {
-        id: RuleIds.NUM_COMPLETING_PARTY,
-        text: 'The Completing Party',
-        test: (num) => { return (num === 1) }
-      },
-      {
         id: RuleIds.NUM_INCORPORATORS,
         text: 'At least one Incorporator',
         test: (num) => { return (num >= 1) }

--- a/tests/unit/PeopleAndRoles.spec.ts
+++ b/tests/unit/PeopleAndRoles.spec.ts
@@ -87,20 +87,19 @@ describe('People And Roles component', () => {
     }
   })
 
-  it('shows Start by Adding Completing Party Button when people list is empty', () => {
+  it('does not show any Completing Party button when people list is empty', () => {
     store.stateModel.addPeopleAndRoleStep.orgPeople = []
     const wrapper = wrapperFactory()
-    expect(wrapper.find(btnStartAddCompletingParty).exists()).toBeTruthy()
-    expect(wrapper.find(btnStartAddCompletingParty).text()).toContain('Start by Adding the Completing Party')
+    expect(wrapper.find(btnStartAddCompletingParty).exists()).toBeFalsy()
+    expect(wrapper.find(btnAddCompletingParty).exists()).toBeFalsy()
     wrapper.destroy()
   })
 
-  it('Does not show other add buttons when people list is empty', () => {
+  it('shows Add Person and Add Corporation buttons when people list is empty', () => {
     store.stateModel.addPeopleAndRoleStep.orgPeople = []
     const wrapper = wrapperFactory()
-    expect(wrapper.find(btnAddPerson).exists()).toBeFalsy()
-    expect(wrapper.find(btnAddCompletingParty).exists()).toBeFalsy()
-    expect(wrapper.find(btnAddOrganization).exists()).toBeFalsy()
+    expect(wrapper.find(btnAddPerson).exists()).toBeTruthy()
+    expect(wrapper.find(btnAddOrganization).exists()).toBeTruthy()
     wrapper.destroy()
   })
 
@@ -121,12 +120,12 @@ describe('People And Roles component', () => {
     resetStore()
   })
 
-  it('shows Add Completing Party Button when people list is not empty and has no Completing Party', () => {
+  it('does not show Add Completing Party Button when people list is not empty and has no Completing Party', () => {
     store.stateModel.addPeopleAndRoleStep.orgPeople = getPersonList([
       { roleType: 'Director', appointmentDate: '2020-03-30' }
     ])
     const wrapper = wrapperFactory()
-    expect(wrapper.find(btnAddCompletingParty).exists()).toBeTruthy()
+    expect(wrapper.find(btnAddCompletingParty).exists()).toBeFalsy()
     wrapper.destroy()
     resetStore()
   })
@@ -173,8 +172,9 @@ describe('People And Roles component', () => {
   })
 
   it('Validates person address as expected', async () => {
+    store.stateModel.addPeopleAndRoleStep.orgPeople = []
     const wrapper = wrapperFactory()
-    await wrapper.find(btnStartAddCompletingParty).trigger('click')
+    await wrapper.find(btnAddPerson).trigger('click')
     const address = wrapper.find('div.base-address')
     await verifyAddressValidation(address)
     wrapper.destroy()

--- a/tests/unit/filing-template-mixin.spec.ts
+++ b/tests/unit/filing-template-mixin.spec.ts
@@ -524,6 +524,21 @@ for (const entityType of ['BEN', 'BC', 'CC', 'ULC']) {
       expect(filing.incorporationApplication).not.toHaveProperty('courtNumber')
     })
 
+    it('strips the Completing Party from parties on load and submission', () => {
+      wrapper.vm.parseIncorporationDraft(ia.filing)
+
+      // the Completing Party role is gone from the store, but the person who was
+      // also a Director is kept (so no parties are dropped here)
+      const orgPeople = store.stateModel.addPeopleAndRoleStep.orgPeople
+      expect(orgPeople.length).toBe(3)
+      expect(orgPeople.some(p => p.roles.some(r => r.roleType === 'Completing Party'))).toBe(false)
+
+      // and it stays out of the built filing
+      const filing = wrapper.vm.buildIncorporationFiling()
+      expect(filing.incorporationApplication.parties
+        .some(p => p.roles.some(r => r.roleType === 'Completing Party'))).toBe(false)
+    })
+
     it('can include courtOrder attribute', () => {
       ia.filing.incorporationApplication.courtOrder = {
         'fileNumber': '12034567',


### PR DESCRIPTION
*Issue #:* /bcgov/entity#32780
Remove the Completing Party from the base company incorporations (BC, BEN, CC, ULC):

- Remove the NUM_COMPLETING_PARTY rule from the BC/BEN/CC/ULC resources, which hides the checklist item, both "Add Completing Party" buttons, the Completing Party role checkbox (add/edit form), and drops the Completing Party step validation.
- Strip the Completing Party from base company incorporation parties on draft load (parseIncorporationDraft), so stale draft data no longer renders in the People & Roles / Review tables and is not submitted.
- Update and add tests accordingly.

as per the figma design: https://www.figma.com/design/YV0TkHNb4gs1JGFlTwPJB7/Incorporation-Application---People-and-Roles?node-id=15020-14822&t=lSrk7VOyGtfB1axa-0

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
