### PR TITLE
33757-continuation-fee-no-fee

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.18.20",
+  "version": "5.18.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.18.20",
+      "version": "5.18.21",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.1.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.18.20",
+  "version": "5.18.21",
   "private": true,
   "appName": "Business Create UI",
   "sbcName": "SBC Common Components",

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -597,7 +597,13 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
     } else if (IsAuthorized(AuthorizedActions.STAFF_PAYMENT)) {
       // otherwise, restore normal Staff Payment data
       // NB: Staff Payment is mutually exclusive with Folio Number
-      this.parseStaffPayment(draftFiling)
+      // NB: ignore a "waiveFees" flag in the draft — drafts saved during the authorization
+      //     stage carry a leaked waiveFees=true, which made the Continuation Application
+      //     default to "No Fee" / $0.00 (see #33757)
+      this.parseStaffPayment({
+        ...draftFiling,
+        header: { ...draftFiling.header, waiveFees: false }
+      } as any)
     }
 
     // NB: Folio Number is mutually exclusive with Staff Payment

--- a/src/mixins/filing-template-mixin.ts
+++ b/src/mixins/filing-template-mixin.ts
@@ -459,7 +459,10 @@ export default class FilingTemplateMixin extends Mixins(AmalgamationMixin, DateM
       filing.header.effectiveDate = this.dateToApi(this.getEffectiveDateTime.effectiveDate)
     }
 
-    if (IsAuthorized(AuthorizedActions.STAFF_PAYMENT)) {
+    // NB: don't persist staff payment during the authorization stage. The zero-fee shown there
+    // is display-only (see parseContinuationInDraft); persisting waiveFees=true here leaks into
+    // the draft header and is later restored as "No Fee" in the Continuation Application. See #33757.
+    if (IsAuthorized(AuthorizedActions.STAFF_PAYMENT) && !this.isContinuationInAuthorization) {
       // Add staff payment data.
       this.buildStaffPayment(filing)
     }

--- a/tests/unit/filing-template-mixin.spec.ts
+++ b/tests/unit/filing-template-mixin.spec.ts
@@ -2,11 +2,13 @@ import { wrapperFactory } from '../vitest-wrapper-factory'
 import MixinTester from '@/mixin-tester.vue'
 import { createPinia, setActivePinia } from 'pinia'
 import { useStore } from '@/store/store'
-import { BusinessTypes, PartyTypes, RestorationTypes, RoleTypes } from '@/enums'
+import { AuthorizationRoles, BusinessTypes, FilingStatus, FilingTypes, PartyTypes, RestorationTypes, RoleTypes,
+  StaffPaymentOptions } from '@/enums'
 import { CorpTypeCd } from '@bcrs-shared-components/corp-type-module'
 import { NameRequestIF } from '@/interfaces'
 import { CorrectNameOptions } from '@bcrs-shared-components/enums'
 import * as FeatureFlags from '@/utils/feature-flag-utils'
+import { setAuthRole } from '../set-auth-role'
 
 setActivePinia(createPinia())
 const store = useStore()
@@ -606,5 +608,62 @@ describe('Restoration Filing', () => {
     const filing = wrapper.vm.buildRestorationFiling()
 
     expect(filing.restoration.contactPoint.extension).toBeUndefined()
+  })
+})
+
+describe('Continuation In Filing - staff payment', () => {
+  let wrapper: any
+
+  beforeEach(() => {
+    wrapper = wrapperFactory(MixinTester, null, {})
+    store.setEntityType(CorpTypeCd.BEN_CONTINUE_IN)
+    store.setFilingType(FilingTypes.CONTINUATION_IN)
+    setAuthRole(store, AuthorizationRoles.STAFF)
+  })
+
+  afterEach(() => {
+    setAuthRole(store, null)
+    wrapper.destroy()
+  })
+
+  it('does not persist staff payment during the authorization stage', () => {
+    store.setFilingStatus(FilingStatus.DRAFT) // authorization stage
+    // store shows zero fees during authorization (display-only)
+    store.stateModel.staffPaymentStep.staffPayment.option = StaffPaymentOptions.NO_FEE
+
+    const filing = wrapper.vm.buildContinuationInFiling()
+
+    expect(filing.header.waiveFees).toBeUndefined()
+  })
+
+  it('persists staff payment during the application stage', () => {
+    store.setFilingStatus(FilingStatus.APPROVED) // application stage
+    store.stateModel.staffPaymentStep.staffPayment.option = StaffPaymentOptions.NO_FEE
+
+    const filing = wrapper.vm.buildContinuationInFiling()
+
+    expect(filing.header.waiveFees).toBe(true)
+  })
+
+  it('shows zero fees when parsing an authorization stage draft', () => {
+    store.setFilingStatus(FilingStatus.DRAFT) // authorization stage
+
+    wrapper.vm.parseContinuationInDraft({
+      header: { filingId: 123 },
+      continuationIn: { nameRequest: { legalType: CorpTypeCd.BEN_CONTINUE_IN } }
+    })
+
+    expect(store.getStaffPaymentStep.staffPayment.option).toBe(StaffPaymentOptions.NO_FEE)
+  })
+
+  it('ignores a leaked waiveFees flag when parsing an application stage draft', () => {
+    store.setFilingStatus(FilingStatus.APPROVED) // application stage
+
+    wrapper.vm.parseContinuationInDraft({
+      header: { filingId: 123, waiveFees: true },
+      continuationIn: { nameRequest: { legalType: CorpTypeCd.BEN_CONTINUE_IN } }
+    })
+
+    expect(store.getStaffPaymentStep.staffPayment.option).toBe(StaffPaymentOptions.NONE)
   })
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#33757

*Description of changes:*
Stop authorization-stage waiver leaking into Continuation Application staff payment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
