### PR TITLE
33595 Amalg - foreign business validation tweaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.18.14",
+  "version": "5.18.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.18.14",
+      "version": "5.18.15",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.1.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.18.14",
+  "version": "5.18.15",
   "private": true,
   "appName": "Business Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/Amalgamation/AmalgamatingBusinesses.vue
+++ b/src/components/Amalgamation/AmalgamatingBusinesses.vue
@@ -347,10 +347,10 @@ export default class AmalgamatingBusinesses extends Mixins(AmalgamationMixin, Co
 
   get foreignBusinessIdentifierRules (): Array<(v: string) => boolean | string> {
     return [
-      v => (!this.isMrasJurisdiction || (!!v && /^[0-9a-zA-Z-]+$/.test(v))) ||
-        'Corporate number is required',
+      v => !!v || 'Corporate number is required',
       v => (!v || v.length >= 3) || 'Must be at least 3 characters',
-      v => (!v || v.length <= 40) || 'Cannot exceed 40 characters'
+      v => (!v || v.length <= 40) || 'Cannot exceed 40 characters',
+      v => (v && /^[0-9a-zA-Z-]+$/.test(v)) || 'Corporate number may only contain letters, numbers, and hyphens'
     ]
   }
 
@@ -641,13 +641,8 @@ export default class AmalgamatingBusinesses extends Mixins(AmalgamationMixin, Co
 
   /** Validate Add Amalgamating Foreign Business. */
   private validateAddAmalgamatingForeignBusiness (): void {
-    this.isForeignBusinessValid = (
-      !!this.jurisdiction &&
-      !!this.legalName &&
-      (!this.isMrasJurisdiction || !!this.identifier)
-    )
     this.jurisdictionErrorMessage = this.jurisdiction ? '' : 'Home jurisdiction is required'
-    this.$refs.foreignBusinessForm.validate()
+    this.isForeignBusinessValid = this.$refs.foreignBusinessForm.validate()
   }
 
   /** Sets validity according to various flags. */

--- a/tests/unit/AmalgamatingBusinesses.spec.ts
+++ b/tests/unit/AmalgamatingBusinesses.spec.ts
@@ -659,6 +659,32 @@ describe('Amalgamating Businesses - add amalgamating foreign business', () => {
     // simulate form data
     await wrapper.setData({
       isCan: true,
+      jurisdiction: { text: 'United States', value: 'US' },
+      legalName: 'Foreign Business',
+      identifier: ''
+    })
+
+    // simulate Save button action
+    await wrapper.vm.saveAmalgamatingForeignBusiness()
+
+    // verify validation - should require identifier
+    expect(wrapper.vm.isForeignBusinessValid).toBe(false)
+
+    await wrapper.setData({
+      isCan: true,
+      jurisdiction: { text: 'Alberta', value: 'AB' },
+      legalName: '',
+      identifier: 'ABC-123'
+    })
+
+    // simulate Save button action
+    wrapper.vm.saveAmalgamatingForeignBusiness()
+
+    // verify validation - should require legal name
+    expect(wrapper.vm.isForeignBusinessValid).toBe(false)
+
+    await wrapper.setData({
+      isCan: true,
       jurisdiction: { text: 'Alberta', value: 'AB' },
       legalName: 'Foreign Business',
       identifier: 'ABC-123'
@@ -751,41 +777,41 @@ describe('Amalgamating Businesses - add amalgamating foreign business', () => {
     expect(wrapper.find('.v-messages__message').exists()).toBe(false)
   })
 
-  it('applies foreign business business corp number rules', async () => {
+  it('applies foreign business corp number rules', async () => {
     // open panel
     await wrapper.find('#add-foreign-business-button').trigger('click')
 
     const identifier = wrapper.find('#foreign-business-corp-number')
 
-    // verify empty legal name - MRAS jurisdiction
+    // verify empty corp number - MRAS
     await wrapper.setData({ isMrasJurisdiction: true })
     await identifier.setValue('')
     await identifier.trigger('change')
     expect(wrapper.find('.v-messages__message').text()).toBe('Corporate number is required')
 
-    // verify empty legal name - non-MRAS jurisdiction
+    // verify empty corp number - non-MRAS jurisdiction
     await wrapper.setData({ isMrasJurisdiction: false })
     await identifier.setValue('')
     await identifier.trigger('change')
     expect(wrapper.find('.v-messages__message').text()).toBe('Corporate number is required')
 
-    // verify invalid legal name - MRAS jurisdiction
+    // verify invalid corp number - MRAS jurisdiction
     await wrapper.setData({ isMrasJurisdiction: true })
     await identifier.setValue('+++')
     await identifier.trigger('change')
-    expect(wrapper.find('.v-messages__message').text()).toBe('Corporate number is required')
+    expect(wrapper.find('.v-messages__message').text()).toBe('Corporate number may only contain letters, numbers, and hyphens')
 
-    // verify legal name too short
+    // verify corp number too short
     await identifier.setValue('xx')
     await identifier.trigger('change')
     expect(wrapper.find('.v-messages__message').text()).toBe('Must be at least 3 characters')
 
-    // verify legal name too long
+    // verify corp number too long
     await identifier.setValue('x'.repeat(41))
     await identifier.trigger('change')
     expect(wrapper.find('.v-messages__message').text()).toBe('Cannot exceed 40 characters')
 
-    // verify valid legal name (max length)
+    // verify valid corp number (max length)
     await identifier.setValue('x'.repeat(40))
     await identifier.trigger('change')
     expect(wrapper.find('.v-messages__message').exists()).toBe(false)


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33595

*Description of changes:*
- update so that foreign identifier is always required
- fix bug where foreign business form (name, jurisdiction, identifier) can be invalid and still be added

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
