### PR TITLE
34469 - Bump base-address to 2.2.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.1.20",
-        "@bcrs-shared-components/base-address": "2.2.7",
+        "@bcrs-shared-components/base-address": "2.2.9",
         "@bcrs-shared-components/breadcrumb": "2.1.15",
         "@bcrs-shared-components/business-lookup": "1.3.15",
         "@bcrs-shared-components/certify": "2.2.4",
@@ -333,11 +333,11 @@
       "license": "MIT"
     },
     "node_modules/@bcrs-shared-components/base-address": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/base-address/-/base-address-2.2.7.tgz",
-      "integrity": "sha512-hMv96ygIJR/oupK5sWk4dyWISvIfRcr5bEfGtRo+KPpZMHlEe9K8FOyoAQ52aC8fo19x/QU+hpn2VNd3OCBbJA==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/base-address/-/base-address-2.2.9.tgz",
+      "integrity": "sha512-/CVh2dFC88IzecTQpQdL/vgFgDp6rtZMRMkERXpJWvgyjquBa2esnX19vJFzftdincgDMIfkj3vf5BU40UAPWw==",
       "dependencies": {
-        "@bcrs-shared-components/mixins": "^1.2.6",
+        "@bcrs-shared-components/mixins": "^1.2.8",
         "@bcrs-shared-components/validators": "^1.0.2",
         "lodash.uniqueid": "^4.0.1",
         "vue": "^2.7.14",
@@ -10782,6 +10782,44 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@bcrs-shared-components/base-address/node_modules/@bcrs-shared-components/mixins": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/mixins/-/mixins-1.2.8.tgz",
+      "integrity": "sha512-wJPgXNL8HZiYSsxb2Cx5UFjzL6aMxIxYpIwrDJy7QyuqO29bvVf3+9wD5SAKRbr6g8lEDgrE+RXb3uzAg455fg==",
+      "dependencies": {
+        "@bcrs-shared-components/corp-type-module": "^1.0.16",
+        "@bcrs-shared-components/enums": "^1.2.4",
+        "@bcrs-shared-components/interfaces": "^1.1.42",
+        "country-list": "^2.3.0",
+        "lodash": "4.17.21",
+        "provinces": "^1.11.0",
+        "vue": "^2.7.14"
+      }
+    },
+    "node_modules/@bcrs-shared-components/base-address/node_modules/@bcrs-shared-components/mixins/node_modules/@bcrs-shared-components/enums": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/enums/-/enums-1.2.4.tgz",
+      "integrity": "sha512-IWg5Py2bOY5BdBJTiJ1ftHHOZWy4Ca4f7ilgppuO41wUjHdkmi+O/mLYskYlyRK2f+jLcgfcBfyE/a9ioOMFWg==",
+      "dependencies": {
+        "@bcrs-shared-components/corp-type-module": "^1.0.16"
+      }
+    },
+    "node_modules/@bcrs-shared-components/base-address/node_modules/@bcrs-shared-components/mixins/node_modules/@bcrs-shared-components/interfaces": {
+      "version": "1.1.42",
+      "resolved": "https://registry.npmjs.org/@bcrs-shared-components/interfaces/-/interfaces-1.1.42.tgz",
+      "integrity": "sha512-Tvi/eOLH6mUNVuReoZUl9Cgu1kJvMvYz+NpXhKCMcgpAUK4eQKRg+ryWivenj/9Xk2+p62/P/QL4jIEXTlSHXw==",
+      "dependencies": {
+        "@bcrs-shared-components/corp-type-module": "^1.0.16",
+        "@bcrs-shared-components/enums": "^1.2.4",
+        "vue": "^2.7.14"
+      }
+    },
+    "node_modules/@bcrs-shared-components/base-address/node_modules/@bcrs-shared-components/mixins/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@babel/compat-data": "^7.21.5",
     "@bcrs-shared-components/approval-type": "1.1.20",
-    "@bcrs-shared-components/base-address": "2.2.7",
+    "@bcrs-shared-components/base-address": "2.2.9",
     "@bcrs-shared-components/breadcrumb": "2.1.15",
     "@bcrs-shared-components/business-lookup": "1.3.15",
     "@bcrs-shared-components/certify": "2.2.4",

--- a/src/components/Registration/BusinessAddresses.vue
+++ b/src/components/Registration/BusinessAddresses.vue
@@ -331,11 +331,14 @@ export default class BusinessAddresses extends Mixins(CommonMixin) {
     // only show errors in editing mode
     if (this.showErrors && this.isEditing) {
       // validate mailing address
-      await this.$refs.mailingAddress.validate()
+      // NB: use validate()'s return value — base-address 2.2.9+ doesn't emit "valid"
+      // for an untouched valid address, so the flags may still hold their initial false
+      this.mailingAddressValid = await this.$refs.mailingAddress.validate()
       if (!this.inheritMailingAddress) {
         // validate delivery address
-        await this.$refs.deliveryAddress.validate()
+        this.deliveryAddressValid = await this.$refs.deliveryAddress.validate()
       }
+      this.emitValid()
     }
   }
 


### PR DESCRIPTION
Issue: bcgov/entity#34469 

Picks up the BaseAddress valid-emit fix from bcgov/bcrs-shared-components#317. Also reads address validity from validate()'s return value in BusinessAddresses