### PR TITLE
33604 - Share structure name validation showing while field is focused

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.18.18",
+  "version": "5.18.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.18.18",
+      "version": "5.18.19",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.1.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.18.18",
+  "version": "5.18.19",
   "private": true,
   "appName": "Business Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/ShareStructure.vue
+++ b/src/components/common/ShareStructure.vue
@@ -27,6 +27,7 @@
                   :rules="getNameRule()"
                   suffix="Shares"
                   persistent-hint
+                  @focus="onNameFocus()"
                   @blur="onNameBlur()"
                 />
 
@@ -234,7 +235,7 @@ export default class ShareStructure extends Mixins(CurrencyLookupMixin) {
   hasNoParValue = false
   maxNumberOfShares = '' // v-model, which is converted to number before saving
   parValue = '' // v-model, which is converted to number before saving
-  nameTouched = false // tracks whether the name field has lost focus at least once
+  nameTouched = false // true once the name field has settled (blurred); reset while it has focus
 
   readonly excludedWordsListForClass: string [] = ['share', 'shares', 'value']
   readonly excludedWordsListForSeries: string [] = ['share', 'shares']
@@ -406,6 +407,13 @@ export default class ShareStructure extends Mixins(CurrencyLookupMixin) {
     }
   }
 
+  /** While the name field has focus, suppress space validation and clear any space error shown. */
+  onNameFocus (): void {
+    this.nameTouched = false
+    this.$nextTick(() => this.$refs.shareNameInput.validate())
+  }
+
+  /** Once the name field loses focus, enable space validation so any space error is shown. */
   onNameBlur (): void {
     this.nameTouched = true
     this.$nextTick(() => this.$refs.shareNameInput.validate())

--- a/tests/unit/ShareStructure.spec.ts
+++ b/tests/unit/ShareStructure.spec.ts
@@ -654,6 +654,35 @@ describe('Share Structure component', () => {
     wrapper.destroy()
   })
 
+  it('Does not show the spaces error while the name field still has focus', async () => {
+    const shareClass = createShareStructure(null, 1, 'Class', 'Class A', true, 100, true, 0.50, 'CAD', true)
+    const wrapper: Wrapper<ShareStructure> = createComponent(shareClass, -1, '1', null, [])
+    const inputElement: Wrapper<Vue> = wrapper.find(nameSelector)
+    // typing a trailing space while still editing (before any blur) must not flag "Invalid spaces"
+    inputElement.setValue('Class B ')
+    inputElement.trigger('change')
+    await waitForUpdate()
+    expect(wrapper.find(formSelector).text()).not.toContain('Invalid spaces')
+    wrapper.destroy()
+  })
+
+  it('Hides the spaces error again when the name field is re-focused for editing', async () => {
+    const shareClass = createShareStructure(null, 1, 'Class', 'Class A', true, 100, true, 0.50, 'CAD', true)
+    const wrapper: Wrapper<ShareStructure> = createComponent(shareClass, -1, '1', null, [])
+    const inputElement: Wrapper<Vue> = wrapper.find(nameSelector)
+    // first blur surfaces the trailing-space error
+    inputElement.setValue('Class B ')
+    inputElement.trigger('blur')
+    await waitForUpdate()
+    expect(wrapper.find(formSelector).text()).toContain('Invalid spaces')
+    // re-focusing to edit clears it (the focus event does not propagate through Vuetify in jsdom,
+    // so invoke the handler directly to exercise the re-focus reset logic)
+    ;(wrapper.vm as any).onNameFocus()
+    await waitForUpdate()
+    expect(wrapper.find(formSelector).text()).not.toContain('Invalid spaces')
+    wrapper.destroy()
+  })
+
   it('Shows error message if class name contains the word "share"', async () => {
     const shareClass = createShareStructure(null, 1, 'Class', 'Class A', true, 100, true, 0.50, 'CAD', true)
     const wrapper: Wrapper<ShareStructure> = createComponent(shareClass, -1, '1', null, [])


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33604

*Description of changes:*

Fixed the name field showing space validation after you click out, and resume typing again when you click back in.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).