### PR TITLE
34550 - Skip completing party name validation for firms when filed by clients

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-create-ui",
-  "version": "5.18.25",
+  "version": "5.18.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "business-create-ui",
-      "version": "5.18.25",
+      "version": "5.18.26",
       "dependencies": {
         "@babel/compat-data": "^7.21.5",
         "@bcrs-shared-components/approval-type": "1.1.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-create-ui",
-  "version": "5.18.25",
+  "version": "5.18.26",
   "private": true,
   "appName": "Business Create UI",
   "sbcName": "SBC Common Components",

--- a/src/components/common/RegAddEditOrgPerson.vue
+++ b/src/components/common/RegAddEditOrgPerson.vue
@@ -99,26 +99,26 @@
                   filled
                   class="item first-name"
                   label="First Name"
-                  :rules="enableRules ?
+                  :rules="enableRules && !isCompletingPartyLocked ?
                     (isCompletingParty ? Rules.FirstNameRulesFirmsCP :
                       Rules.FirstNameRulesFirms) : []"
-                  :readonly="isCompletingParty && !IsAuthorized(AuthorizedActions.EDITABLE_COMPLETING_PARTY)"
+                  :readonly="isCompletingPartyLocked"
                 />
                 <v-text-field
                   v-model.trim="orgPerson.officer.middleName"
                   filled
                   class="item middle-name"
                   label="Middle Name (Optional)"
-                  :rules="enableRules ? Rules.MiddleNameRulesFirms : []"
-                  :readonly="isCompletingParty && !IsAuthorized(AuthorizedActions.EDITABLE_COMPLETING_PARTY)"
+                  :rules="enableRules && !isCompletingPartyLocked ? Rules.MiddleNameRulesFirms : []"
+                  :readonly="isCompletingPartyLocked"
                 />
                 <v-text-field
                   v-model.trim="orgPerson.officer.lastName"
                   filled
                   class="item last-name"
                   label="Last Name"
-                  :rules="enableRules ? Rules.LastNameRules : []"
-                  :readonly="isCompletingParty && !IsAuthorized(AuthorizedActions.EDITABLE_COMPLETING_PARTY)"
+                  :rules="enableRules && !isCompletingPartyLocked ? Rules.LastNameRules : []"
+                  :readonly="isCompletingPartyLocked"
                 />
               </div>
             </article>
@@ -536,6 +536,11 @@ export default class RegAddEditOrgPerson extends Mixins(AddEditOrgPersonMixin) {
 
   /** The document type that will be sent to the entered email adress. */
   @Prop({ default: '' }) readonly docType!: string
+
+  /** Whether the Completing Party name is pre-populated from the user's login and not editable. */
+  get isCompletingPartyLocked (): boolean {
+    return this.isCompletingParty && !this.IsAuthorized(this.AuthorizedActions.EDITABLE_COMPLETING_PARTY)
+  }
 
   /** The validation rules for the Organization Name. */
   readonly OrgNameRules: Array<VuetifyRuleFunction> = [

--- a/tests/unit/RegAddEditOrgPerson.spec.ts
+++ b/tests/unit/RegAddEditOrgPerson.spec.ts
@@ -636,7 +636,8 @@ describe('Registration Add/Edit Org/Person component', () => {
     wrapper.destroy()
   })
 
-  it('displays error message when user does not enter person names', async () => {
+  it('displays error message when staff does not enter person names', async () => {
+    setAuthRole(store, AuthorizationRoles.STAFF)
     const wrapper = createComponent(validCompletingParty, NaN, null)
 
     const firstNameInput = wrapper.find(`${firstNameSelector} input`)
@@ -658,9 +659,11 @@ describe('Registration Add/Edit Org/Person component', () => {
     expect(wrapper.vm.$data.addPersonOrgFormValid).toBe(false)
 
     wrapper.destroy()
+    setAuthRole(store, AuthorizationRoles.PUBLIC_USER)
   })
 
-  it('Displays error message when user enters person names that are too long', async () => {
+  it('Displays error message when staff enters person names that are too long', async () => {
+    setAuthRole(store, AuthorizationRoles.STAFF)
     const wrapper = createComponent(validCompletingParty, NaN, null)
 
     const firstNameInput = wrapper.find(`${firstNameSelector} input`)
@@ -683,6 +686,31 @@ describe('Registration Add/Edit Org/Person component', () => {
     expect(messages.at(1).text()).toBe('Cannot exceed 30 characters')
     expect(messages.at(2).text()).toBe('Cannot exceed 30 characters')
     expect(wrapper.vm.$data.addPersonOrgFormValid).toBe(false)
+
+    wrapper.destroy()
+    setAuthRole(store, AuthorizationRoles.PUBLIC_USER)
+  })
+
+  it('does not validate completing party names when they are not editable by the user', async () => {
+    const wrapper = createComponent(validCompletingParty, NaN, null)
+
+    const firstNameInput = wrapper.find(`${firstNameSelector} input`)
+    const middleNameInput = wrapper.find(`${middleNameSelector} input`)
+    const lastNameInput = wrapper.find(`${lastNameSelector} input`)
+
+    firstNameInput.setValue('1234567890123456789012345678901')
+    firstNameInput.trigger('change')
+    middleNameInput.setValue('1234567890123456789012345678901')
+    middleNameInput.trigger('change')
+    lastNameInput.setValue('1234567890123456789012345678901')
+    lastNameInput.trigger('change')
+    await Vue.nextTick()
+    await flushPromises()
+    await Vue.nextTick()
+
+    const messages = wrapper.findAll('.v-messages__message')
+    expect(messages.length).toBe(0)
+    expect(wrapper.vm.$data.addPersonOrgFormValid).toBe(true)
 
     wrapper.destroy()
   })


### PR DESCRIPTION
*Issue:*bcgov/entity#34550

Description of changes:
Skip completing party first/middle/last name validation in firm registrations when the name is pre-populated from BCSC login and not editable (staff filings keep validation).