### PR TITLE
34187 registration - summary remove red highlight on contacts

### DIFF
--- a/src/components/common/BusinessContactInfo.vue
+++ b/src/components/common/BusinessContactInfo.vue
@@ -112,7 +112,7 @@
           sm="3"
           class="pr-4"
         >
-          <label class="title-label">{{ contactInformationLabel }}</label>
+          <label>{{ contactInformationLabel }}</label>
         </v-col>
 
         <v-col


### PR DESCRIPTION
*Issue #:* /bcgov/entity#34187

*Description of changes:*
- removed unnecessary title-label class on summary business contact header. It was rendering as red due to parent override 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
